### PR TITLE
Add simplification rules for log/exp/sqrt/pow compositions

### DIFF
--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -149,6 +149,12 @@ template <scalar_expr_holder E> [[nodiscard]] auto sqrt(E &&e) {
         return p.expr_lhs();
     }
   }
+  // sqrt(exp(x)) → exp(x/2)
+  // Implemented via pow(exp(x), 1/2) which triggers pow_base → exp(x * 1/2)
+  if (is_same<scalar_exp>(e)) {
+    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+    return binary_scalar_pow_simplify(std::forward<E>(e), std::move(half));
+  }
   return make_expression<scalar_sqrt>(std::forward<E>(e));
 }
 
@@ -167,6 +173,17 @@ template <scalar_expr_holder E> [[nodiscard]] auto log(E &&e) {
     return get_scalar_zero();
   if (is_same<scalar_exp>(e))
     return e.template get<scalar_exp>().expr();
+  // log(sqrt(x)) → log(x)/2
+  if (is_same<scalar_sqrt>(e)) {
+    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+    return log(e.template get<scalar_sqrt>().expr()) * half;
+  }
+  // log(pow(x, n)) → n * log(x), when x is positive
+  if (is_same<scalar_pow>(e)) {
+    auto const &p = e.template get<scalar_pow>();
+    if (is_positive(p.expr_lhs()))
+      return p.expr_rhs() * log(p.expr_lhs());
+  }
   return make_expression<scalar_log>(std::forward<E>(e));
 }
 

--- a/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
@@ -103,6 +103,9 @@ protected:
 
   expr_holder_t dispatch(scalar_exp const &);
 
+  /// pow(sqrt(x), n) → pow(x, n/2)
+  expr_holder_t dispatch(scalar_sqrt const &);
+
   template <typename Expr> expr_holder_t dispatch(Expr const &) {
     auto &_rhs{m_rhs.template get<scalar_visitable_t>()};
     pow_default<void> visitor(std::move(m_lhs), std::move(m_rhs));

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -1,6 +1,9 @@
 #include <numsim_cas/core/operators.h>
+#include <numsim_cas/core/scalar_number.h>
 #include <numsim_cas/scalar/scalar_definitions.h>
+#include <numsim_cas/scalar/scalar_make_constant.h>
 #include <numsim_cas/scalar/scalar_operators.h>
+#include <numsim_cas/scalar/scalar_std.h>
 #include <numsim_cas/scalar/simplifier/scalar_simplifier_pow.h>
 
 namespace numsim::cas::simplifier {
@@ -85,6 +88,12 @@ pow_base::pow_base(expr_holder_t lhs, expr_holder_t rhs)
 
 pow_base::expr_holder_t pow_base::dispatch(scalar_exp const &) {
   return exp(m_lhs.template get<scalar_exp>().expr() * m_rhs);
+}
+
+/// pow(sqrt(x), n) → pow(x, n/2)
+pow_base::expr_holder_t pow_base::dispatch(scalar_sqrt const &) {
+  auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+  return pow(m_lhs.template get<scalar_sqrt>().expr(), m_rhs * half);
 }
 
 pow_base::expr_holder_t pow_base::dispatch(scalar_pow const &) {

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -655,6 +655,8 @@ TEST_F(ScalarFixture, Scalar_PowSqrtSimplification) {
   EXPECT_PRINT(pow(sqrt(x), _2), "x");
   // pow(sqrt(x), 3) → pow(x, 3/2)
   EXPECT_PRINT(pow(sqrt(x), _3), "pow(x,3/2)");
+}
+
 // Operator early-exit coverage: zero/one identity & annihilator for +, -, *, /
 //
 TEST_F(ScalarFixture, OperatorEarlyExit_SubZero) {

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -608,4 +608,50 @@ TEST_F(ScalarFixture, Scalar_ExpPowSimplification) {
   EXPECT_PRINT(pow(exp(x + y), _2), "exp(2*(x+y))");
 }
 
+//
+// SQRT-EXP composition — sqrt(exp(x)) → exp(x/2)
+//
+TEST_F(ScalarFixture, Scalar_SqrtExpSimplification) {
+  // sqrt(exp(x)) → exp(x/2)
+  EXPECT_PRINT(sqrt(exp(x)), "exp((1/2)*x)");
+  // sqrt(exp(x+y)) → exp((x+y)/2)
+  EXPECT_PRINT(sqrt(exp(x + y)), "exp((1/2)*(x+y))");
+  // Chained: log(sqrt(exp(x))) → x/2
+  EXPECT_PRINT(log(sqrt(exp(x))), "(1/2)*x");
+}
+
+//
+// LOG-SQRT composition — log(sqrt(x)) → log(x)/2
+//
+TEST_F(ScalarFixture, Scalar_LogSqrtSimplification) {
+  // log(sqrt(x)) → log(x)/2
+  EXPECT_PRINT(log(sqrt(x)), "(1/2)*log(x)");
+  // log(sqrt(exp(x))) → x/2 (chains with exp(log(x))=x)
+  EXPECT_PRINT(log(sqrt(exp(x))), "(1/2)*x");
+}
+
+//
+// LOG-POW composition — log(pow(x, n)) → n*log(x) when x > 0
+//
+TEST_F(ScalarFixture, Scalar_LogPowSimplification) {
+  using namespace numsim::cas;
+  // Need positive assumption for log(pow(x,n)) → n*log(x)
+  auto px = make_expression<scalar>("px");
+  assume(px, positive{});
+  EXPECT_PRINT(log(pow(px, _2)), "2*log(px)");
+  EXPECT_PRINT(log(pow(px, _3)), "3*log(px)");
+  // Without positive assumption, should NOT simplify
+  EXPECT_PRINT(log(pow(x, _2)), "log(pow(x,2))");
+}
+
+//
+// POW-SQRT composition — pow(sqrt(x), n) → pow(x, n/2)
+//
+TEST_F(ScalarFixture, Scalar_PowSqrtSimplification) {
+  // pow(sqrt(x), 2) → x (via pow(x, 2/2) = pow(x, 1) = x)
+  EXPECT_PRINT(pow(sqrt(x), _2), "x");
+  // pow(sqrt(x), 3) → pow(x, 3/2)
+  EXPECT_PRINT(pow(sqrt(x), _3), "pow(x,3/2)");
+}
+
 #endif // SCALAREXPRESSIONTEST_H


### PR DESCRIPTION
## Simplify log/exp/sqrt/pow compositions                                                                                                                                             
                                                                                                                                                                                        
  Expressions produced by symbolic regression often contain redundant nested transcendentals (e.g. `log(sqrt(exp(x)))` instead of `x/2`). This PR adds construction-time simplification 
  rules that collapse them eagerly:                                                                                                                                                     
                                                                                                                                                                                        
  | Pattern | Result | Condition |
  |---|---|---|
  | `sqrt(exp(x))` | `exp(x/2)` | — |
  | `log(sqrt(x))` | `log(x)/2` | — |
  | `log(pow(x, n))` | `n*log(x)` | `x > 0` (positive assumption) |                                                                                                                     
  | `pow(sqrt(x), n)` | `pow(x, n/2)` | — |
                                                                                                                                                                                        
  Rules compose naturally: `log(sqrt(exp(x)))` → `log(exp(x/2))` → `x/2`.                                                                                                               
   
  ### Implementation                                                                                                                                                                    
                  
  - **`scalar_std.h`**: Guard clauses in `sqrt()` and `log()` constructors detect `scalar_exp`, `scalar_sqrt`, and `scalar_pow` children and rewrite before node creation.              
  - **`scalar_simplifier_pow.h/.cpp`**: New `pow_base::dispatch(scalar_sqrt const&)` handles `pow(sqrt(x), n)` → `pow(x, n/2)` inside the existing pow simplifier.
  - `log(pow(x, n))` requires a positive assumption on `x` via `is_positive()` to ensure correctness (log of negative power is undefined).                                              
                  
  ### Tests                                                                                                                                                                             
                  
  4 new test cases in `ScalarExpressionTest.h`:                                                                                                                                         
  - `Scalar_SqrtExpSimplification` — `sqrt(exp(x))`, chained with `log`
  - `Scalar_LogSqrtSimplification` — `log(sqrt(x))`, chained with `exp`                                                                                                                 
  - `Scalar_LogPowSimplification` — `log(pow(x, n))` with/without positive assumption                                                                                                   
  - `Scalar_PowSqrtSimplification` — `pow(sqrt(x), n)` including `pow(sqrt(x), 2) → x`
