### PR TITLE
Correct #97 audit claim; lock in existing mul × mul merge behavior

### DIFF
--- a/docs/simplifier-coverage.md
+++ b/docs/simplifier-coverage.md
@@ -125,12 +125,33 @@ a tracking issue.
    (`pow(pow(A, m), n) → pow(A, m·n)`, `pow(inv(A), n) → inv(pow(A, n))`, etc.).
    Tracked as [#96](https://github.com/NumSim-Stack/numsim-cas/issues/96).
 
-2. **No `n_ary_mul_mul_dispatch`.** The mul family has only the base
-   `mul_dispatch` ([`simplifier_mul.h:16`](../include/numsim_cas/core/simplifier/simplifier_mul.h)).
-   Rules like `(c₁·x·y) · (c₂·x·z) → c₁·c₂·pow(x,2)·y·z` aren't reachable
-   without a dedicated LHS=mul dispatcher. Compare with the add side's
-   `n_ary_add_dispatch`, which exists.
-   Tracked as [#97](https://github.com/NumSim-Stack/numsim-cas/issues/97).
+2. **No `n_ary_mul_mul_dispatch`** in the generic layer, but the
+   functional rules **are** implemented per-domain. The mul family in
+   `core/simplifier/simplifier_mul.h` has only the base `mul_dispatch`,
+   yet:
+   - **Scalar** handles mul × mul via `n_ary_mul::dispatch(scalar_mul)` in
+     [`scalar_simplifier_mul.cpp:100`](../src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp).
+     Approach: copy lhs, multiply each rhs child into the result via
+     `operator*` (re-triggers simplification).
+   - **T2s** handles mul × mul via `mul_base::dispatch(tensor_to_scalar_mul)`
+     in [`tensor_to_scalar_simplifier_mul.cpp:99`](../src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp).
+     Approach: copy lhs, call a `push_or_combine` helper for each rhs
+     child (inlined merge with pow-promotion).
+   - **Tensor** mul has different semantics (inner-product based, not
+     commutative) and doesn't apply.
+   
+   `(c₁·x·y) · (c₂·x·z) → c₁·c₂·pow(x,2)·y·z` works in both scalar and
+   t2s today (verified by `tests/CoreBugFixTest.h` regression tests
+   `MulMulMergesLikeFactorsScalar` / `T2s`).
+   
+   The architectural concern that #95 raised is real: the **drift**
+   between the scalar and t2s implementations (different approaches to
+   the same algebraic task) is the kind of thing that surfaces bugs
+   like #91 / #102. Consolidating into a single generic dispatcher is
+   worth tracking as a refactor but isn't a missing-feature gap.
+   Tracked as [#97](https://github.com/NumSim-Stack/numsim-cas/issues/97)
+   (closed as based on wrong premise) and a new follow-up if
+   consolidation is pursued.
 
 3. **`pow_add` Pythagorean identity is scalar-only.** `sin²(x) + cos²(x) → 1`
    is implemented in [`scalar_simplifier_add.h:127`](../include/numsim_cas/scalar/simplifier/scalar_simplifier_add.h)

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -321,6 +321,11 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 // ---------------------------------------------------------------------------
 
 TEST(CoreBugFix, MulMulMergesLikeFactorsScalar) {
+  // EXPECT_EQ compares via expression_holder::operator==, which is
+  // hash-based — child ordering inside the resulting mul is not
+  // observable through this assertion. The "alphabetical-looking"
+  // expected forms below match the canonical hash order on this
+  // platform but the test passes regardless of order.
   auto [x, y, z, a] = make_scalar_variable("x", "y", "z", "a");
   auto two = make_scalar_constant(2);
   auto three = make_scalar_constant(3);
@@ -329,7 +334,7 @@ TEST(CoreBugFix, MulMulMergesLikeFactorsScalar) {
   EXPECT_EQ((two * x * y) * (three * x * z), 6 * pow(x, 2) * y * z);
   // (x*y) * (x*z) -> pow(x,2)*y*z
   EXPECT_EQ((x * y) * (x * z), pow(x, 2) * y * z);
-  // (x*y*z) * (x*a) -> a*pow(x,2)*y*z (alphabetical ordering)
+  // (x*y*z) * (x*a) -> a*pow(x,2)*y*z
   EXPECT_EQ((x * y * z) * (x * a), a * pow(x, 2) * y * z);
 }
 

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -315,6 +315,39 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// mul × mul merges like factors (verifies issue #97's claim was wrong —
+// the rules ARE implemented, in per-domain wrappers rather than a generic
+// dispatcher; these regressions lock in the contract).
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, MulMulMergesLikeFactorsScalar) {
+  auto [x, y, z, a] = make_scalar_variable("x", "y", "z", "a");
+  auto two = make_scalar_constant(2);
+  auto three = make_scalar_constant(3);
+
+  // (2*x*y) * (3*x*z) -> 6*pow(x,2)*y*z
+  EXPECT_EQ((two * x * y) * (three * x * z), 6 * pow(x, 2) * y * z);
+  // (x*y) * (x*z) -> pow(x,2)*y*z
+  EXPECT_EQ((x * y) * (x * z), pow(x, 2) * y * z);
+  // (x*y*z) * (x*a) -> a*pow(x,2)*y*z (alphabetical ordering)
+  EXPECT_EQ((x * y * z) * (x * a), a * pow(x, 2) * y * z);
+}
+
+TEST(CoreBugFix, MulMulMergesLikeFactorsT2s) {
+  // Same contract for tensor-to-scalar mul × mul, via the push_or_combine
+  // helper in tensor_to_scalar_simplifier_mul.cpp.
+  auto [X, Y, Z] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}},
+                           std::tuple{"Y", std::size_t{3}, std::size_t{2}},
+                           std::tuple{"Z", std::size_t{3}, std::size_t{2}});
+  auto tX = trace(X);
+  auto tY = trace(Y);
+  auto tZ = trace(Z);
+  // (tr(X) * tr(Y)) * (tr(X) * tr(Z)) -> pow(tr(X), 2) * tr(Y) * tr(Z)
+  EXPECT_EQ((tX * tY) * (tX * tZ), pow(tX, 2) * tY * tZ);
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #97.

Investigation during the #97 work showed the audit's claim that `(c₁·x·y) · (c₂·x·z) → c₁·c₂·pow(x,2)·y·z` "isn't reachable without a dedicated `n_ary_mul_mul_dispatch`" was **wrong**. The rules ARE implemented today, just in per-domain wrappers rather than a generic dispatcher.

## What's actually there

| Domain | Where | Approach |
|---|---|---|
| Scalar | `n_ary_mul::dispatch(scalar_mul)` in `scalar_simplifier_mul.cpp:100` | Operator-chain: copy lhs, multiply each rhs child via `operator*` (re-triggers simplification) |
| T2s | `mul_base::dispatch(tensor_to_scalar_mul)` in `tensor_to_scalar_simplifier_mul.cpp:99` | `push_or_combine` helper: inlined merge with pow-promotion |
| Tensor | n/a | Different mul semantics (inner-product, non-commutative) |

Verified by direct probe:
- `(2*x*y) * (3*x*z) = 6*pow(x,2)*y*z` ✓
- `(x*y) * (x*z) = pow(x,2)*y*z` ✓
- `(x*y*z) * (x*a) = a*pow(x,2)*y*z` ✓
- `(tr(X)*tr(Y)) * (tr(X)*tr(Z)) = pow(tr(X),2)*tr(Y)*tr(Z)` ✓

## What this PR does

1. **Updates the audit doc** (`docs/simplifier-coverage.md`) to correct the claim and document where the mul × mul logic actually lives in each domain.
2. **Adds two regression tests** in `CoreBugFixTest.h`:
   - `MulMulMergesLikeFactorsScalar`
   - `MulMulMergesLikeFactorsT2s`
   These lock in the contract so any future refactor that lifts the merge into a generic dispatcher can't silently drop it.

## What it deliberately does NOT do

The architectural concern that #95 raised is real: the **drift** between scalar's operator-chain approach and t2s's `push_or_combine` approach is a refactoring opportunity. But:
- Both approaches work correctly today.
- The work to consolidate is substantial (lift to a generic dispatcher, choose between the two patterns, migrate the per-domain wrappers).
- The benefit is marginal — minor perf gain for scalar, architectural symmetry.

Worth filing as a separate refactor issue if pursued; not a missing-feature gap as #97 claimed.

## Base

Stacked on `95-unify-simplifier-dispatchers` (PR #98). Re-target to `main` once #98 lands.

## Test plan

- [x] `cmake --build build` — clean
- [x] `ctest` — 100% pass (1497 → 1499 with the two new regressions)
