### PR TITLE
Add tensor pow simplifications for pow(I, n) and pow(inv(A), n)

### DIFF
--- a/docs/simplifier-coverage.md
+++ b/docs/simplifier-coverage.md
@@ -94,7 +94,7 @@ expressions (e.g. mul × mul, symbol × mul) goes through the base dispatcher's
 | Add | `add_default<Derived>`, `n_ary_add`, `symbol_add`, **`tensor_scalar_mul_add`**, `add_negative` | **Does not inherit generic.** Hand-written because `tensor_traits::mul_type` is `void` (no n-ary scalar multiplication node in this domain — see [`tensor_domain_traits.h`](../include/numsim_cas/tensor/tensor_domain_traits.h)). `tensor_scalar_mul_add` is domain-specific. |
 | Sub | `sub_default<Derived>`, `negative_sub`, `n_ary_sub`, `symbol_sub` | Same architectural note as add. |
 | Mul | `mul_default<Derived>`, `tensor_pow_mul`, `kronecker_delta_mul`, `symbol_mul`, `n_ary_mul` | Hand-written. `kronecker_delta_mul` handles index contraction; `symbol_mul`: `x·x → pow(x,2)`. |
-| Pow | **— absent —** | No `tensor_simplifier_pow.h` file. Rules like `pow(pow(A,m), n) → pow(A, m·n)` and `pow(inv(A), n)` have no construction-time handling. → tracked separately. |
+| Pow | **— no dispatcher-based simplifier —** but construction-time rules in [`tensor_std.h::pow`](../include/numsim_cas/tensor/tensor_std.h): `pow(0, n) → 0`, `pow(A, 0) → I`, `pow(A, 1) → A`, `pow(pow(A,m), n) → pow(A, m·n)`, `pow(I, n) → I`, `pow(inv(A), n) → inv(pow(A, n))`. Architecture is asymmetric with scalar/t2s (which use the dispatcher pattern) but functional coverage is comparable. |
 
 Additional domain-specific simplifiers (not in the dispatcher hierarchy):
 
@@ -118,12 +118,17 @@ a tracking issue.
 
 ### Material gaps (filed)
 
-1. **No tensor pow simplifier.** Entire `tensor/simplifier/tensor_simplifier_pow.h`
-   is missing. Tensor `pow` expressions are constructed via
-   [`tensor/functions/tensor_pow.h`](../include/numsim_cas/tensor/functions/tensor_pow.h)
-   and the `pow()` free function but receive no simplifier-driven rewrites
-   (`pow(pow(A, m), n) → pow(A, m·n)`, `pow(inv(A), n) → inv(pow(A, n))`, etc.).
-   Tracked as [#96](https://github.com/NumSim-Stack/numsim-cas/issues/96).
+1. **Tensor pow uses construction-time simplification, not the dispatcher pattern.**
+   Unlike scalar and t2s, which use the `pow_dispatch` / `pow_pow_dispatch` /
+   `mul_pow_dispatch` family, tensor handles all pow simplifications as
+   `if (is_same<...>) return ...;` checks in
+   [`tensor_std.h::pow`](../include/numsim_cas/tensor/tensor_std.h).
+   Functional coverage is comparable (`pow(0, n)`, `pow(A, 0)`, `pow(A, 1)`,
+   `pow(pow(A,m), n)`, `pow(I, n)`, `pow(inv(A), n)` all simplify), but the
+   architecture is asymmetric. A future refactor could lift this into a
+   tensor pow dispatcher family for parity — see #96 (closed as the
+   construction-time rules cover the same ground; refactor follow-up is
+   non-blocking).
 
 2. **No `n_ary_mul_mul_dispatch`.** The mul family has only the base
    `mul_dispatch` ([`simplifier_mul.h:16`](../include/numsim_cas/core/simplifier/simplifier_mul.h)).

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -11,6 +11,7 @@
 #include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/kronecker_delta.h>
 #include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor/tensor_functions.h>
 #include <numsim_cas/tensor/tensor_zero.h>
 #include <numsim_cas/tensor/visitors/tensor_printer.h>
 #include <sstream>
@@ -70,11 +71,12 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
   // pow(inv(A), n) → inv(pow(A, n))
   // Push inv outermost so other simplifications keying on inv() (e.g.
   // contains_skew_factor in inv() rejection, or future inv-of-X rules)
-  // see the canonical shape. The inner pow re-enters this function and
-  // any rules applicable to A and n still fire.
+  // see the canonical shape. Routes through inv() rather than
+  // make_expression<tensor_inv> so the construction-time checks (inv(I)
+  // collapse, skew-odd-dim rejection) still run on the new operand.
   if (is_same<tensor_inv>(expr_lhs)) {
     auto const &inv_node = expr_lhs.template get<tensor_inv>();
-    return make_expression<tensor_inv>(pow(inv_node.expr(), expr_rhs));
+    return inv(pow(inv_node.expr(), expr_rhs));
   }
 
   return numsim::cas::make_expression<numsim::cas::tensor_pow>(

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -6,7 +6,9 @@
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/scalar/scalar_zero.h>
+#include <numsim_cas/tensor/functions/tensor_inv.h>
 #include <numsim_cas/tensor/functions/tensor_pow.h>
+#include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/kronecker_delta.h>
 #include <numsim_cas/tensor/tensor_expression.h>
 #include <numsim_cas/tensor/tensor_zero.h>
@@ -56,6 +58,23 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
   if (is_same<tensor_pow>(expr_lhs)) {
     auto const &inner = expr_lhs.template get<tensor_pow>();
     return pow(inner.expr_lhs(), inner.expr_rhs() * expr_rhs);
+  }
+
+  // pow(I, n) → I  (identity is idempotent under exponentiation; this covers
+  // both kronecker_delta and identity_tensor representations of "I")
+  if (is_same<kronecker_delta>(expr_lhs) ||
+      is_same<identity_tensor>(expr_lhs)) {
+    return std::forward<ExprLHS>(expr_lhs);
+  }
+
+  // pow(inv(A), n) → inv(pow(A, n))
+  // Push inv outermost so other simplifications keying on inv() (e.g.
+  // contains_skew_factor in inv() rejection, or future inv-of-X rules)
+  // see the canonical shape. The inner pow re-enters this function and
+  // any rules applicable to A and n still fire.
+  if (is_same<tensor_inv>(expr_lhs)) {
+    auto const &inv_node = expr_lhs.template get<tensor_inv>();
+    return make_expression<tensor_inv>(pow(inv_node.expr(), expr_rhs));
   }
 
   return numsim::cas::make_expression<numsim::cas::tensor_pow>(

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -62,7 +62,12 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
   }
 
   // pow(I, n) → I  (identity is idempotent under exponentiation; this covers
-  // both kronecker_delta and identity_tensor representations of "I")
+  // both kronecker_delta and identity_tensor representations of "I").
+  // Rank-agnostic: identity_tensor may be rank-2 (δ_ij) or rank-4 (the minor
+  // identity δ_ik δ_jl). For ranks where tensor `pow` isn't standard the
+  // earlier construction would have produced a tensor_pow node that wouldn't
+  // evaluate anyway; returning the identity is no worse and is the right
+  // result for the rank-2 case.
   if (is_same<kronecker_delta>(expr_lhs) ||
       is_same<identity_tensor>(expr_lhs)) {
     return std::forward<ExprLHS>(expr_lhs);

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -315,6 +315,39 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// Tensor pow simplifications (issue #96) — extends the construction-time
+// rules in tensor_std.h::pow with pow(I, n) → I and pow(inv(A), n) →
+// inv(pow(A, n)). The existing rules pow(0, n) → 0, pow(A, 0) → I,
+// pow(A, 1) → A, pow(pow(A,m), n) → pow(A, m*n) are already covered.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, TensorPowIdentityIsIdempotent) {
+  // pow(I, n) → I (kronecker_delta as I)
+  auto I = make_expression<kronecker_delta>(std::size_t{3});
+  EXPECT_EQ(pow(I, 5), I);
+  EXPECT_EQ(pow(I, 0), I); // also covered by existing pow(A, 0) → I rule
+  // For pow(A, 1) the existing rule returns A directly; identity round-trips
+  EXPECT_EQ(pow(I, 1), I);
+}
+
+TEST(CoreBugFix, TensorPowOfInvLiftsToInvOfPow) {
+  // pow(inv(A), n) → inv(pow(A, n))
+  // Use an even-dim symmetric A so inv() doesn't reject and any structural
+  // checks downstream are well-defined.
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{4}, std::size_t{2}});
+  EXPECT_EQ(pow(inv(A), 2), inv(pow(A, 2)));
+  EXPECT_EQ(pow(inv(A), 3), inv(pow(A, 3)));
+}
+
+TEST(CoreBugFix, TensorPowPowChains) {
+  // pow(pow(A, 2), 3) → pow(A, 6) — already existed; lock in.
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  EXPECT_EQ(pow(pow(A, 2), 3), pow(A, 6));
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #96.

The audit's claim that "the entire tensor pow simplifier family is missing" was overstated. Tensor pow already had construction-time simplifications in `tensor_std.h::pow` covering `pow(0, n)`, `pow(A, 0)`, `pow(A, 1)`, and `pow(pow(A, m), n)`. Investigation surfaced two genuinely missing rules:

1. `pow(I, n) → I` — kronecker_delta and identity_tensor are idempotent under exponentiation, but the existing code didn't short-circuit.
2. `pow(inv(A), n) → inv(pow(A, n))` — pushes inv outermost as canonical form so other simplifications keyed on `inv()` see it consistently.

## What this PR does

Adds both rules to `tensor_std.h::pow` following the existing construction-time pattern. The architectural asymmetry — tensor uses inline `is_same<...>` checks while scalar/t2s use the dispatcher family from `core/simplifier/simplifier_pow.h` — is documented in the audit doc as a refactor opportunity rather than a functional gap.

## Tests

Three new regression tests in `CoreBugFixTest.h`:
- `TensorPowIdentityIsIdempotent` — `pow(I, 5) = I` and friends.
- `TensorPowOfInvLiftsToInvOfPow` — `pow(inv(A), 2) = inv(pow(A, 2))` and friends.
- `TensorPowPowChains` — locks in the existing `pow(pow(A,m), n) = pow(A, m·n)` rule.

## Audit doc update

The "no tensor pow simplifier" entry is corrected to reflect that:
- Tensor pow handles the same algebraic cases as scalar/t2s.
- The architecture is asymmetric (inline rules vs dispatcher pattern).
- A dispatcher-based refactor would close the architectural drift but isn't a missing-feature gap.

## Base

Stacked on `95-unify-simplifier-dispatchers` (PR #98). Re-target to `main` once #98 lands.

## Test plan

- [x] `cmake --build build` — clean
- [x] `ctest` — 100% pass (1497 → 1500 with the three new regressions)
- [x] Verified the new rules fire on the issue's examples (manual probe pre-commit)
