### PR TITLE
Lock in correctness of t2s_eval rebuild (partial work on #94)

### DIFF
--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -421,6 +421,11 @@ TEST(CoreBugFix, TensorToScalarWithTensorMulCorrectness) {
   // fresh tensor_to_scalar_evaluator on every visit (issue #94); any
   // future optimization that caches the inner evaluator must preserve
   // the value contract this test locks in.
+  //
+  // Result access uses raw_data() rather than a static_cast back to the
+  // concrete tensor_data<T,Dim,Rank> type — the raw buffer view doesn't
+  // depend on the underlying representation, so a future optimization
+  // that changed how the result is stored still satisfies the contract.
   auto A = make_expression<tensor>("A", std::size_t{3}, std::size_t{2});
   auto t2s_expr = trace(A);
   auto expr = make_expression<tensor_to_scalar_with_tensor_mul>(A, t2s_expr);
@@ -434,26 +439,31 @@ TEST(CoreBugFix, TensorToScalarWithTensorMulCorrectness) {
   Araw[4] = 2.0;
   Araw[8] = 3.0;
 
+  // Row-major indices 0,4,8 are the diagonal in a 3x3.
+  auto check_diag = [](tensor_data_base<double> const &result) {
+    auto const *raw = result.raw_data();
+    EXPECT_NEAR(raw[0], 6.0, 1e-12);
+    EXPECT_NEAR(raw[4], 12.0, 1e-12);
+    EXPECT_NEAR(raw[8], 18.0, 1e-12);
+    // off-diagonals
+    EXPECT_NEAR(raw[1], 0.0, 1e-12);
+    EXPECT_NEAR(raw[2], 0.0, 1e-12);
+    EXPECT_NEAR(raw[5], 0.0, 1e-12);
+  };
+
   tensor_evaluator<double> ev;
   ev.set(A, A_data);
   auto result = ev.apply(expr);
   ASSERT_NE(result, nullptr);
-  auto const &res =
-      static_cast<tensor_data<double, 3, 2> const &>(*result).data();
-  EXPECT_NEAR(res(0, 0), 6.0, 1e-12);
-  EXPECT_NEAR(res(1, 1), 12.0, 1e-12);
-  EXPECT_NEAR(res(2, 2), 18.0, 1e-12);
-  EXPECT_NEAR(res(0, 1), 0.0, 1e-12);
+  check_diag(*result);
 
-  // Re-apply with the same evaluator: the rebuild fires again,
-  // result must be identical. Locks in idempotence across visits.
+  // Re-apply with the same evaluator: the rebuild fires again, result
+  // must be identical. Locks in idempotence across visits — a future
+  // optimization that caches the inner t2s_eval must not leak state
+  // from the first call into the second.
   auto result2 = ev.apply(expr);
   ASSERT_NE(result2, nullptr);
-  auto const &res2 =
-      static_cast<tensor_data<double, 3, 2> const &>(*result2).data();
-  EXPECT_NEAR(res2(0, 0), 6.0, 1e-12);
-  EXPECT_NEAR(res2(1, 1), 12.0, 1e-12);
-  EXPECT_NEAR(res2(2, 2), 18.0, 1e-12);
+  check_diag(*result2);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -404,6 +404,59 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// t2s_eval rebuild correctness lock-in (issue #94) — the per-visit rebuild
+// path in tensor_evaluator::operator()(tensor_to_scalar_with_tensor_mul)
+// is functionally correct but pays construction + symbol-table copy cost
+// on every visit. Optimization is non-trivial because of the include
+// cycle between tensor_evaluator.h and tensor_to_scalar_evaluator.h
+// (see #94 for the architectural constraint). This test verifies the
+// rebuild path produces correct results across many visits — any future
+// optimization that caches or shares state must preserve the contract.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, TensorToScalarWithTensorMulCorrectness) {
+  // Construct a tensor_to_scalar_with_tensor_mul node directly (mirroring
+  // the existing TensorEvaluatorTest pattern) and verify evaluation
+  // produces correct results. The dispatcher for this node rebuilds a
+  // fresh tensor_to_scalar_evaluator on every visit (issue #94); any
+  // future optimization that caches the inner evaluator must preserve
+  // the value contract this test locks in.
+  auto A = make_expression<tensor>("A", std::size_t{3}, std::size_t{2});
+  auto t2s_expr = trace(A);
+  auto expr = make_expression<tensor_to_scalar_with_tensor_mul>(A, t2s_expr);
+
+  // A = diag(1, 2, 3); trace(A) = 6; result = 6 * A.
+  auto A_data = std::make_shared<tensor_data<double, 3, 2>>();
+  auto *Araw = A_data->raw_data();
+  for (std::size_t i = 0; i < 9; ++i)
+    Araw[i] = 0.0;
+  Araw[0] = 1.0;
+  Araw[4] = 2.0;
+  Araw[8] = 3.0;
+
+  tensor_evaluator<double> ev;
+  ev.set(A, A_data);
+  auto result = ev.apply(expr);
+  ASSERT_NE(result, nullptr);
+  auto const &res =
+      static_cast<tensor_data<double, 3, 2> const &>(*result).data();
+  EXPECT_NEAR(res(0, 0), 6.0, 1e-12);
+  EXPECT_NEAR(res(1, 1), 12.0, 1e-12);
+  EXPECT_NEAR(res(2, 2), 18.0, 1e-12);
+  EXPECT_NEAR(res(0, 1), 0.0, 1e-12);
+
+  // Re-apply with the same evaluator: the rebuild fires again,
+  // result must be identical. Locks in idempotence across visits.
+  auto result2 = ev.apply(expr);
+  ASSERT_NE(result2, nullptr);
+  auto const &res2 =
+      static_cast<tensor_data<double, 3, 2> const &>(*result2).data();
+  EXPECT_NEAR(res2(0, 0), 6.0, 1e-12);
+  EXPECT_NEAR(res2(1, 1), 12.0, 1e-12);
+  EXPECT_NEAR(res2(2, 2), 18.0, 1e-12);
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Partial work on #94.

## Honest framing

The full optimization the issue asks for (cache the inner `tensor_to_scalar_evaluator` instead of rebuilding it per visit) is non-trivial. The blocker is the include cycle:

- `tensor_to_scalar_evaluator` has `tensor_evaluator` as a member — needs the complete type.
- `tensor_evaluator` would need `tensor_to_scalar_evaluator` as a member (or unique_ptr) to cache it — also needs the complete type for the destructor.

Both can't be complete at the point the other's class definition closes. A unique_ptr to a forward-declared type works for storage, but the destructor still needs the complete type when it's instantiated — and the obvious workaround (bottom-include of t2s_eval.h inside tensor_evaluator.h) re-enters the cycle when the user includes t2s_eval.h directly.

Clean fixes available:
1. **PIMPL** — move the destructor and the offending method to a separate .cpp file with explicit template instantiations for `double`/`float`/`std::complex<double>`. Substantial refactor of the otherwise header-only design.
2. **Custom deleter** for the unique_ptr, declared in tensor_evaluator.h and defined in t2s_eval.h. Works but is fiddly.
3. **Share state** — give the inner t2s_eval references to the parent's `m_tensor_values` / `m_scalar_eval` instead of its own copies. Requires structural changes to `tensor_to_scalar_evaluator`.

All three are bigger than fits cleanly in one PR alongside the other simplifier work in #95.

## What this PR does

Locks in the value contract of the current rebuild path with `TensorToScalarWithTensorMulCorrectness`. The test:
- Builds a `tensor_to_scalar_with_tensor_mul` node directly.
- Evaluates against deterministic input.
- Re-evaluates with the same `tensor_evaluator` to catch state-leak regressions.

Any future optimization that caches or shares the inner evaluator must preserve the same result. The architectural constraint is documented in the test's comment block.

## Base

Stacked on `99-centralize-collapse-pattern` (PR #100). Re-target to `main` once the upstream chain lands.

## Test plan

- [x] `cmake --build build` — clean
- [x] `ctest` — 100% pass (1504 → 1505)
- [x] Test re-evaluates the same evaluator twice, verifying no state leak.

## Follow-up

The deeper refactor stays in #94. If pursued, options 1–3 above are the design space.
