### PR TITLE
Investigate #93: lock in Skew preservation (cannot reproduce original loss)

### DIFF
--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -315,6 +315,68 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// Skew annotation propagation lock-in (issue #93).
+// On the build platform that motivated commit 7e962e5, the Skew space
+// annotation could be lost when skew(A) was stored inside a tensor_mul.
+// The structural skew classifier in skew_classification.h was added as
+// a defensive fallback. These tests lock in that on THIS build the
+// annotation IS preserved through the common composition paths — any
+// regression would be visible here (whether or not the platform-specific
+// loss the original commit observed ever recurs).
+// ---------------------------------------------------------------------------
+
+namespace {
+template <typename Holder> bool is_skew_annotated(Holder const &e) {
+  if (auto const &sp = e.get().space())
+    return std::holds_alternative<Skew>(sp->perm);
+  return false;
+}
+} // namespace
+
+TEST(CoreBugFix, SkewSpacePreservedThroughNegation) {
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto sA = skew(A);
+  ASSERT_TRUE(is_skew_annotated(sA));
+  EXPECT_TRUE(is_skew_annotated(-sA));
+}
+
+TEST(CoreBugFix, SkewSpacePreservedThroughScalarMul) {
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto sA = skew(A);
+  ASSERT_TRUE(is_skew_annotated(sA));
+  EXPECT_TRUE(is_skew_annotated(2 * sA));
+}
+
+TEST(CoreBugFix, SkewSpacePreservedAsTensorMulChild) {
+  // The case the original commit (7e962e5) flagged as platform-dependent:
+  // skew(A) stored inside a tensor_mul. On this build the child retains
+  // its Skew annotation. The structural classifier in skew_classification.h
+  // is the authoritative fallback when the annotation IS lost on other
+  // platforms.
+  auto [A, B] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}},
+                           std::tuple{"B", std::size_t{3}, std::size_t{2}});
+  auto sA = skew(A);
+  ASSERT_TRUE(is_skew_annotated(sA));
+  auto prod = sA * B;
+  ASSERT_TRUE(is_same<tensor_mul>(prod));
+  auto const &mul = prod.get<tensor_mul>();
+  ASSERT_EQ(mul.data().size(), 2u);
+  // Find the skew child (the one carrying the annotation)
+  bool found_skew_child = false;
+  for (auto const &ch : mul.data()) {
+    if (is_skew_annotated(ch)) {
+      found_skew_child = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_skew_child)
+      << "skew(A) child of tensor_mul lost its Skew annotation on this build";
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -327,6 +327,8 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 
 namespace {
 template <typename Holder> bool is_skew_annotated(Holder const &e) {
+  if (!e.is_valid())
+    return false;
   if (auto const &sp = e.get().space())
     return std::holds_alternative<Skew>(sp->perm);
   return false;
@@ -364,16 +366,24 @@ TEST(CoreBugFix, SkewSpacePreservedAsTensorMulChild) {
   ASSERT_TRUE(is_same<tensor_mul>(prod));
   auto const &mul = prod.get<tensor_mul>();
   ASSERT_EQ(mul.data().size(), 2u);
-  // Find the skew child (the one carrying the annotation)
-  bool found_skew_child = false;
+  // Verify the skew child is specifically the operand we passed as skew —
+  // not just "some child happens to be annotated." Find the child equal
+  // to sA and assert ITS annotation is preserved; the other child (B)
+  // must not be spuriously annotated as Skew.
+  bool found_sA_with_skew = false;
+  bool other_child_spuriously_skew = false;
   for (auto const &ch : mul.data()) {
-    if (is_skew_annotated(ch)) {
-      found_skew_child = true;
-      break;
+    if (ch == sA) {
+      EXPECT_TRUE(is_skew_annotated(ch))
+          << "skew(A) child lost its Skew annotation on this build";
+      found_sA_with_skew = is_skew_annotated(ch);
+    } else if (is_skew_annotated(ch)) {
+      other_child_spuriously_skew = true;
     }
   }
-  EXPECT_TRUE(found_skew_child)
-      << "skew(A) child of tensor_mul lost its Skew annotation on this build";
+  EXPECT_TRUE(found_sA_with_skew) << "skew(A) child not found in tensor_mul";
+  EXPECT_FALSE(other_child_spuriously_skew)
+      << "non-skew child spuriously annotated as Skew";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Partial work on #93.

## Honest framing

The platform-dependent Skew annotation loss that commit `7e962e5` flagged **cannot be reproduced on this build** (Linux / libstdc++ / gcc). Every composition path tested preserves the Skew annotation. The structural classifier added in PR #90 remains as the defensive fallback for the platforms where annotation propagation does break.

## Investigation

Probed these composition paths:

| Construction | Annotation preserved? |
|---|---|
| `skew(A)` | ✓ (constructor sets Skew) |
| `-skew(A)` | ✓ (tensor_negative preserves) |
| `2 * skew(A)` | ✓ (tensor_scalar_mul preserves) |
| `trans(skew(A))` | ✓ (resolves to `-skew(A)`, Skew preserved) |
| `skew(A) * B` as a `tensor_mul` child | ✓ (child retains Skew) |

If the loss exists, it's specific to a platform (libc++ vs libstdc++? specific gcc version? CI runner?) I don't have access to. Without a reproducer, I can't trace and fix at the source.

## What this PR does

Three lock-in tests in `CoreBugFixTest`:
- `SkewSpacePreservedThroughNegation`
- `SkewSpacePreservedThroughScalarMul`
- `SkewSpacePreservedAsTensorMulChild`

These narrow the surface where a future annotation-propagation regression could go undetected. They pass today on this build; they would fail on a build where the platform-specific loss recurs.

## What this PR does NOT do

- **Fix the original platform-specific loss.** Without reproduction, no source-level fix is possible.
- **Remove the structural fallback.** `skew_classification.h` stays as the authoritative check — the issue body's "re-evaluate whether `is_provably_skew` still needs the structural fallback" depends on the source-level fix, which is deferred.

## What's worth doing as follow-up

If the platform-specific loss is observed again on CI or another platform:
1. Capture the build environment (compiler, stdlib, flags).
2. Run the three lock-in tests on that environment — they should fail and isolate the path.
3. Trace from there.

The issue stays open as the tracker for that future investigation.

## Base

Stacked on `95-unify-simplifier-dispatchers` (PR #98). Re-target to `main` once #98 lands.

## Test plan

- [x] `cmake --build build` — clean
- [x] `ctest` — 100% pass (1497 → 1500 with the three new tests)
