### PR TITLE
Add inv(alpha * A) -> (1/alpha) * inv(A) simplification rule

### DIFF
--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -378,7 +378,13 @@ template <tensor_expr_holder Expr>
   // throws and the new rule produces the same overall error.
   if (is_same<tensor_scalar_mul>(expr)) {
     auto const &sm = expr.template get<tensor_scalar_mul>();
-    return (get_scalar_one() / sm.expr_lhs()) * inv(sm.expr_rhs());
+    // Construct the lifted scalar*inv(A) directly via make_expression so this
+    // header doesn't have to include tensor_operators.h — which would form a
+    // cycle through the tensor simplifier headers.
+    auto reciprocal = get_scalar_one() / sm.expr_lhs();
+    auto inv_inner = inv(sm.expr_rhs());
+    return make_expression<tensor_scalar_mul>(std::move(reciprocal),
+                                              std::move(inv_inner));
   }
   // A skew-symmetric matrix in odd dimensions is singular (det = 0) by the
   // determinant theorem det(-A^T) = (-1)^n det(A). contains_skew_factor also

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <numsim_cas/core/cas_error.h>
+#include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/tensor/data/tensor_data_make_imp.h>
 #include <numsim_cas/tensor/kronecker_delta.h>
 #include <numsim_cas/tensor/projection_tensor.h>

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -371,6 +371,15 @@ template <tensor_expr_holder Expr>
     return std::forward<Expr>(expr);
   if (is_same<kronecker_delta>(expr))
     return std::forward<Expr>(expr);
+  // inv(alpha * A) -> (1/alpha) * inv(A). Lift the scalar factor out before
+  // any skew rejection check so the canonical form is consistent. The
+  // recursive inv(A) runs its own checks (inv(inv) -> A, identity short-
+  // circuits, skew-odd-dim rejection); if A is singular, the recursion
+  // throws and the new rule produces the same overall error.
+  if (is_same<tensor_scalar_mul>(expr)) {
+    auto const &sm = expr.template get<tensor_scalar_mul>();
+    return (get_scalar_one() / sm.expr_lhs()) * inv(sm.expr_rhs());
+  }
   // A skew-symmetric matrix in odd dimensions is singular (det = 0) by the
   // determinant theorem det(-A^T) = (-1)^n det(A). contains_skew_factor also
   // catches expressions that aren't themselves skew but contain a skew factor

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -441,6 +441,23 @@ TEST(CoreBugFix, InvLiftsThenRejectsSkewInner) {
       { [[maybe_unused]] auto r = inv(two * sA); }, invalid_expression_error);
 }
 
+TEST(CoreBugFix, InvLiftsNestedScalarFactor) {
+  // inv(s * (t * A)) — nested tensor_scalar_mul. The recursive rule should
+  // produce a canonical (s*t)-scaled inv(A) rather than a doubly-nested
+  // tensor_scalar_mul.
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto [s, t] = make_scalar_variable("s", "t");
+  auto r = inv(s * (t * A));
+  // Result should be a tensor_scalar_mul whose tensor child is inv(A),
+  // not another tensor_scalar_mul (the operator* on scalar*tensor_scalar_mul
+  // collapses the nesting via mul_base::dispatch(tensor_scalar_mul)).
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(r));
+  EXPECT_TRUE(is_same<tensor_inv>(r.get<tensor_scalar_mul>().expr_rhs()))
+      << "Inner tensor should be tensor_inv directly (collapsed), got: "
+      << to_string(r);
+}
+
 // ---------------------------------------------------------------------------
 // Skew annotation propagation lock-in (issue #93).
 // On the build platform that motivated commit 7e962e5, the Skew space

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -456,6 +456,9 @@ TEST(CoreBugFix, InvLiftsNestedScalarFactor) {
   EXPECT_TRUE(is_same<tensor_inv>(r.get<tensor_scalar_mul>().expr_rhs()))
       << "Inner tensor should be tensor_inv directly (collapsed), got: "
       << to_string(r);
+}
+
+// ---------------------------------------------------------------------------
 // Division-by-reciprocal canonicalisation (issue #49).
 // `a * (1/b)` should canonicalise to `a/b`. Both produce the same
 // pow(b, -1)-based structural form on construction (comment in

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -439,6 +439,9 @@ TEST(CoreBugFix, InvLiftsThenRejectsSkewInner) {
   auto sA = skew(A);
   EXPECT_THROW(
       { [[maybe_unused]] auto r = inv(two * sA); }, invalid_expression_error);
+}
+
+// ---------------------------------------------------------------------------
 // Skew annotation propagation lock-in (issue #93).
 // On the build platform that motivated commit 7e962e5, the Skew space
 // annotation could be lost when skew(A) was stored inside a tensor_mul.
@@ -508,6 +511,9 @@ TEST(CoreBugFix, SkewSpacePreservedAsTensorMulChild) {
   EXPECT_TRUE(found_sA_with_skew) << "skew(A) child not found in tensor_mul";
   EXPECT_FALSE(other_child_spuriously_skew)
       << "non-skew child spuriously annotated as Skew";
+}
+
+// ---------------------------------------------------------------------------
 // Tensor pow simplifications (issue #96) — extends the construction-time
 // rules in tensor_std.h::pow with pow(I, n) → I and pow(inv(A), n) →
 // inv(pow(A, n)). The existing rules pow(0, n) → 0, pow(A, 0) → I,
@@ -538,6 +544,9 @@ TEST(CoreBugFix, TensorPowPowChains) {
   auto [A] =
       make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
   EXPECT_EQ(pow(pow(A, 2), 3), pow(A, 6));
+}
+
+// ---------------------------------------------------------------------------
 // mul × mul merges like factors (verifies issue #97's claim was wrong —
 // the rules ARE implemented, in per-domain wrappers rather than a generic
 // dispatcher; these regressions lock in the contract).

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -315,6 +315,44 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// inv(alpha * A) -> (1/alpha) * inv(A) (issue #71)
+// Scalar factor is lifted outside the inverse so the canonical form keeps
+// the tensor inverse on the inner operand.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, InvLiftsConstantScalarFactor) {
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto two = make_scalar_constant(2);
+  auto r = inv(two * A);
+  // Result should be a tensor_scalar_mul wrapping inv(A).
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(r));
+  auto const &sm = r.get<tensor_scalar_mul>();
+  ASSERT_TRUE(is_same<tensor_inv>(sm.expr_rhs()));
+  EXPECT_EQ(sm.expr_rhs().get<tensor_inv>().expr(), A);
+}
+
+TEST(CoreBugFix, InvLiftsSymbolicScalarFactor) {
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto [s] = make_scalar_variable("s");
+  auto r = inv(s * A);
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(r));
+  EXPECT_TRUE(is_same<tensor_inv>(r.get<tensor_scalar_mul>().expr_rhs()));
+}
+
+TEST(CoreBugFix, InvLiftsThenRejectsSkewInner) {
+  // inv(2 * skew(A)) in odd dim: the scalar lifts out (canonical form),
+  // then the recursive inv(skew(A)) throws via contains_skew_factor.
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  auto two = make_scalar_constant(2);
+  auto sA = skew(A);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto r = inv(two * sA); }, invalid_expression_error);
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #71.

The scalar-factoring rule for `inv()` was the half of #71 not yet implemented (inv(inv(A)) already existed). Adds a guard clause in `tensor_functions.h::inv()`:

- inv(alpha * A) → (1/alpha) * inv(A)

Order in inv(): after inv(inv) and identity short-circuits, before the skew-odd-dim rejection. So inv(2 * skew_3d) lifts the scalar first, then the recursive inv(skew_3d) throws via contains_skew_factor. Same overall outcome (rejection), one level deeper.

Three regressions:
- InvLiftsConstantScalarFactor: inv(2 * A) → (1/2) * inv(A) — fails without fix.
- InvLiftsSymbolicScalarFactor: inv(s * A) → (1/s) * inv(A) — fails without fix.
- InvLiftsThenRejectsSkewInner: inv(2 * skew(A)) still throws.

## Base

Stacked on 95-unify-simplifier-dispatchers (PR #98).

## Test plan

- [x] cmake build clean
- [x] ctest 100% pass (1497 → 1500)
- [x] Lock-in verified to fail without the fix