### PR TITLE
Add trace(-A), trace(trans), trace(otimes) simplification rules

### DIFF
--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -64,6 +64,27 @@ trace(expression_holder<tensor_expression> const &expr) {
     return result;
   }
 
+  // trace(-A) -> -trace(A). Linearity through unary negation.
+  if (is_same<tensor_negative>(expr)) {
+    return -trace(expr.get<tensor_negative>().expr());
+  }
+
+  // trace(trans(A)) -> trace(A). Trace is invariant under transpose for
+  // rank-2 tensors (basis_change_imp with indices {2,1} is the transpose).
+  if (is_same<basis_change_imp>(expr)) {
+    auto const &bc = expr.get<basis_change_imp>();
+    if (bc.indices() == sequence{2, 1})
+      return trace(bc.expr());
+  }
+
+  // trace(u ⊗ v) -> u · v. The trace assertion (rank == 2) means any
+  // outer_product_wrapper reaching this point has rank-1 operands; their
+  // inner product is u_i v_i.
+  if (is_same<outer_product_wrapper>(expr)) {
+    auto const &op = expr.get<outer_product_wrapper>();
+    return dot_product(op.expr_lhs(), sequence{1}, op.expr_rhs(), sequence{1});
+  }
+
   return make_expression<tensor_trace>(expr);
 }
 

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -315,6 +315,37 @@ TEST(CoreBugFix, NArySubAddDispatchT2s) {
 }
 
 // ---------------------------------------------------------------------------
+// trace() simplification rules (issue #72).
+// Existing: trace(0)=0, trace(I)=dim, trace(alpha*A)=alpha*trace(A),
+// trace(A+B+...)=trace(A)+trace(B)+... .
+// New: trace(-A)=-trace(A), trace(trans(A))=trace(A),
+// trace(otimes(u,v))=dot_product(u,v).
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, TraceNegativeIsNegated) {
+  // trace(-A) -> -trace(A)
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  EXPECT_EQ(trace(-A), -trace(A));
+}
+
+TEST(CoreBugFix, TraceTransIsSelf) {
+  // trace(trans(A)) -> trace(A)
+  auto [A] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}});
+  EXPECT_EQ(trace(trans(A)), trace(A));
+}
+
+TEST(CoreBugFix, TraceOuterProductIsDot) {
+  // trace(u ⊗ v) -> dot_product(u, v) for rank-1 vectors.
+  auto [u, v] =
+      make_tensor_variable(std::tuple{"u", std::size_t{3}, std::size_t{1}},
+                           std::tuple{"v", std::size_t{3}, std::size_t{1}});
+  auto r = trace(otimes(u, v));
+  EXPECT_EQ(r, dot_product(u, sequence{1}, v, sequence{1}));
+}
+
+// ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #72.

Three common trace identities added to `trace()` in `tensor_to_scalar_functions.cpp`:

- `trace(-A) → -trace(A)` (linearity through unary negation)
- `trace(trans(A)) → trace(A)` (rank-2 transpose; uses basis_change_imp{2,1} pattern)
- `trace(u ⊗ v) → dot_product(u, v)` (rank-2 outer product of rank-1 vectors)

Existing rules unchanged: trace(0)=0, trace(I)=dim, trace(alpha*A)=alpha*trace(A), linearity through tensor_add.

Three regression tests in `CoreBugFixTest`.

## Base

Stacked on 95-unify-simplifier-dispatchers (PR #98).

## Test plan

- [x] cmake build clean
- [x] ctest 100% pass (1497 → 1500)