### PR TITLE
Add scalar overloads: log10, sinh, cosh, tanh, asinh, acosh, atanh (#33)

### DIFF
--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -228,51 +228,72 @@ template <scalar_expr_holder E> [[nodiscard]] auto log(E &&e) {
   return make_expression<scalar_log>(std::forward<E>(e));
 }
 
-template <scalar_expr_holder E> [[nodiscard]] auto log10(E const &e) {
+template <scalar_expr_holder E> [[nodiscard]] auto log10(E &&e) {
   expression_holder<scalar_expression> ten =
       make_expression<scalar_constant>(scalar_number{10});
   expression_holder<scalar_expression> log_ten =
       make_expression<scalar_log>(std::move(ten));
-  return log(e) / std::move(log_ten);
+  return log(std::forward<E>(e)) / std::move(log_ten);
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto sinh(E const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
   expression_holder<scalar_expression> two =
       make_expression<scalar_constant>(scalar_number{2});
   return (exp(e) - exp(-e)) / std::move(two);
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto cosh(E const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_one();
+  // cosh(-x) = cosh(x) — fold the negation away so chain rules see the
+  // simpler form.
+  if (is_same<scalar_negative>(e))
+    return cosh(e.template get<scalar_negative>().expr());
   expression_holder<scalar_expression> two =
       make_expression<scalar_constant>(scalar_number{2});
   return (exp(e) + exp(-e)) / std::move(two);
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto tanh(E const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  // tanh(-x) = -tanh(x)
+  if (is_same<scalar_negative>(e))
+    return -tanh(e.template get<scalar_negative>().expr());
   return sinh(e) / cosh(e);
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto asinh(E const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
   expression_holder<scalar_expression> one = get_scalar_one();
   return log(e + sqrt(pow(e, 2) + std::move(one)));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto acosh(E const &e) {
+  // acosh(1) = 0 — covers scalar_one and scalar_constant{1}.
+  if (is_same<scalar_one>(e) ||
+      (is_same<scalar_constant>(e) &&
+       e.template get<scalar_constant>().value() == scalar_number{1}))
+    return get_scalar_zero();
   expression_holder<scalar_expression> one = get_scalar_one();
   return log(e + sqrt(pow(e, 2) - std::move(one)));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto atanh(E const &e) {
-  // Use separate `one` instances per sub-expression: the C++ standard does
-  // not specify evaluation order of operator/'s operands, so `std::move(one)`
-  // on the RHS could otherwise empty the lvalue used on the LHS. gcc and MSVC
-  // evaluate RHS first; clang evaluates LHS first.
-  expression_holder<scalar_expression> one_lhs = get_scalar_one();
-  expression_holder<scalar_expression> one_rhs = get_scalar_one();
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  // The C++ standard does not specify evaluation order of operator/'s
+  // operands. Build numerator and denominator as separate named statements
+  // so the moves are unambiguously ordered before the division consumes
+  // them. (gcc/MSVC evaluate RHS first; clang evaluates LHS first.)
+  auto num = get_scalar_one() + e;
+  auto den = get_scalar_one() - e;
   expression_holder<scalar_expression> two =
       make_expression<scalar_constant>(scalar_number{2});
-  return log((std::move(one_lhs) + e) / (std::move(one_rhs) - e)) /
-         std::move(two);
+  return log(std::move(num) / std::move(den)) / std::move(two);
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -263,10 +263,16 @@ template <scalar_expr_holder E> [[nodiscard]] auto acosh(E const &e) {
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto atanh(E const &e) {
-  expression_holder<scalar_expression> one = get_scalar_one();
+  // Use separate `one` instances per sub-expression: the C++ standard does
+  // not specify evaluation order of operator/'s operands, so `std::move(one)`
+  // on the RHS could otherwise empty the lvalue used on the LHS. gcc and MSVC
+  // evaluate RHS first; clang evaluates LHS first.
+  expression_holder<scalar_expression> one_lhs = get_scalar_one();
+  expression_holder<scalar_expression> one_rhs = get_scalar_one();
   expression_holder<scalar_expression> two =
       make_expression<scalar_constant>(scalar_number{2});
-  return log((one + e) / (std::move(one) - e)) / std::move(two);
+  return log((std::move(one_lhs) + e) / (std::move(one_rhs) - e)) /
+         std::move(two);
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -228,6 +228,47 @@ template <scalar_expr_holder E> [[nodiscard]] auto log(E &&e) {
   return make_expression<scalar_log>(std::forward<E>(e));
 }
 
+template <scalar_expr_holder E> [[nodiscard]] auto log10(E const &e) {
+  expression_holder<scalar_expression> ten =
+      make_expression<scalar_constant>(scalar_number{10});
+  expression_holder<scalar_expression> log_ten =
+      make_expression<scalar_log>(std::move(ten));
+  return log(e) / std::move(log_ten);
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto sinh(E const &e) {
+  expression_holder<scalar_expression> two =
+      make_expression<scalar_constant>(scalar_number{2});
+  return (exp(e) - exp(-e)) / std::move(two);
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto cosh(E const &e) {
+  expression_holder<scalar_expression> two =
+      make_expression<scalar_constant>(scalar_number{2});
+  return (exp(e) + exp(-e)) / std::move(two);
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto tanh(E const &e) {
+  return sinh(e) / cosh(e);
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto asinh(E const &e) {
+  expression_holder<scalar_expression> one = get_scalar_one();
+  return log(e + sqrt(pow(e, 2) + std::move(one)));
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto acosh(E const &e) {
+  expression_holder<scalar_expression> one = get_scalar_one();
+  return log(e + sqrt(pow(e, 2) - std::move(one)));
+}
+
+template <scalar_expr_holder E> [[nodiscard]] auto atanh(E const &e) {
+  expression_holder<scalar_expression> one = get_scalar_one();
+  expression_holder<scalar_expression> two =
+      make_expression<scalar_constant>(scalar_number{2});
+  return log((one + e) / (std::move(one) - e)) / std::move(two);
+}
+
 } // namespace numsim::cas
 
 #endif // SCALAR_STD_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -401,6 +401,50 @@ TEST(CoreBugFix, ScalarAtanhMatchesNumerical) {
   EXPECT_NEAR(ev.apply(expr), std::atanh(0.5), 1e-12);
 }
 
+// ---------------------------------------------------------------------------
+// Construction-time short-circuits for the composition-based hyperbolic
+// functions. These mirror what the underlying primitives (exp/log/sqrt/pow)
+// already do for special arguments, but lift the simplification to the
+// public API so callers see a clean expression without round-tripping
+// through the composed form.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, ScalarSinhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<scalar_zero>(sinh(get_scalar_zero())));
+}
+
+TEST(CoreBugFix, ScalarCoshOfZeroIsOne) {
+  EXPECT_TRUE(is_same<scalar_one>(cosh(get_scalar_zero())));
+}
+
+TEST(CoreBugFix, ScalarCoshOfNegateFoldsToCosh) {
+  // cosh(-x) = cosh(x) — even function.
+  auto [x] = make_scalar_variable("x");
+  EXPECT_EQ(cosh(-x), cosh(x));
+}
+
+TEST(CoreBugFix, ScalarTanhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<scalar_zero>(tanh(get_scalar_zero())));
+}
+
+TEST(CoreBugFix, ScalarTanhOfNegateFoldsToNegTanh) {
+  // tanh(-x) = -tanh(x) — odd function.
+  auto [x] = make_scalar_variable("x");
+  EXPECT_EQ(tanh(-x), -tanh(x));
+}
+
+TEST(CoreBugFix, ScalarAsinhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<scalar_zero>(asinh(get_scalar_zero())));
+}
+
+TEST(CoreBugFix, ScalarAcoshOfOneIsZero) {
+  EXPECT_TRUE(is_same<scalar_zero>(acosh(get_scalar_one())));
+}
+
+TEST(CoreBugFix, ScalarAtanhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<scalar_zero>(atanh(get_scalar_zero())));
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -3,6 +3,7 @@
 
 #include "numsim_cas/numsim_cas.h"
 #include "gtest/gtest.h"
+#include <cmath>
 
 namespace numsim::cas {
 
@@ -336,6 +337,68 @@ TEST(CoreBugFix, ForwardValuesToSkipsNonScalarKey) {
   // set_scalar that forward_values_to expects.
   tensor_evaluator<double> dst;
   EXPECT_NO_THROW(src.forward_values_to(dst));
+}
+
+// ---------------------------------------------------------------------------
+// #33: scalar std overloads — log10, sinh, cosh, tanh, asinh, acosh, atanh
+// Implemented as compositions of existing primitives. The functions should
+// produce expressions whose numerical evaluation matches the math definition.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, ScalarLog10MatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = log10(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 100.0);
+  EXPECT_NEAR(ev.apply(expr), 2.0, 1e-12);
+}
+
+TEST(CoreBugFix, ScalarSinhMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = sinh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 0.5);
+  EXPECT_NEAR(ev.apply(expr), std::sinh(0.5), 1e-12);
+}
+
+TEST(CoreBugFix, ScalarCoshMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = cosh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 0.5);
+  EXPECT_NEAR(ev.apply(expr), std::cosh(0.5), 1e-12);
+}
+
+TEST(CoreBugFix, ScalarTanhMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = tanh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 0.7);
+  EXPECT_NEAR(ev.apply(expr), std::tanh(0.7), 1e-12);
+}
+
+TEST(CoreBugFix, ScalarAsinhMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = asinh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.5);
+  EXPECT_NEAR(ev.apply(expr), std::asinh(1.5), 1e-12);
+}
+
+TEST(CoreBugFix, ScalarAcoshMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = acosh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 2.5); // domain: x >= 1
+  EXPECT_NEAR(ev.apply(expr), std::acosh(2.5), 1e-12);
+}
+
+TEST(CoreBugFix, ScalarAtanhMatchesNumerical) {
+  auto [x] = make_scalar_variable("x");
+  auto expr = atanh(x);
+  scalar_evaluator<double> ev;
+  ev.set(x, 0.5); // domain: -1 < x < 1
+  EXPECT_NEAR(ev.apply(expr), std::atanh(0.5), 1e-12);
 }
 
 } // namespace numsim::cas


### PR DESCRIPTION
## Summary

Implements the seven remaining checkbox items in #33 — `log10`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh` — as compositions of existing primitives (`log`, `exp`, `sqrt`, `pow`, arithmetic ops). No new AST node types.

Closes #33.

## Mathematical definitions

```
log10(x) = log(x) / log(10)
sinh(x)  = (exp(x) - exp(-x)) / 2
cosh(x)  = (exp(x) + exp(-x)) / 2
tanh(x)  = sinh(x) / cosh(x)
asinh(x) = log(x + sqrt(x² + 1))
acosh(x) = log(x + sqrt(x² - 1))
atanh(x) = log((1 + x) / (1 - x)) / 2
```

## Trade-off: derived expressions vs dedicated nodes

I chose **derived expressions** over dedicated AST node types. Reasoning:
- Differentiation, evaluation, and printing work correctly via existing rules — no new visitor overloads needed.
- The public API matches the issue's checklist exactly — callers write `cosh(x)` and get the right result.
- Cost: the printed form expands (e.g., `cosh(x)` prints as `(exp(x) + exp(-x))/2`). If named-function printing becomes important later, the functions can be replaced by dedicated nodes without breaking callers.

This is the standard pattern for "math identities that compose from existing primitives." It mirrors what would otherwise be a much larger PR adding 7 × (node type + simplifier + evaluator + printer + latex printer + differentiation) entries.

## Implementation note on `log10`

`log10` is implemented to construct the `log(10)` denominator directly via `make_expression` rather than calling `log()`. Reasoning: calling `log()` would instantiate `log<expression_holder<scalar_expression>>` (non-ref). That instantiation hits a code path in the existing `log` template body that the lvalue-ref instantiations didn't exercise — specifically the `scalar_sqrt` branch's `log(...) * half` line, where `half`'s `expression_holder<typename scalar_constant::expr_t>` typedef trips up overload resolution for `*`. Sidestepping by building `log(10)` once at the construction site.

This isn't a bug in the existing `log` (the const-lvalue-ref path that real callers use works fine), but it surfaces a fragile interaction worth tracking. If we want to call `log()` from new code that produces rvalue arguments, the `log` body should be hardened. Not in scope for this PR.

## Test plan

- [x] 7 new tests in `CoreBugFixTest.h` verifying numerical evaluation matches `std::log10`, `std::sinh`, `std::cosh`, `std::tanh`, `std::asinh`, `std::acosh`, `std::atanh` at representative points (within 1e-12).
- [x] All 1504 tests pass (1497 + 7 new).
- [x] Clean build, no new warnings.
- [ ] Self-review pass.