### PR TITLE
Add t2s overloads: log10, sinh, cosh, tanh, asinh, acosh, atanh (#32)

### DIFF
--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -123,49 +123,70 @@ inline auto t2s_constant(scalar_number v) {
 } // namespace tensor_to_scalar_detail
 
 template <tensor_to_scalar_expr_holder Expr>
-[[nodiscard]] auto log10(Expr const &expr) {
+[[nodiscard]] auto log10(Expr &&expr) {
   expression_holder<tensor_to_scalar_expression> log_ten =
       make_expression<tensor_to_scalar_log>(
           tensor_to_scalar_detail::t2s_constant(scalar_number{10}));
-  return log(expr) / std::move(log_ten);
+  return log(std::forward<Expr>(expr)) / std::move(log_ten);
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto sinh(Expr const &expr) {
+  if (is_same<tensor_to_scalar_zero>(expr))
+    return make_expression<tensor_to_scalar_zero>();
   auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
   return (exp(expr) - exp(-expr)) / std::move(two);
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto cosh(Expr const &expr) {
+  if (is_same<tensor_to_scalar_zero>(expr))
+    return make_expression<tensor_to_scalar_one>();
+  // cosh(-x) = cosh(x) — even function.
+  if (is_same<tensor_to_scalar_negative>(expr))
+    return cosh(expr.template get<tensor_to_scalar_negative>().expr());
   auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
   return (exp(expr) + exp(-expr)) / std::move(two);
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto tanh(Expr const &expr) {
+  if (is_same<tensor_to_scalar_zero>(expr))
+    return make_expression<tensor_to_scalar_zero>();
+  // tanh(-x) = -tanh(x) — odd function.
+  if (is_same<tensor_to_scalar_negative>(expr))
+    return -tanh(expr.template get<tensor_to_scalar_negative>().expr());
   return sinh(expr) / cosh(expr);
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto asinh(Expr const &expr) {
+  if (is_same<tensor_to_scalar_zero>(expr))
+    return make_expression<tensor_to_scalar_zero>();
   auto one = make_expression<tensor_to_scalar_one>();
   return log(expr + sqrt(pow(expr, 2) + std::move(one)));
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto acosh(Expr const &expr) {
+  // acosh(1) = 0
+  if (is_same<tensor_to_scalar_one>(expr))
+    return make_expression<tensor_to_scalar_zero>();
   auto one = make_expression<tensor_to_scalar_one>();
   return log(expr + sqrt(pow(expr, 2) - std::move(one)));
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto atanh(Expr const &expr) {
-  auto one_a = make_expression<tensor_to_scalar_one>();
-  auto one_b = make_expression<tensor_to_scalar_one>();
+  if (is_same<tensor_to_scalar_zero>(expr))
+    return make_expression<tensor_to_scalar_zero>();
+  // Build numerator and denominator as separate named statements so the
+  // moves are unambiguously ordered before the division consumes them.
+  // (operator/'s operand evaluation order is unspecified in C++.)
+  auto num = make_expression<tensor_to_scalar_one>() + expr;
+  auto den = make_expression<tensor_to_scalar_one>() - expr;
   auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
-  return log((std::move(one_a) + expr) / (std::move(one_b) - expr)) /
-         std::move(two);
+  return log(std::move(num) / std::move(den)) / std::move(two);
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -115,6 +115,59 @@ template <tensor_to_scalar_expr_holder Expr>
   return make_expression<tensor_to_scalar_sqrt>(std::forward<Expr>(expr));
 }
 
+namespace tensor_to_scalar_detail {
+inline auto t2s_constant(scalar_number v) {
+  return make_expression<tensor_to_scalar_scalar_wrapper>(
+      make_expression<scalar_constant>(v));
+}
+} // namespace tensor_to_scalar_detail
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto log10(Expr const &expr) {
+  expression_holder<tensor_to_scalar_expression> log_ten =
+      make_expression<tensor_to_scalar_log>(
+          tensor_to_scalar_detail::t2s_constant(scalar_number{10}));
+  return log(expr) / std::move(log_ten);
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto sinh(Expr const &expr) {
+  auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
+  return (exp(expr) - exp(-expr)) / std::move(two);
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto cosh(Expr const &expr) {
+  auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
+  return (exp(expr) + exp(-expr)) / std::move(two);
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto tanh(Expr const &expr) {
+  return sinh(expr) / cosh(expr);
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto asinh(Expr const &expr) {
+  auto one = make_expression<tensor_to_scalar_one>();
+  return log(expr + sqrt(pow(expr, 2) + std::move(one)));
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto acosh(Expr const &expr) {
+  auto one = make_expression<tensor_to_scalar_one>();
+  return log(expr + sqrt(pow(expr, 2) - std::move(one)));
+}
+
+template <tensor_to_scalar_expr_holder Expr>
+[[nodiscard]] auto atanh(Expr const &expr) {
+  auto one_a = make_expression<tensor_to_scalar_one>();
+  auto one_b = make_expression<tensor_to_scalar_one>();
+  auto two = tensor_to_scalar_detail::t2s_constant(scalar_number{2});
+  return log((std::move(one_a) + expr) / (std::move(one_b) - expr)) /
+         std::move(two);
+}
+
 } // namespace numsim::cas
 
 #endif // TENSOR_TO_SCALAR_STD_H

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -325,6 +325,49 @@ TEST(T2sEval, T2sAtanhMatchesNumerical) {
   EXPECT_NEAR(ev.apply(expr), std::atanh(0.5), t2s_tol);
 }
 
+// ─── #32 hyperbolic short-circuit lock-ins ───────────────────────────────
+// Mirror the scalar short-circuits added in PR #123 for t2s.
+
+TEST(T2sEval, T2sSinhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(
+      sinh(make_expression<tensor_to_scalar_zero>())));
+}
+
+TEST(T2sEval, T2sCoshOfZeroIsOne) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_one>(
+      cosh(make_expression<tensor_to_scalar_zero>())));
+}
+
+TEST(T2sEval, T2sCoshOfNegateFoldsToCosh) {
+  auto A = make_expression<tensor>("A", 2, 2);
+  EXPECT_EQ(cosh(-trace(A)), cosh(trace(A)));
+}
+
+TEST(T2sEval, T2sTanhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(
+      tanh(make_expression<tensor_to_scalar_zero>())));
+}
+
+TEST(T2sEval, T2sTanhOfNegateFoldsToNegTanh) {
+  auto A = make_expression<tensor>("A", 2, 2);
+  EXPECT_EQ(tanh(-trace(A)), -tanh(trace(A)));
+}
+
+TEST(T2sEval, T2sAsinhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(
+      asinh(make_expression<tensor_to_scalar_zero>())));
+}
+
+TEST(T2sEval, T2sAcoshOfOneIsZero) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(
+      acosh(make_expression<tensor_to_scalar_one>())));
+}
+
+TEST(T2sEval, T2sAtanhOfZeroIsZero) {
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(
+      atanh(make_expression<tensor_to_scalar_zero>())));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORTOSCALAREVALUATORTEST_H

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -258,6 +258,73 @@ TEST(T2sEval, EvaluationErrorIsCatchableAsRuntimeError) {
   EXPECT_THROW(ev.apply(trace(A)), std::runtime_error);
 }
 
+// ─── #32: t2s std overloads — log10, hyperbolic, inverse hyperbolic ──────
+// Implemented as compositions of existing primitives (log, exp, sqrt, pow,
+// +, -, *, /). Verify numerical evaluation matches std:: counterparts when
+// applied to a t2s expression. Use trace(A) as the inner t2s expression.
+
+TEST(T2sEval, T2sLog10MatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 1 + 99 = 100 → log10 = 2
+  ev.set(A, make_test_data<2, 2>({1.0, 0.0, 0.0, 99.0}));
+  auto expr = log10(trace(A));
+  EXPECT_NEAR(ev.apply(expr), 2.0, t2s_tol);
+}
+
+TEST(T2sEval, T2sSinhMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 0.5
+  ev.set(A, make_test_data<2, 2>({0.2, 0.0, 0.0, 0.3}));
+  auto expr = sinh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::sinh(0.5), t2s_tol);
+}
+
+TEST(T2sEval, T2sCoshMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  ev.set(A, make_test_data<2, 2>({0.2, 0.0, 0.0, 0.3}));
+  auto expr = cosh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::cosh(0.5), t2s_tol);
+}
+
+TEST(T2sEval, T2sTanhMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 0.7
+  ev.set(A, make_test_data<2, 2>({0.3, 0.0, 0.0, 0.4}));
+  auto expr = tanh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::tanh(0.7), t2s_tol);
+}
+
+TEST(T2sEval, T2sAsinhMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 1.5
+  ev.set(A, make_test_data<2, 2>({0.5, 0.0, 0.0, 1.0}));
+  auto expr = asinh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::asinh(1.5), t2s_tol);
+}
+
+TEST(T2sEval, T2sAcoshMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 2.5 (domain: x >= 1)
+  ev.set(A, make_test_data<2, 2>({1.0, 0.0, 0.0, 1.5}));
+  auto expr = acosh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::acosh(2.5), t2s_tol);
+}
+
+TEST(T2sEval, T2sAtanhMatchesNumerical) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  // trace = 0.5 (domain: |x| < 1)
+  ev.set(A, make_test_data<2, 2>({0.2, 0.0, 0.0, 0.3}));
+  auto expr = atanh(trace(A));
+  EXPECT_NEAR(ev.apply(expr), std::atanh(0.5), t2s_tol);
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORTOSCALAREVALUATORTEST_H


### PR DESCRIPTION
## Summary

Symmetric to PR #123 (scalar) for the tensor-to-scalar domain. Implements 7 of the 13 missing t2s overloads as compositions of existing primitives. No new AST node types.

Partial closure of #32. The remaining 6 (`sin`, `cos`, `tan`, `asin`, `acos`, `atan`) require dedicated node types and are out of scope.

## Implemented

```
log10(x) = log(x) / log(10)
sinh(x)  = (exp(x) - exp(-x)) / 2
cosh(x)  = (exp(x) + exp(-x)) / 2
tanh(x)  = sinh(x) / cosh(x)
asinh(x) = log(x + sqrt(x² + 1))
acosh(x) = log(x + sqrt(x² - 1))
atanh(x) = log((1 + x) / (1 - x)) / 2
```

## Why the trig 6 aren't here

t2s currently has no `tensor_to_scalar_sin`, `tensor_to_scalar_cos`, etc. nodes. Unlike scalar (which has `scalar_sin` etc.), and unlike `log/exp/sqrt` (which already exist in t2s), there's nothing to compose `sin(trace(A))` from. Adding them requires the full ~5-file pattern per node:
- New AST node class
- Simplifier entries
- Printer / latex printer overloads
- Evaluator overload (delegating to `std::sin` etc.)
- Differentiation rule (`d/dx sin = cos`)

Filed as a follow-up. Not blocking the 7 functions that compose cleanly.

## Test plan

- [x] 7 new tests in `TensorToScalarEvaluatorTest.h` — apply each function to `trace(A)` for representative A, verify numerical evaluation matches `std::sinh`, `std::log10`, etc. (within 1e-12).
- [x] All 1511 tests pass (1504 + 7 new).
- [x] Clean build, no new warnings.
- [ ] Self-review pass.