### PR TITLE
Audit scalar_evaluator overload coverage (#44)

### DIFF
--- a/tests/ScalarEvaluatorTest.h
+++ b/tests/ScalarEvaluatorTest.h
@@ -17,6 +17,18 @@ namespace {
 using expr_t = expression_holder<scalar_expression>;
 } // namespace
 
+// ---------------------------------------------------------------------------
+// Audit #44 (2026-05-17): scalar_evaluator overload coverage verified.
+// All 20 node types in NUMSIM_CAS_SCALAR_NODE_LIST have explicit operator()
+// overrides in scalar_evaluator (header-only, see scalar/visitors/
+// scalar_evaluator.h). Fallback uses static_assert(sizeof(T) == 0, ...) so
+// adding a new node type without an override is a compile error.
+// All 20 nodes have explicit EvalScalar* lock-in tests below. The audit's
+// concern about "empty stubs" mentioned in the issue body is not present
+// — every visitor produces a value via std::* primitives or recurses into
+// children. No code changes required.
+// ---------------------------------------------------------------------------
+
 // --- Individual operator() tests ---
 
 TEST(ScalarEval, EvalScalarSymbol) {


### PR DESCRIPTION
## Audit findings

**Coverage:** all 20 node types in `NUMSIM_CAS_SCALAR_NODE_LIST` have explicit `operator()` overrides in `scalar_evaluator`. Verified by cross-checking the node list against `scalar/visitors/scalar_evaluator.h`.

**Fallback safety:** the catch-all uses `static_assert(sizeof(T) == 0, "...")` — adding a new node type without an override is a compile error, not silent fallback. Same defensive pattern as `scalar_differentiation`.

**Existing test coverage:** all 20 nodes already have explicit `EvalScalar*` lock-in tests in `tests/ScalarEvaluatorTest.h`. Plus integration tests: `EvalPolynomial`, `EvalMultiVariable`, `EvalNestedTrig`, `EvalChainPowExp`.

## Issue body concerns addressed

> The issue body suggested `several operator() overloads take const & visitables and call apply(visitable.expr())` might need a const-ref apply overload.

Verified: `apply()` takes `expr_holder_t const &`, which binds to lvalues, const-lvalues, and rvalues. **No additional overloads needed.**

> The issue body also flagged 'empty stubs' as a concern.

**None exist** — every visitor produces a value via `std::*` primitives (`std::sin`, `std::cos`, `std::pow`, etc.) or recurses into children via `apply()`. The premise was likely from an older state of the codebase.

## Other notable findings

- `scalar_constant` correctly handles **complex, rational, and arithmetic** variants via `std::visit` on `value().raw()`.
- `scalar_sign` correctly handles three cases (positive / negative / zero).
- All evaluations use `std::*` primitives directly — no precision loss vs. composition-based alternatives.

## What this PR adds

A single audit comment block at the top of `ScalarEvaluatorTest.h` documenting the verification. **No production code changes.** Audit was clean.

## Test plan

- [x] Full test suite passes (1498).
- [x] Clean build, no warnings.

Closes #44.