### PR TITLE
Audit tensor_to_scalar_differentiation overload coverage (#38)

### DIFF
--- a/tests/TensorToScalarDifferentiationTest.h
+++ b/tests/TensorToScalarDifferentiationTest.h
@@ -137,6 +137,66 @@ TEST_F(TensorToScalarDifferentiationTest, SymmetricDotDetDiff) {
       << "  d: " << to_string(d);
 }
 
+// ---------------------------------------------------------------------------
+// Audit #38: lock-in coverage tests for tensor_to_scalar_differentiation.
+// All 15 node types in NUMSIM_CAS_TENSOR_TO_SCALAR_NODE_LIST have explicit
+// operator() overrides via the pure-virtual visitor base (missing override
+// = compile error, not silent fallback). Existing TEST_F entries above
+// cover trace, det, dot, norm, log, add, negative, one, zero. These add
+// lock-ins for the remaining six nodes.
+// ---------------------------------------------------------------------------
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_ScalarWrapper) {
+  // d(scalar_wrapper(c))/dY = 0 — scalar constant inside t2s is independent.
+  auto c = make_expression<tensor_to_scalar_scalar_wrapper>(
+      make_expression<scalar_constant>(2.0));
+  auto d = diff(c, Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid derivative for scalar_wrapper";
+  EXPECT_TRUE(is_same<tensor_zero>(d))
+      << "Expected tensor_zero, got: " << to_string(d);
+}
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_Mul) {
+  // d(trace(Y) * det(Y))/dY — product rule applied to t2s factors.
+  auto expr = trace(Y) * det(Y);
+  auto d = diff(expr, Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid derivative for t2s mul";
+  EXPECT_EQ(d.get().rank(), rank);
+}
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_Pow) {
+  // d(trace(Y)^3)/dY — exercise the t2s pow differentiation path.
+  auto expr = pow(trace(Y), 3);
+  auto d = diff(expr, Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid derivative for t2s pow";
+  EXPECT_EQ(d.get().rank(), rank);
+}
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_Exp) {
+  // d(exp(trace(Y)))/dY — chain rule via t2s exp.
+  auto expr = exp(trace(Y));
+  auto d = diff(expr, Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid derivative for t2s exp";
+  EXPECT_EQ(d.get().rank(), rank);
+}
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_Sqrt) {
+  // d(sqrt(trace(Y)))/dY — chain rule via t2s sqrt.
+  auto expr = sqrt(trace(Y));
+  auto d = diff(expr, Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid derivative for t2s sqrt";
+  EXPECT_EQ(d.get().rank(), rank);
+}
+
+TEST_F(TensorToScalarDifferentiationTest, AuditNode_InnerProductToScalar) {
+  // d(Y:Y)/dY via dot_product (constructs tensor_inner_product_to_scalar).
+  auto expr = dot_product(Y, sequence{1, 2}, Y, sequence{1, 2});
+  auto d = diff(expr, Y);
+  EXPECT_TRUE(d.is_valid())
+      << "Expected valid derivative for inner_product_to_scalar";
+  EXPECT_EQ(d.get().rank(), rank);
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORTOSCALARDIFFERENTIATIONTEST_H


### PR DESCRIPTION
## Audit findings

**Coverage:** all 15 node types in `NUMSIM_CAS_TENSOR_TO_SCALAR_NODE_LIST` have explicit `operator()` overrides via the pure-virtual visitor base. Missing override = compile error, not silent fallback.

**Pre-audit test coverage:** 9 of 15 nodes already had explicit `Node_*` tests (`Node_Trace`, `Node_Negative`, `Node_Add`, `Node_OneIsZeroDerivative`, `Node_ZeroIsZeroDerivative`, `Node_Log`, `Node_Det`, `Node_Dot`, `Node_Norm`).

## What this PR adds

6 lock-in tests in `TensorToScalarDifferentiationTest.h::AuditNode_*`:

- `ScalarWrapper` — `d(wrapper(c))/dY = 0`
- `Mul` — product rule on t2s factors
- `Pow` — `d(trace(Y)^3)/dY`
- `Exp` — chain rule via t2s exp
- `Sqrt` — chain rule via t2s sqrt
- `InnerProductToScalar` — `d(Y:Y)/dY`

Each test verifies the derivative is valid and has the correct rank.

Closes #38.