### PR TITLE
Predicate domain skeleton (PR 1/5 toward #135)

### DIFF
--- a/include/numsim_cas/predicate/predicate_definitions.h
+++ b/include/numsim_cas/predicate/predicate_definitions.h
@@ -1,0 +1,17 @@
+#ifndef PREDICATE_DEFINITIONS_H
+#define PREDICATE_DEFINITIONS_H
+
+// Umbrella include for the predicate domain. Pulls in the base class, the
+// node list / visitor typedefs, the two leaf nodes, and the global-access
+// helpers. Subsequent PRs (#136 comparisons, #135 if_then_else) will add
+// further headers and append them here.
+
+#include "predicate_expression.h"
+#include "predicate_false.h"
+#include "predicate_globals.h"
+#include "predicate_io.h"
+#include "predicate_node_list.h"
+#include "predicate_true.h"
+#include "predicate_visitor_typedef.h"
+
+#endif // PREDICATE_DEFINITIONS_H

--- a/include/numsim_cas/predicate/predicate_expression.h
+++ b/include/numsim_cas/predicate/predicate_expression.h
@@ -1,0 +1,42 @@
+#ifndef PREDICATE_EXPRESSION_H
+#define PREDICATE_EXPRESSION_H
+
+#include <numsim_cas/core/expression.h>
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/predicate/predicate_visitor_typedef.h>
+
+namespace numsim::cas {
+
+// Base type for the predicate (boolean) domain. Predicates carry a logical
+// truth value; they have no arithmetic and are not differentiable. They
+// flow into `if_then_else` as the condition, and they're produced by
+// comparison operators (lt, gt, eq, ...) and logical combinators (and,
+// or, not) added in subsequent PRs.
+class predicate_expression : public expression {
+public:
+  using expr_t = predicate_expression;
+  using visitor_t = predicate_visitor_t;
+  using visitor_const_t = predicate_visitor_const_t;
+
+  template <typename... Args>
+  requires(sizeof...(Args) != 1 ||
+           !std::is_same_v<std::remove_cvref_t<Args>..., predicate_expression>)
+  predicate_expression(Args &&...args)
+      : expression(std::forward<Args>(args)...) {}
+  predicate_expression(predicate_expression const &data)
+      : expression(static_cast<expression const &>(data)) {}
+  predicate_expression(predicate_expression &&data) noexcept
+      : expression(std::move(static_cast<expression &&>(data))) {}
+  ~predicate_expression() override = default;
+  const predicate_expression &operator=(predicate_expression const &) = delete;
+};
+
+template <class T>
+concept predicate_expr_holder =
+    requires { typename std::remove_cvref_t<T>::expr_type; } &&
+    std::is_base_of_v<predicate_expression,
+                      typename std::remove_cvref_t<T>::expr_type>;
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_EXPRESSION_H

--- a/include/numsim_cas/predicate/predicate_false.h
+++ b/include/numsim_cas/predicate/predicate_false.h
@@ -1,0 +1,49 @@
+#ifndef PREDICATE_FALSE_H
+#define PREDICATE_FALSE_H
+
+#include <numsim_cas/core/hash_functions.h>
+#include <numsim_cas/predicate/predicate_expression.h>
+
+namespace numsim::cas {
+
+// The constant `false` predicate. Used as the trivially-unsatisfied branch
+// of an if_then_else, or as the result of folding a constant comparison
+// like `5 < 2`.
+class predicate_false final : public predicate_node_base_t<predicate_false> {
+public:
+  using base = predicate_node_base_t<predicate_false>;
+
+  predicate_false() {}
+  predicate_false(predicate_false &&data) noexcept
+      : base(static_cast<base &&>(data)) {}
+  predicate_false(predicate_false const &data)
+      : base(static_cast<base const &>(data)) {}
+  ~predicate_false() override = default;
+  const predicate_false &operator=(predicate_false &&) = delete;
+
+  friend inline bool operator<(predicate_false const &lhs,
+                               predicate_false const &rhs) {
+    return lhs.hash_value() < rhs.hash_value();
+  }
+  friend inline bool operator>(predicate_false const &lhs,
+                               predicate_false const &rhs) {
+    return rhs < lhs;
+  }
+  friend inline bool operator==(predicate_false const &lhs,
+                                predicate_false const &rhs) {
+    return lhs.hash_value() == rhs.hash_value();
+  }
+  friend inline bool operator!=(predicate_false const &lhs,
+                                predicate_false const &rhs) {
+    return !(lhs == rhs);
+  }
+
+private:
+  void update_hash_value() const override {
+    hash_combine(base::m_hash_value, base::get_id());
+  }
+};
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_FALSE_H

--- a/include/numsim_cas/predicate/predicate_globals.h
+++ b/include/numsim_cas/predicate/predicate_globals.h
@@ -1,0 +1,17 @@
+#ifndef PREDICATE_GLOBALS_H
+#define PREDICATE_GLOBALS_H
+
+#include <numsim_cas/predicate/predicate_expression.h>
+
+namespace numsim::cas {
+
+// Cached `true` / `false` leaf expression_holders. All simplifications that
+// fold a comparison to a literal return one of these — there's never any
+// need for a fresh make_expression<predicate_true>() call inside the
+// simplifier or evaluator paths.
+expression_holder<predicate_expression> const &get_predicate_true() noexcept;
+expression_holder<predicate_expression> const &get_predicate_false() noexcept;
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_GLOBALS_H

--- a/include/numsim_cas/predicate/predicate_io.h
+++ b/include/numsim_cas/predicate/predicate_io.h
@@ -1,0 +1,16 @@
+#ifndef PREDICATE_IO_H
+#define PREDICATE_IO_H
+
+#include <ostream>
+
+namespace numsim::cas {
+
+class predicate_expression;
+template <class ExprBase> class expression_holder;
+
+std::ostream &operator<<(std::ostream &os,
+                         expression_holder<predicate_expression> const &expr);
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_IO_H

--- a/include/numsim_cas/predicate/predicate_node_list.h
+++ b/include/numsim_cas/predicate/predicate_node_list.h
@@ -1,0 +1,18 @@
+#ifndef PREDICATE_NODE_LIST_H
+#define PREDICATE_NODE_LIST_H
+
+// X-macro registry of every node type in the predicate domain.
+// Predicates carry a boolean value (true / false). Inhabitants of the
+// domain are the two literal leaves plus (in later PRs) comparison nodes
+// produced by scalar `<`/`>`/`==` operators and logical combinators
+// (`and`/`or`/`not`).
+//
+// Usage: NUMSIM_CAS_PREDICATE_NODE_LIST(FIRST_MACRO, NEXT_MACRO)
+// FIRST_MACRO(T) expands the first element (no leading comma).
+// NEXT_MACRO(T) expands subsequent elements (with leading comma).
+
+#define NUMSIM_CAS_PREDICATE_NODE_LIST(FIRST, NEXT)                            \
+  FIRST(predicate_true)                                                        \
+  NEXT(predicate_false)
+
+#endif // PREDICATE_NODE_LIST_H

--- a/include/numsim_cas/predicate/predicate_true.h
+++ b/include/numsim_cas/predicate/predicate_true.h
@@ -1,0 +1,49 @@
+#ifndef PREDICATE_TRUE_H
+#define PREDICATE_TRUE_H
+
+#include <numsim_cas/core/hash_functions.h>
+#include <numsim_cas/predicate/predicate_expression.h>
+
+namespace numsim::cas {
+
+// The constant `true` predicate. Used as the trivially-satisfied branch
+// of an if_then_else, or as the result of folding a constant comparison
+// like `2 < 3`.
+class predicate_true final : public predicate_node_base_t<predicate_true> {
+public:
+  using base = predicate_node_base_t<predicate_true>;
+
+  predicate_true() {}
+  predicate_true(predicate_true &&data) noexcept
+      : base(static_cast<base &&>(data)) {}
+  predicate_true(predicate_true const &data)
+      : base(static_cast<base const &>(data)) {}
+  ~predicate_true() override = default;
+  const predicate_true &operator=(predicate_true &&) = delete;
+
+  friend inline bool operator<(predicate_true const &lhs,
+                               predicate_true const &rhs) {
+    return lhs.hash_value() < rhs.hash_value();
+  }
+  friend inline bool operator>(predicate_true const &lhs,
+                               predicate_true const &rhs) {
+    return rhs < lhs;
+  }
+  friend inline bool operator==(predicate_true const &lhs,
+                                predicate_true const &rhs) {
+    return lhs.hash_value() == rhs.hash_value();
+  }
+  friend inline bool operator!=(predicate_true const &lhs,
+                                predicate_true const &rhs) {
+    return !(lhs == rhs);
+  }
+
+private:
+  void update_hash_value() const override {
+    hash_combine(base::m_hash_value, base::get_id());
+  }
+};
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_TRUE_H

--- a/include/numsim_cas/predicate/predicate_visitor_typedef.h
+++ b/include/numsim_cas/predicate/predicate_visitor_typedef.h
@@ -1,0 +1,78 @@
+#ifndef PREDICATE_VISITOR_TYPEDEF_H
+#define PREDICATE_VISITOR_TYPEDEF_H
+
+#include <numsim_cas/core/visitor_base.h>
+#include <numsim_cas/predicate/predicate_node_list.h>
+#include <numsim_cas/type_list.h>
+
+#include <cstdint>
+
+namespace numsim::cas {
+
+class predicate_expression;
+
+// Forward declare every node in the predicate domain.
+#define NUMSIM_CAS_FWD_FIRST(T) class T;
+#define NUMSIM_CAS_FWD_NEXT(T) class T;
+NUMSIM_CAS_PREDICATE_NODE_LIST(NUMSIM_CAS_FWD_FIRST, NUMSIM_CAS_FWD_NEXT)
+#undef NUMSIM_CAS_FWD_FIRST
+#undef NUMSIM_CAS_FWD_NEXT
+
+// Typelist of nodes (for get_index lookup).
+#define NUMSIM_CAS_TYPELIST_FIRST(T) T
+#define NUMSIM_CAS_TYPELIST_NEXT(T) , T
+using predicate_node_types = type_list<NUMSIM_CAS_PREDICATE_NODE_LIST(
+    NUMSIM_CAS_TYPELIST_FIRST, NUMSIM_CAS_TYPELIST_NEXT)>;
+#undef NUMSIM_CAS_TYPELIST_FIRST
+#undef NUMSIM_CAS_TYPELIST_NEXT
+
+template <typename T> struct get_index<T, predicate_expression> {
+  static constexpr std::uint16_t index = index_of_v<T, predicate_node_types>;
+};
+
+// Visitor typedefs.
+#define NUMSIM_CAS_VIS_FIRST(T) T
+#define NUMSIM_CAS_VIS_NEXT(T) , T
+template <typename ReturnType>
+using predicate_visitor_return_t =
+    visitor_return<ReturnType, NUMSIM_CAS_PREDICATE_NODE_LIST(
+                                   NUMSIM_CAS_VIS_FIRST, NUMSIM_CAS_VIS_NEXT)>;
+#undef NUMSIM_CAS_VIS_FIRST
+#undef NUMSIM_CAS_VIS_NEXT
+
+using predicate_visitor_return_expr_t =
+    predicate_visitor_return_t<expression_holder<predicate_expression>>;
+
+#define NUMSIM_CAS_VIS_FIRST(T) T
+#define NUMSIM_CAS_VIS_NEXT(T) , T
+using predicate_visitor_t = visitor<NUMSIM_CAS_PREDICATE_NODE_LIST(
+    NUMSIM_CAS_VIS_FIRST, NUMSIM_CAS_VIS_NEXT)>;
+using predicate_visitor_const_t = visitor_const<NUMSIM_CAS_PREDICATE_NODE_LIST(
+    NUMSIM_CAS_VIS_FIRST, NUMSIM_CAS_VIS_NEXT)>;
+#undef NUMSIM_CAS_VIS_FIRST
+#undef NUMSIM_CAS_VIS_NEXT
+
+// Visitable base typedef.
+#define NUMSIM_CAS_VT_FIRST(T) T
+#define NUMSIM_CAS_VT_NEXT(T) , T
+using predicate_visitable_t =
+    visitable<predicate_expression,
+              NUMSIM_CAS_PREDICATE_NODE_LIST(NUMSIM_CAS_VT_FIRST,
+                                             NUMSIM_CAS_VT_NEXT)>;
+#undef NUMSIM_CAS_VT_FIRST
+#undef NUMSIM_CAS_VT_NEXT
+
+// Node base alias for each concrete node T.
+#define NUMSIM_CAS_NB_FIRST(T) T
+#define NUMSIM_CAS_NB_NEXT(T) , T
+template <typename T>
+using predicate_node_base_t =
+    visitable_impl<predicate_expression, T,
+                   NUMSIM_CAS_PREDICATE_NODE_LIST(NUMSIM_CAS_NB_FIRST,
+                                                  NUMSIM_CAS_NB_NEXT)>;
+#undef NUMSIM_CAS_NB_FIRST
+#undef NUMSIM_CAS_NB_NEXT
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_VISITOR_TYPEDEF_H

--- a/include/numsim_cas/predicate/visitors/predicate_evaluator.h
+++ b/include/numsim_cas/predicate/visitors/predicate_evaluator.h
@@ -1,0 +1,48 @@
+#ifndef PREDICATE_EVALUATOR_H
+#define PREDICATE_EVALUATOR_H
+
+#include <numsim_cas/predicate/predicate_definitions.h>
+
+namespace numsim::cas {
+
+// Evaluator for the predicate domain. Returns a bool. Used at runtime to
+// reduce predicates to a definite truth value — e.g. inside an
+// `if_then_else` evaluator that needs to pick a branch, or in tests.
+//
+// Leaf-only for PR 1; comparison nodes added in #136 will read scalar
+// values from a companion scalar_evaluator (composition similar to how
+// tensor_to_scalar_evaluator delegates to scalar_evaluator).
+class predicate_evaluator final : public predicate_visitor_const_t {
+public:
+  predicate_evaluator() = default;
+  predicate_evaluator(predicate_evaluator const &) = delete;
+  predicate_evaluator(predicate_evaluator &&) = delete;
+  predicate_evaluator &operator=(predicate_evaluator const &) = delete;
+
+  bool apply(expression_holder<predicate_expression> const &expr) {
+    if (!expr.is_valid()) {
+      // An invalid predicate has no truth value — default to false to
+      // match the scalar evaluator's "default to zero" convention for
+      // invalid inputs.
+      return false;
+    }
+    static_cast<predicate_visitable_t const &>(expr.get())
+        .accept(static_cast<predicate_visitor_const_t &>(*this));
+    return m_result;
+  }
+
+  void operator()([[maybe_unused]] predicate_true const &) override {
+    m_result = true;
+  }
+
+  void operator()([[maybe_unused]] predicate_false const &) override {
+    m_result = false;
+  }
+
+private:
+  bool m_result = false;
+};
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_EVALUATOR_H

--- a/include/numsim_cas/predicate/visitors/predicate_latex_printer.h
+++ b/include/numsim_cas/predicate/visitors/predicate_latex_printer.h
@@ -1,0 +1,41 @@
+#ifndef PREDICATE_LATEX_PRINTER_H
+#define PREDICATE_LATEX_PRINTER_H
+
+#include <numsim_cas/predicate/predicate_definitions.h>
+
+namespace numsim::cas {
+
+// LaTeX printer for the predicate domain. Mirrors predicate_printer but
+// emits LaTeX glyphs — `\top` / `\bot` for the two literals.
+template <typename StreamType>
+class predicate_latex_printer final : public predicate_visitor_const_t {
+public:
+  explicit predicate_latex_printer(StreamType &out) : m_out(out) {}
+
+  predicate_latex_printer(predicate_latex_printer const &) = delete;
+  predicate_latex_printer(predicate_latex_printer &&) = delete;
+  predicate_latex_printer &operator=(predicate_latex_printer const &) = delete;
+
+  void apply(expression_holder<predicate_expression> const &expr) {
+    if (!expr.is_valid()) {
+      return;
+    }
+    static_cast<predicate_visitable_t const &>(expr.get())
+        .accept(static_cast<predicate_visitor_const_t &>(*this));
+  }
+
+  void operator()([[maybe_unused]] predicate_true const &) override {
+    m_out << "\\top";
+  }
+
+  void operator()([[maybe_unused]] predicate_false const &) override {
+    m_out << "\\bot";
+  }
+
+private:
+  StreamType &m_out;
+};
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_LATEX_PRINTER_H

--- a/include/numsim_cas/predicate/visitors/predicate_printer.h
+++ b/include/numsim_cas/predicate/visitors/predicate_printer.h
@@ -1,0 +1,48 @@
+#ifndef PREDICATE_PRINTER_H
+#define PREDICATE_PRINTER_H
+
+#include <numsim_cas/predicate/predicate_definitions.h>
+
+namespace numsim::cas {
+
+// Header-only printer for the predicate domain. Writes `true` / `false`
+// (and, in subsequent PRs, the compound forms `a < b`, `a && b`, `!a`, etc.)
+// to the supplied stream.
+//
+// Symmetric with the existing scalar_printer / tensor_printer structure
+// but without the precedence machinery — the only inhabitants of the
+// domain so far are the two literal leaves, which never need parens.
+// Precedence handling will be folded in alongside the comparison and
+// logical combinator nodes (#136).
+template <typename StreamType>
+class predicate_printer final : public predicate_visitor_const_t {
+public:
+  explicit predicate_printer(StreamType &out) : m_out(out) {}
+
+  predicate_printer(predicate_printer const &) = delete;
+  predicate_printer(predicate_printer &&) = delete;
+  predicate_printer &operator=(predicate_printer const &) = delete;
+
+  void apply(expression_holder<predicate_expression> const &expr) {
+    if (!expr.is_valid()) {
+      return;
+    }
+    static_cast<predicate_visitable_t const &>(expr.get())
+        .accept(static_cast<predicate_visitor_const_t &>(*this));
+  }
+
+  void operator()([[maybe_unused]] predicate_true const &) override {
+    m_out << "true";
+  }
+
+  void operator()([[maybe_unused]] predicate_false const &) override {
+    m_out << "false";
+  }
+
+private:
+  StreamType &m_out;
+};
+
+} // namespace numsim::cas
+
+#endif // PREDICATE_PRINTER_H

--- a/src/numsim_cas/predicate/predicate_globals.cpp
+++ b/src/numsim_cas/predicate/predicate_globals.cpp
@@ -1,0 +1,18 @@
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/predicate/predicate_false.h>
+#include <numsim_cas/predicate/predicate_globals.h>
+#include <numsim_cas/predicate/predicate_true.h>
+
+namespace numsim::cas {
+
+expression_holder<predicate_expression> const &get_predicate_true() noexcept {
+  static auto t = make_expression<predicate_true>();
+  return t;
+}
+
+expression_holder<predicate_expression> const &get_predicate_false() noexcept {
+  static auto f = make_expression<predicate_false>();
+  return f;
+}
+
+} // namespace numsim::cas

--- a/src/numsim_cas/predicate/predicate_io.cpp
+++ b/src/numsim_cas/predicate/predicate_io.cpp
@@ -1,0 +1,14 @@
+#include <numsim_cas/predicate/predicate_io.h>
+#include <numsim_cas/predicate/visitors/predicate_printer.h>
+#include <ostream>
+
+namespace numsim::cas {
+
+std::ostream &operator<<(std::ostream &os,
+                         expression_holder<predicate_expression> const &expr) {
+  predicate_printer<std::ostream> p(os);
+  p.apply(expr);
+  return os;
+}
+
+} // namespace numsim::cas

--- a/tests/PredicateExpressionTest.h
+++ b/tests/PredicateExpressionTest.h
@@ -1,0 +1,106 @@
+#ifndef PREDICATEEXPRESSIONTEST_H
+#define PREDICATEEXPRESSIONTEST_H
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include <numsim_cas/predicate/predicate_definitions.h>
+#include <numsim_cas/predicate/visitors/predicate_evaluator.h>
+#include <numsim_cas/predicate/visitors/predicate_latex_printer.h>
+#include <numsim_cas/predicate/visitors/predicate_printer.h>
+
+namespace numsim::cas {
+
+// ─── Construction and identity ───────────────────────────────────────
+
+TEST(PredicateExpression, TrueAndFalseAreValid) {
+  EXPECT_TRUE(get_predicate_true().is_valid());
+  EXPECT_TRUE(get_predicate_false().is_valid());
+}
+
+TEST(PredicateExpression, GlobalsReturnCachedSingletons) {
+  // Repeated calls return the same shared expression — no fresh allocation.
+  EXPECT_EQ(&get_predicate_true().get(), &get_predicate_true().get());
+  EXPECT_EQ(&get_predicate_false().get(), &get_predicate_false().get());
+}
+
+TEST(PredicateExpression, IsSameDistinguishesLiterals) {
+  EXPECT_TRUE(is_same<predicate_true>(get_predicate_true()));
+  EXPECT_FALSE(is_same<predicate_false>(get_predicate_true()));
+  EXPECT_TRUE(is_same<predicate_false>(get_predicate_false()));
+  EXPECT_FALSE(is_same<predicate_true>(get_predicate_false()));
+}
+
+TEST(PredicateExpression, TrueAndFalseHashesDiffer) {
+  // The two literals share no value; their hashes must distinguish them.
+  EXPECT_NE(get_predicate_true().get().hash_value(),
+            get_predicate_false().get().hash_value());
+}
+
+TEST(PredicateExpression, EqualityHoldsForSameLiteral) {
+  EXPECT_EQ(get_predicate_true(), get_predicate_true());
+  EXPECT_EQ(get_predicate_false(), get_predicate_false());
+  EXPECT_NE(get_predicate_true(), get_predicate_false());
+}
+
+// ─── Evaluator ───────────────────────────────────────────────────────
+
+TEST(PredicateEvaluator, TrueLiteralEvaluatesToTrue) {
+  predicate_evaluator ev;
+  EXPECT_TRUE(ev.apply(get_predicate_true()));
+}
+
+TEST(PredicateEvaluator, FalseLiteralEvaluatesToFalse) {
+  predicate_evaluator ev;
+  EXPECT_FALSE(ev.apply(get_predicate_false()));
+}
+
+TEST(PredicateEvaluator, InvalidExpressionEvaluatesToFalse) {
+  predicate_evaluator ev;
+  expression_holder<predicate_expression> null_expr;
+  EXPECT_FALSE(ev.apply(null_expr));
+}
+
+// ─── Printer ─────────────────────────────────────────────────────────
+
+TEST(PredicatePrinter, TrueLiteralPrintsAsTrue) {
+  std::stringstream ss;
+  predicate_printer<std::stringstream> p(ss);
+  p.apply(get_predicate_true());
+  EXPECT_EQ(ss.str(), "true");
+}
+
+TEST(PredicatePrinter, FalseLiteralPrintsAsFalse) {
+  std::stringstream ss;
+  predicate_printer<std::stringstream> p(ss);
+  p.apply(get_predicate_false());
+  EXPECT_EQ(ss.str(), "false");
+}
+
+TEST(PredicatePrinter, InvalidExpressionPrintsNothing) {
+  std::stringstream ss;
+  predicate_printer<std::stringstream> p(ss);
+  expression_holder<predicate_expression> null_expr;
+  p.apply(null_expr);
+  EXPECT_EQ(ss.str(), "");
+}
+
+// ─── LaTeX printer ───────────────────────────────────────────────────
+
+TEST(PredicateLatexPrinter, TrueLiteralPrintsTop) {
+  std::stringstream ss;
+  predicate_latex_printer<std::stringstream> p(ss);
+  p.apply(get_predicate_true());
+  EXPECT_EQ(ss.str(), "\\top");
+}
+
+TEST(PredicateLatexPrinter, FalseLiteralPrintsBot) {
+  std::stringstream ss;
+  predicate_latex_printer<std::stringstream> p(ss);
+  p.apply(get_predicate_false());
+  EXPECT_EQ(ss.str(), "\\bot");
+}
+
+} // namespace numsim::cas
+
+#endif // PREDICATEEXPRESSIONTEST_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,5 +1,6 @@
 #include "CoreBugFixTest.h"
 #include "LimitVisitorTest.h"
+#include "PredicateExpressionTest.h"
 #include "ScalarAssumptionTest.h"
 #include "ScalarDifferentiationTest.h"
 #include "ScalarEvaluatorTest.h"


### PR DESCRIPTION
First PR in the chain toward `if_then_else` (issue #135) under the constitutive-modeling primitives umbrella (#139). Pure foundation — no semantic-level features yet, just the domain scaffolding so subsequent PRs have something to extend.

## What's in this PR

A fourth expression domain `predicate_expression` alongside scalar / tensor / tensor_to_scalar, with the two literal leaf nodes (`predicate_true`, `predicate_false`), their visitor typedefs, and minimal printer / latex printer / evaluator coverage.

```
include/numsim_cas/predicate/
├── predicate_node_list.h           # X-macro for codegen registration
├── predicate_visitor_typedef.h     # visitor type aliases
├── predicate_expression.h          # base class
├── predicate_true.h, predicate_false.h
├── predicate_globals.h             # cached singletons
├── predicate_io.h                  # operator<<
├── predicate_definitions.h         # umbrella
└── visitors/
    ├── predicate_printer.h         # 'true' / 'false'
    ├── predicate_latex_printer.h   # \top / \bot
    └── predicate_evaluator.h       # returns bool

src/numsim_cas/predicate/
├── predicate_globals.cpp
└── predicate_io.cpp

tests/PredicateExpressionTest.h    # 13 lock-in tests
```

## Architecture choices (locked in here, documented inline)

- **Dedicated domain, not scalar-as-predicate.** Predicates have no arithmetic and aren't differentiable. Wrapping them as `scalar`s that evaluate to 0 / 1 would force every boolean op through arithmetic and lose type discipline. Mapping to `bool` / `&&` / `||` / `!` in generated C++ is cleaner with a separate domain.
- **Free-function comparison syntax** (`lt`, `gt`, `eq`, added in PR 2/#136). Avoids disrupting the hash-based `operator<` ordering used by `std::map<expression_holder, ...>` and the `n_ary_tree` simplifier. User-facing trade-off: `if_then_else(lt(f_trial, 0), elastic, plastic)` instead of `if_then_else(f_trial < 0, elastic, plastic)`. Worth it.
- **No precedence machinery in printers (yet).** Leaves never need parens. Will be folded in alongside compound forms (`and` / `or` / `not`) in PR 3.

## Phasing

| PR | Issue | Scope |
|----|-------|-------|
| **This PR (1)** | (foundation) | Domain skeleton: leaves, visitors, IO |
| 2 | #136 | Scalar comparisons (lt, gt, eq, le, ge, ne) |
| 3 | #136 | Logical combinators (and, or, not) |
| 4 | #135 | `if_then_else` ternary in scalar / tensor / t2s + differentiation |
| 5 | #137 / #138 | min/max + Macauley bracket + cross-cutting visitor audits |

## Test plan

- [x] 13 new tests in `PredicateExpressionTest.h` covering: construction, hash inequality, cached-singleton identity, evaluator on both literals + invalid input, printer / LaTeX output.
- [x] All 1508 tests pass (1495 baseline + 13 new).
- [x] Clean build with no new warnings.

Foundational; no behaviour changes outside the new domain.