### PR TITLE
Add tag_invoke(mul_fn, ...) for tensor × tensor_to_scalar (#145)

### DIFF
--- a/include/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.h
+++ b/include/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.h
@@ -1,0 +1,66 @@
+#ifndef TENSOR_WITH_TENSOR_TO_SCALAR_SIMPLIFIER_MUL_H
+#define TENSOR_WITH_TENSOR_TO_SCALAR_SIMPLIFIER_MUL_H
+
+#include <numsim_cas/tensor/operators/tensor_to_scalar/tensor_to_scalar_with_tensor_mul.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor/tensor_zero.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+
+namespace numsim::cas {
+
+class tensor_scalar_mul;
+
+namespace tensor_with_tensor_to_scalar_detail {
+namespace simplifier {
+
+// lhs := tensor_expression
+// rhs := tensor_to_scalar_expression
+//
+// Dispatches on the tensor side. The two specialised dispatches
+// (defined in the .cpp because they construct nodes that need the
+// tensor_to_scalar operators in scope) handle:
+//   * tensor_scalar_mul lhs ⇒ bubble the scalar coefficient outward.
+//   * tensor_to_scalar_with_tensor_mul lhs ⇒ collapse nested t2s muls.
+// The default returns a freshly constructed tensor_to_scalar_with_tensor_mul.
+class mul_base final : public tensor_visitor_return_expr_t {
+public:
+  using expr_holder_tensor_t = expression_holder<tensor_expression>;
+  using expr_holder_t2s_t = expression_holder<tensor_to_scalar_expression>;
+
+  mul_base(expr_holder_tensor_t lhs, expr_holder_t2s_t rhs)
+      : m_lhs(std::move(lhs)), m_rhs(std::move(rhs)) {}
+
+protected:
+#define NUMSIM_ADD_OVR_FIRST(T)                                                \
+  expr_holder_tensor_t operator()(T const &lhs) override {                     \
+    return dispatch(lhs);                                                      \
+  }
+#define NUMSIM_ADD_OVR_NEXT(T)                                                 \
+  expr_holder_tensor_t operator()(T const &lhs) override {                     \
+    return dispatch(lhs);                                                      \
+  }
+  NUMSIM_CAS_TENSOR_NODE_LIST(NUMSIM_ADD_OVR_FIRST, NUMSIM_ADD_OVR_NEXT)
+#undef NUMSIM_ADD_OVR_FIRST
+#undef NUMSIM_ADD_OVR_NEXT
+
+  // tensor_zero × t2s = tensor_zero. m_lhs is already the tensor_zero.
+  expr_holder_tensor_t dispatch(tensor_zero const &) noexcept { return m_lhs; }
+
+  expr_holder_tensor_t
+  dispatch(tensor_to_scalar_with_tensor_mul const &lhs) noexcept;
+  expr_holder_tensor_t dispatch(tensor_scalar_mul const &lhs) noexcept;
+
+  template <typename Expr>
+  expr_holder_tensor_t dispatch(Expr const &) noexcept {
+    return make_expression<tensor_to_scalar_with_tensor_mul>(m_lhs, m_rhs);
+  }
+
+  expr_holder_tensor_t m_lhs;
+  expr_holder_t2s_t m_rhs;
+};
+
+} // namespace simplifier
+} // namespace tensor_with_tensor_to_scalar_detail
+} // namespace numsim::cas
+
+#endif // TENSOR_WITH_TENSOR_TO_SCALAR_SIMPLIFIER_MUL_H

--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -217,11 +217,22 @@ inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
   // Wrapper unwrap: a t2s that's a thin shell around a scalar should
   // not double-wrap — route through the existing tensor × scalar path
   // so its full simplifier (tensor_with_scalar) is reused.
+  //
+  // We don't `std::forward<R>(rhs)` here: `.expr()` returns a
+  // `const expression_holder<scalar_expression>&` and so cannot be
+  // moved from anyway. Keeping the unwrap parameter as an lvalue ref
+  // documents this — moving would gain nothing.
   if (is_same<tensor_to_scalar_scalar_wrapper>(rhs)) {
     return std::forward<L>(lhs) *
            rhs.template get<tensor_to_scalar_scalar_wrapper>().expr();
   }
 
+  // `_lhs` references the object owned by `lhs`'s shared_ptr; we then
+  // forward `lhs` into the visitor's constructor, which moves the
+  // shared_ptr ownership. The referenced object remains alive at the
+  // same address (the shared_ptr is moved, not the pointee), so
+  // dereferencing `_lhs` after the forward is safe. This is the same
+  // pattern used by the `(tensor, scalar)` overload above.
   auto &_lhs{lhs.template get<tensor_visitable_t>()};
   tensor_with_tensor_to_scalar_detail::simplifier::mul_base visitor(
       std::forward<L>(lhs), std::forward<R>(rhs));

--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -12,7 +12,11 @@
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_mul.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_sub.h>
 #include <numsim_cas/tensor/simplifier/tensor_with_scalar_simplifier_mul.h>
+#include <numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.h>
 #include <numsim_cas/tensor/tensor_zero.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_one.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_zero.h>
 
 namespace numsim::cas::detail {
 
@@ -187,6 +191,51 @@ inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
   tensor_with_scalar_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                                           std::forward<R>(rhs));
   return _rhs.accept(visitor);
+}
+
+// tensor × tensor_to_scalar — produces a tensor result via the
+// `tensor_to_scalar_with_tensor_mul` node. Mirrors the depth of the
+// tensor × scalar path: zero/one/wrapper short-circuits inline, with
+// the no-fold case dispatching to the dedicated simplifier visitor
+// for nested-mul collapse and scalar-coefficient bubbling.
+//
+// (See issue #145 for the user-facing gap this closes — diff already
+// produces this node internally; user arithmetic now matches.)
+template <class L, class R>
+requires std::same_as<std::remove_cvref_t<L>,
+                      expression_holder<tensor_expression>> &&
+         std::same_as<std::remove_cvref_t<R>,
+                      expression_holder<tensor_to_scalar_expression>>
+inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
+                                                       R &&rhs) {
+  if (is_same<tensor_zero>(lhs) || is_same<tensor_to_scalar_zero>(rhs)) {
+    return make_expression<tensor_zero>(lhs.get().dim(), lhs.get().rank());
+  }
+  if (is_same<tensor_to_scalar_one>(rhs)) {
+    return std::forward<L>(lhs);
+  }
+  // Wrapper unwrap: a t2s that's a thin shell around a scalar should
+  // not double-wrap — route through the existing tensor × scalar path
+  // so its full simplifier (tensor_with_scalar) is reused.
+  if (is_same<tensor_to_scalar_scalar_wrapper>(rhs)) {
+    return std::forward<L>(lhs) *
+           rhs.template get<tensor_to_scalar_scalar_wrapper>().expr();
+  }
+
+  auto &_lhs{lhs.template get<tensor_visitable_t>()};
+  tensor_with_tensor_to_scalar_detail::simplifier::mul_base visitor(
+      std::forward<L>(lhs), std::forward<R>(rhs));
+  return _lhs.accept(visitor);
+}
+
+template <class L, class R>
+requires std::same_as<std::remove_cvref_t<L>,
+                      expression_holder<tensor_to_scalar_expression>> &&
+         std::same_as<std::remove_cvref_t<R>,
+                      expression_holder<tensor_expression>>
+inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
+                                                       R &&rhs) {
+  return std::forward<R>(rhs) * std::forward<L>(lhs);
 }
 
 template <class L, class R>

--- a/src/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.cpp
@@ -1,0 +1,34 @@
+#include <numsim_cas/core/operators.h>
+#include <numsim_cas/tensor/operators/scalar/tensor_scalar_mul.h>
+#include <numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
+
+namespace numsim::cas {
+namespace tensor_with_tensor_to_scalar_detail {
+namespace simplifier {
+
+// (T × f) × g  →  T × (f × g)
+// Collapse nested tensor_to_scalar_with_tensor_mul on the lhs by
+// pushing the inner-lhs tensor outward and folding the two t2s
+// factors via the existing t2s × t2s mul (which has its own
+// simplifier).
+mul_base::expr_holder_tensor_t
+mul_base::dispatch(tensor_to_scalar_with_tensor_mul const &lhs) noexcept {
+  return lhs.expr_lhs() * (lhs.expr_rhs() * m_rhs);
+}
+
+// (s × T) × g  →  s × (T × g)
+// Bubble the scalar coefficient outward. The inner T × g re-enters
+// this simplifier (terminates at the default since T is no longer a
+// tensor_scalar_mul nor a t2s-with-tensor-mul under the canonicalised
+// build path). The outer s × (...) routes through the existing
+// tensor × scalar operator.
+mul_base::expr_holder_tensor_t
+mul_base::dispatch(tensor_scalar_mul const &lhs) noexcept {
+  return lhs.expr_lhs() * (lhs.expr_rhs() * m_rhs);
+}
+
+} // namespace simplifier
+} // namespace tensor_with_tensor_to_scalar_detail
+} // namespace numsim::cas

--- a/src/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.cpp
@@ -24,6 +24,14 @@ mul_base::dispatch(tensor_to_scalar_with_tensor_mul const &lhs) noexcept {
 // tensor_scalar_mul nor a t2s-with-tensor-mul under the canonicalised
 // build path). The outer s × (...) routes through the existing
 // tensor × scalar operator.
+//
+// `tensor_scalar_mul` operand convention: `expr_lhs()` is the
+// *scalar* coefficient and `expr_rhs()` is the *tensor* body. (Yes
+// it's lhs=scalar even though the node is named "tensor_scalar_mul";
+// match the convention used by tensor_with_scalar_simplifier_mul.cpp,
+// which also computes `rhs.expr_lhs() * scalar` to merge
+// coefficients.) Misreading this swap would silently corrupt the
+// product — read either site to confirm before changing.
 mul_base::expr_holder_tensor_t
 mul_base::dispatch(tensor_scalar_mul const &lhs) noexcept {
   return lhs.expr_lhs() * (lhs.expr_rhs() * m_rhs);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_numsim_cas_test(numsim_cas_test
     TensorSpacePropagationTest.h
     TensorSubstitutionTest.h
     TensorToScalarDifferentiationTest.h
+    TensorToScalarMulOperatorTest.h
     TensorToScalarEvaluatorTest.h
     TensorToScalarExpressionTest.h
     TensorToScalarSubstitutionTest.h

--- a/tests/TensorToScalarMulOperatorTest.h
+++ b/tests/TensorToScalarMulOperatorTest.h
@@ -47,8 +47,13 @@ protected:
 TYPED_TEST_SUITE(TensorToScalarMulOperatorTest, TestDims);
 
 // --- 1. Compile-smoke + node identity.
+//
+// (Test 2 below locks in actual structural equality of the two
+// directions; this test only verifies each operand order produces the
+// correct node *type* — both must be t2s_with_tensor_mul, not the
+// dedicated div node or something else.)
 
-TYPED_TEST(TensorToScalarMulOperatorTest, BothDirectionsConstructTheSameNode) {
+TYPED_TEST(TensorToScalarMulOperatorTest, BothDirectionsProduceMulNode) {
   auto &X = this->X;
   auto trX = trace(X);
 
@@ -110,6 +115,12 @@ TYPED_TEST(TensorToScalarMulOperatorTest, WrapperUnwrapsToScalarPath) {
 }
 
 // --- 6. Nested-mul collapse: (T × f) × g → T × (f*g).
+//
+// Beyond just confirming the structural flattening, we explicitly
+// verify *both* t2s factors survive on the result's t2s side via
+// contains_expression. Without that check, a buggy collapse that
+// silently dropped one factor (e.g. `(T × f) × g → T × g`) would
+// pass the structural shape assertion.
 
 TYPED_TEST(TensorToScalarMulOperatorTest, NestedT2sMulCollapses) {
   auto &X = this->X;
@@ -131,6 +142,11 @@ TYPED_TEST(TensorToScalarMulOperatorTest, NestedT2sMulCollapses) {
   // tensor_to_scalar_with_tensor_mul.
   EXPECT_FALSE(is_same<tensor_to_scalar_with_tensor_mul>(as_node.expr_lhs()));
   EXPECT_EQ(as_node.expr_lhs(), X);
+  // Both t2s factors survive on the t2s side: the collapsed t2s
+  // operand is *exactly* the canonical t2s product of trX and dX.
+  // n_ary commutativity guarantees `trX * dX == dX * trX`, so the
+  // order in which we wrote them at the call sites doesn't matter.
+  EXPECT_EQ(as_node.expr_rhs(), trX * dX);
 }
 
 // --- 7. Scalar coefficient bubbles outward: (s × T) × g → s × (T × g).

--- a/tests/TensorToScalarMulOperatorTest.h
+++ b/tests/TensorToScalarMulOperatorTest.h
@@ -1,0 +1,201 @@
+#ifndef TENSORTOSCALARMULOPERATORTEST_H
+#define TENSORTOSCALARMULOPERATORTEST_H
+
+// Lock-in tests for the `tag_invoke(mul_fn, …)` overloads on
+// `(tensor_expression, tensor_to_scalar_expression)` and its
+// symmetric pair — i.e. user-level `trace(A) * A` style products
+// (#145). The AST node already existed (constructed internally by
+// differentiation); this PR exposes the operator to user code with
+// matching simplifier depth.
+
+#include "cas_test_helpers.h"
+#include "numsim_cas/numsim_cas.h"
+#include "gtest/gtest.h"
+
+#include <numsim_cas/tensor/visitors/tensor_evaluator.h>
+
+namespace numsim::cas {
+
+namespace {
+
+using TestDims = ::testing::Types<std::integral_constant<std::size_t, 1>,
+                                  std::integral_constant<std::size_t, 2>,
+                                  std::integral_constant<std::size_t, 3>>;
+
+} // namespace
+
+template <typename DimTag>
+class TensorToScalarMulOperatorTest : public ::testing::Test {
+protected:
+  static constexpr std::size_t Dim = DimTag::value;
+
+  using tensor_t = expression_holder<tensor_expression>;
+  using t2s_t = expression_holder<tensor_to_scalar_expression>;
+  using scalar_t = expression_holder<scalar_expression>;
+
+  TensorToScalarMulOperatorTest() {
+    std::tie(X, Y, Z) =
+        make_tensor_variable(std::tuple{"X", Dim, 2}, std::tuple{"Y", Dim, 2},
+                             std::tuple{"Z", Dim, 2});
+    std::tie(x, y) = make_scalar_variable("x", "y");
+  }
+
+  tensor_t X, Y, Z;
+  scalar_t x, y;
+};
+
+TYPED_TEST_SUITE(TensorToScalarMulOperatorTest, TestDims);
+
+// --- 1. Compile-smoke + node identity.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, BothDirectionsConstructTheSameNode) {
+  auto &X = this->X;
+  auto trX = trace(X);
+
+  auto fwd = trX * X; // t2s × tensor
+  auto bwd = X * trX; // tensor × t2s
+
+  EXPECT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(fwd));
+  EXPECT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(bwd));
+}
+
+// --- 2. Symmetry: operand order at the call site doesn't matter.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, SymmetryAcrossArgumentOrder) {
+  auto &X = this->X;
+  auto trX = trace(X);
+  EXPECT_EQ(trX * X, X * trX);
+  EXPECT_SAME_PRINT(trX * X, X * trX);
+}
+
+// --- 3. Zero folds — both sides.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, TensorZeroFold) {
+  constexpr std::size_t Dim = TestFixture::Dim;
+  auto &X = this->X;
+  auto trX = trace(X);
+  auto Z = make_expression<tensor_zero>(Dim, 2);
+  EXPECT_TRUE(is_same<tensor_zero>(Z * trX));
+  EXPECT_TRUE(is_same<tensor_zero>(trX * Z));
+}
+
+TYPED_TEST(TensorToScalarMulOperatorTest, T2sZeroFold) {
+  auto &X = this->X;
+  auto t2s_zero = make_expression<tensor_to_scalar_zero>();
+  EXPECT_TRUE(is_same<tensor_zero>(X * t2s_zero));
+  EXPECT_TRUE(is_same<tensor_zero>(t2s_zero * X));
+}
+
+// --- 4. One fold.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, T2sOneFoldReturnsTensor) {
+  auto &X = this->X;
+  auto t2s_one = make_expression<tensor_to_scalar_one>();
+  EXPECT_EQ(X * t2s_one, X);
+  EXPECT_EQ(t2s_one * X, X);
+}
+
+// --- 5. Wrapper unwrap routes through tensor × scalar.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, WrapperUnwrapsToScalarPath) {
+  auto &X = this->X;
+  auto two = make_scalar_constant(2);
+  auto wrapped = make_expression<tensor_to_scalar_scalar_wrapper>(two);
+
+  auto result = wrapped * X;
+  // The wrapper should be unwrapped; result is a tensor_scalar_mul,
+  // not a tensor_to_scalar_with_tensor_mul.
+  EXPECT_TRUE(is_same<tensor_scalar_mul>(result));
+  EXPECT_FALSE(is_same<tensor_to_scalar_with_tensor_mul>(result));
+}
+
+// --- 6. Nested-mul collapse: (T × f) × g → T × (f*g).
+
+TYPED_TEST(TensorToScalarMulOperatorTest, NestedT2sMulCollapses) {
+  auto &X = this->X;
+  auto trX = trace(X);
+  auto dX = det(X);
+
+  // Build (X × trX) first — a tensor_to_scalar_with_tensor_mul.
+  auto inner = X * trX;
+  ASSERT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(inner));
+
+  // Multiplying by another t2s should bubble the t2s factor into the
+  // existing node's rhs (a t2s × t2s product) rather than nest a
+  // second t2s_with_tensor_mul node.
+  auto outer = inner * dX;
+  ASSERT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(outer));
+
+  auto const &as_node = outer.template get<tensor_to_scalar_with_tensor_mul>();
+  // The inner tensor side should now be the bare X, not a nested
+  // tensor_to_scalar_with_tensor_mul.
+  EXPECT_FALSE(is_same<tensor_to_scalar_with_tensor_mul>(as_node.expr_lhs()));
+  EXPECT_EQ(as_node.expr_lhs(), X);
+}
+
+// --- 7. Scalar coefficient bubbles outward: (s × T) × g → s × (T × g).
+
+TYPED_TEST(TensorToScalarMulOperatorTest, ScalarCoefficientBubblesOutward) {
+  auto &X = this->X;
+  auto &x = this->x;
+  auto trX = trace(X);
+
+  // Build s × X first — a tensor_scalar_mul.
+  auto scaled = x * X;
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(scaled));
+
+  // (s × X) × trX should bubble the scalar outward → s × (X × trX),
+  // i.e. the outer node is a tensor_scalar_mul (not the new node).
+  auto outer = scaled * trX;
+  EXPECT_TRUE(is_same<tensor_scalar_mul>(outer));
+}
+
+// --- 8. Evaluator round-trip.
+
+TEST(TensorToScalarMulOperatorEval, EvaluatorMatchesTmech) {
+  constexpr double tol = 1e-12;
+  auto A = make_expression<tensor>("A", 2, 2);
+
+  tensor_evaluator<double> ev;
+  auto data = std::make_shared<tensor_data<double, 2, 2>>();
+  // clang-format off
+  auto *raw = data->raw_data();
+  raw[0] = 1.0; raw[1] = 2.0;
+  raw[2] = 3.0; raw[3] = 4.0;
+  // clang-format on
+  ev.set(A, data);
+
+  // trace(A) * A symbolically; numerically expect (1+4) * [[1,2],[3,4]].
+  auto expr = trace(A) * A;
+  auto result = ev.apply(expr);
+  ASSERT_NE(result, nullptr);
+
+  tmech::tensor<double, 2, 2> expected;
+  auto *e = expected.raw_data();
+  e[0] = 5.0;
+  e[1] = 10.0;
+  e[2] = 15.0;
+  e[3] = 20.0;
+
+  auto const &got =
+      static_cast<tensor_data<double, 2, 2> const &>(*result).data();
+  EXPECT_TRUE(tmech::almost_equal(got, expected, tol));
+}
+
+// --- 9. Diff round-trip — user-level `trace(A) * A` differentiates the
+//        same way the internal-only construction always did.
+
+TEST(TensorToScalarMulOperatorDiff, DiffMatchesProductRule) {
+  auto A = make_expression<tensor>("A", 3, 2);
+  // d/dA (trace(A) * A) is well-defined; we just need it not to
+  // crash and to produce a non-trivial expression. The product rule
+  // gives: trace(A) * dA/dA + A ⊗ (d trace(A)/dA) = trace(A)*I4 + A⊗I2.
+  auto expr = trace(A) * A;
+  auto d_expr = diff(expr, A);
+  ASSERT_TRUE(d_expr.is_valid());
+  EXPECT_FALSE(is_same<tensor_zero>(d_expr));
+}
+
+} // namespace numsim::cas
+
+#endif // TENSORTOSCALARMULOPERATORTEST_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -19,6 +19,7 @@
 #include "TensorToScalarEvaluatorTest.h"
 #include "TensorToScalarExpressionTest.h"
 #include "TensorToScalarLatexPrinterTest.h"
+#include "TensorToScalarMulOperatorTest.h"
 #include "TensorToScalarPrinterTest.h"
 #include "TensorToScalarSubstitutionTest.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
Closes #145.

## Summary

Two new `tag_invoke(mul_fn, …)` overloads in `tensor_operators.h` — `(tensor, t2s)` and `(t2s, tensor)` — make user-level arithmetic like `trace(A) * A` compile. The AST node `tensor_to_scalar_with_tensor_mul` already existed and had full visitor coverage; only the operator was missing. Five internal call sites in differentiation already constructed it, so this PR closes the hole.

## Construction-time simplifications

Inline (in the operator):
- `tensor_zero × t2s` → `tensor_zero`
- `tensor × tensor_to_scalar_zero` → `tensor_zero`
- `tensor × tensor_to_scalar_one` → `tensor`
- `tensor × tensor_to_scalar_scalar_wrapper(s)` → unwrap, route through existing `tensor × scalar` path

Visitor (`tensor_with_tensor_to_scalar_detail::simplifier::mul_base`):
- `(T × f) × g` → `T × (f*g)` — nested t2s-mul collapse
- `(s × T) × g` → `s × (T × g)` — scalar coefficient bubbling outward

Default path constructs the bare node.

## Test plan

- [x] 10 lock-in tests in `tests/TensorToScalarMulOperatorTest.h`:
  1. Both directions construct the same node type
  2. Symmetry (operand order at call site doesn't matter)
  3. `tensor_zero` fold both directions
  4. `tensor_to_scalar_zero` fold both directions
  5. `tensor_to_scalar_one` fold both directions
  6. Wrapper unwraps to `tensor_scalar_mul`
  7. Nested t2s-mul collapse
  8. Scalar coefficient bubbles outward
  9. Evaluator round-trip vs tmech
  10. Differentiation round-trip produces non-trivial result
- [x] 1530 → 1556 ctest cases, all passing (typed tests × 3 dims + standalone)
- [x] Smoke compile of user-facing `trace(A) * A` from a fresh TU
- [x] Clean build under `-Wall -Wextra -Wpedantic -Werror`

## Out of scope

- `tag_invoke(div_fn, ...)` for the same pairing — `tensor_to_scalar_with_tensor_div` node has the same gap, but routing through `pow(t2s, -1)` vs direct div-node construction is its own design call. Worth a separate issue if anyone hits the gap.