### PR TITLE
Lock in zero-precedence + document t2s pow contract (#154)

### DIFF
--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -16,6 +16,16 @@ to_string(const expression_holder<tensor_to_scalar_expression> &expr) {
   return ss.str();
 }
 
+// CONTRACT NOTE: `pow(x, -1)` is deliberately NOT short-circuited to a
+// dedicated reciprocal node. The tensor ÷ tensor_to_scalar operator
+// (tensor_operators.h, see #147) implements division as
+// `lhs × pow(rhs, -1)` and relies on the result being a regular
+// `tensor_to_scalar_pow` node so the existing pow-of-pow flatten
+// (`pow(pow(x, m), n) → pow(x, m*n)`) handles further composition. If
+// you add a `pow(x, -1) → reciprocal_node` rule here, also update the
+// div operator to construct that node directly, and update the lock-in
+// tests in `tests/TensorToScalarDivOperatorTest.h::ResultShapeIsMulPow`
+// and `DivByPowFlattensExponent`.
 template <tensor_to_scalar_expr_holder ExprLHS,
           tensor_to_scalar_expr_holder ExprRHS>
 [[nodiscard]] auto pow(ExprLHS &&expr_lhs, ExprRHS &&expr_rhs) {

--- a/tests/TensorToScalarDivOperatorTest.h
+++ b/tests/TensorToScalarDivOperatorTest.h
@@ -95,6 +95,21 @@ TYPED_TEST(TensorToScalarDivOperatorTest, TensorZeroFold) {
   EXPECT_TRUE(is_same<tensor_zero>(Z / det(X)));
 }
 
+// --- 3b. Zero-precedence: tensor_zero / t2s_zero.
+//
+// `0/0` is IEEE-undefined, but this CAS resolves it the same way the
+// scalar domain does: the lhs-zero check fires first, returning
+// tensor_zero. Documented behaviour, but unverified by test before
+// #154 — pinned here so any reordering of the zero-fold checks in the
+// div operator surfaces immediately.
+
+TYPED_TEST(TensorToScalarDivOperatorTest, ZeroPrecedence_ZeroOverZero) {
+  constexpr std::size_t Dim = TestFixture::Dim;
+  auto Z = make_expression<tensor_zero>(Dim, 2);
+  auto t2s_zero = make_expression<tensor_to_scalar_zero>();
+  EXPECT_TRUE(is_same<tensor_zero>(Z / t2s_zero));
+}
+
 // --- 4. One fold: tensor / tensor_to_scalar_one → tensor.
 
 TYPED_TEST(TensorToScalarDivOperatorTest, T2sOneFoldReturnsTensor) {

--- a/tests/TensorToScalarMulOperatorTest.h
+++ b/tests/TensorToScalarMulOperatorTest.h
@@ -91,6 +91,22 @@ TYPED_TEST(TensorToScalarMulOperatorTest, T2sZeroFold) {
   EXPECT_TRUE(is_same<tensor_zero>(t2s_zero * X));
 }
 
+// --- 3c. Zero-precedence when *both* sides could trigger the fold.
+//
+// The operator chains `is_same<tensor_zero>(lhs) || is_same<t2s_zero>(rhs)`
+// — so when both sides are zero, the lhs check fires first and the
+// result is a fresh `tensor_zero` stamped with lhs's dim/rank.
+// Without this test the precedence is only asserted by inference,
+// not by code. See #154.
+
+TYPED_TEST(TensorToScalarMulOperatorTest, ZeroPrecedence_BothSidesZero) {
+  constexpr std::size_t Dim = TestFixture::Dim;
+  auto Z = make_expression<tensor_zero>(Dim, 2);
+  auto t2s_zero = make_expression<tensor_to_scalar_zero>();
+  EXPECT_TRUE(is_same<tensor_zero>(Z * t2s_zero));
+  EXPECT_TRUE(is_same<tensor_zero>(t2s_zero * Z));
+}
+
 // --- 4. One fold.
 
 TYPED_TEST(TensorToScalarMulOperatorTest, T2sOneFoldReturnsTensor) {


### PR DESCRIPTION
Closes #154. **Stacked on #150** — review/merge order: #146 → #148 → #150 → this.

## Summary

Two tests + one doc comment, closing the two gaps from #154:

### Gap A: ambiguous zero-precedence

The mul operator chains \`is_same<tensor_zero>(lhs) || is_same<t2s_zero>(rhs)\`. When both sides could trigger, the lhs check fires first and returns a fresh \`tensor_zero\` stamped with lhs's dim/rank. The div operator behaves the same way for \`0/0\` — matching the scalar domain's IEEE-undefined-but-consistent convention. Both behaviours were asserted only by inference before this PR.

New tests:
- \`ZeroPrecedence_BothSidesZero\` (mul, both orderings): \`tensor_zero × t2s_zero\` and \`t2s_zero × tensor_zero\` → \`tensor_zero\`.
- \`ZeroPrecedence_ZeroOverZero\` (div): \`tensor_zero ÷ t2s_zero\` → \`tensor_zero\`.

### Gap B: pow contract documentation

\`DivByPowFlattensExponent\` and \`ResultShapeIsMulPow\` (both in \`TensorToScalarDivOperatorTest.h\`) implicitly verify that \`pow(x, -1)\` is NOT short-circuited by the t2s pow simplifier. The div operator at \`tensor_operators.h\` (#147) relies on this shape for the pow-of-pow flatten to handle further composition.

A \`CONTRACT NOTE\` comment in \`tensor_to_scalar_std.h\` documents this dependency and lists the specific lock-in tests that need updating if anyone later adds a \`pow(x, -1) → reciprocal\` rule.

## Test plan

- [x] 6 new typed tests (3 dims × 2 ambiguous-zero cases). 1576 → 1582 ctest cases.
- [x] Fuzz suite still 791/791.
- [x] Clean build under \`-Werror\`.