### PR TITLE
Tighten mul-side test contracts (#152, #153)

### DIFF
--- a/tests/TensorToScalarMulOperatorTest.h
+++ b/tests/TensorToScalarMulOperatorTest.h
@@ -165,6 +165,39 @@ TYPED_TEST(TensorToScalarMulOperatorTest, NestedT2sMulCollapses) {
   EXPECT_EQ(as_node.expr_rhs(), trX * dX);
 }
 
+// --- 6b. Deep nesting: 4-level collapse via recursive dispatch (#153).
+//
+// The visitor's `dispatch(tensor_to_scalar_with_tensor_mul const &lhs)`
+// recurses by re-entering the operator on the inner side. Each level
+// peels off one t2s factor and merges it into the accumulating
+// product. We exercise depth 4 to verify the recursion terminates
+// correctly and the canonical form is a *single* t2s_with_tensor_mul
+// with all four t2s factors in the rhs:
+//
+//   ((((X × trX) × dX) × normX) × dotX)
+//          ↓
+//     X × (trX × dX × normX × dotX)
+
+TYPED_TEST(TensorToScalarMulOperatorTest, DeepNesting_FourFactorsCollapse) {
+  auto &X = this->X;
+  auto trX = trace(X);
+  auto dX = det(X);
+  auto normX = norm(X);
+  auto dotX = dot(X);
+
+  auto outer = (((X * trX) * dX) * normX) * dotX;
+
+  // Single t2s_with_tensor_mul at the top — no nesting survived.
+  ASSERT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(outer));
+  auto const &as_node = outer.template get<tensor_to_scalar_with_tensor_mul>();
+  EXPECT_EQ(as_node.expr_lhs(), X);
+  EXPECT_FALSE(is_same<tensor_to_scalar_with_tensor_mul>(as_node.expr_lhs()));
+
+  // All four t2s factors landed on the rhs as a single canonical
+  // n_ary product. Hash-based equality is order-independent.
+  EXPECT_EQ(as_node.expr_rhs(), trX * dX * normX * dotX);
+}
+
 // --- 7. Scalar coefficient bubbles outward: (s × T) × g → s × (T × g).
 
 TYPED_TEST(TensorToScalarMulOperatorTest, ScalarCoefficientBubblesOutward) {
@@ -179,7 +212,21 @@ TYPED_TEST(TensorToScalarMulOperatorTest, ScalarCoefficientBubblesOutward) {
   // (s × X) × trX should bubble the scalar outward → s × (X × trX),
   // i.e. the outer node is a tensor_scalar_mul (not the new node).
   auto outer = scaled * trX;
-  EXPECT_TRUE(is_same<tensor_scalar_mul>(outer));
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(outer));
+
+  // Pin the *inner* structure too (closes #152). Without this a buggy
+  // bubble-outward that dropped `trX` (producing `s × X` again) or
+  // dropped `X` (producing `s × trX`) would still pass the outer
+  // type check. We assert the full shape:
+  //   * outer.lhs is the scalar `x`
+  //   * outer.rhs is `tensor_to_scalar_with_tensor_mul(X, trX)`.
+  auto const &outer_node = outer.template get<tensor_scalar_mul>();
+  EXPECT_EQ(outer_node.expr_lhs(), x);
+  ASSERT_TRUE(is_same<tensor_to_scalar_with_tensor_mul>(outer_node.expr_rhs()));
+  auto const &inner =
+      outer_node.expr_rhs().template get<tensor_to_scalar_with_tensor_mul>();
+  EXPECT_EQ(inner.expr_lhs(), X);
+  EXPECT_EQ(inner.expr_rhs(), trX);
 }
 
 // --- 8. Evaluator round-trip.


### PR DESCRIPTION
Closes #152 and #153. **Stacked on #155** — review/merge order: #146 → #148 → #150 → #155 → this.

## Summary

Two test tightenings on PR #146's mul side.

### Closes #152 — `ScalarCoefficientBubblesOutward` inner shape

Previously asserted only \`is_same<tensor_scalar_mul>(outer)\`. A buggy bubble-outward that dropped \`trX\` or \`X\` would still have passed.

New assertions pin the full collapsed shape:
- Outer node's scalar coefficient is \`x\`.
- Outer node's tensor side is a \`tensor_to_scalar_with_tensor_mul\`.
- Inner node's tensor side is \`X\`.
- Inner node's t2s side is \`trX\`.

### Closes #153 — deep-nesting recursion test

The visitor's \`dispatch(tensor_to_scalar_with_tensor_mul const &)\` recurses on the inner side, peeling off one t2s factor per level. The existing \`NestedT2sMulCollapses\` only goes 2 levels.

New \`DeepNesting_FourFactorsCollapse\` constructs \`((((X × trX) × dX) × normX) × dotX)\` and verifies:
- Result is a *single* \`tensor_to_scalar_with_tensor_mul\` (no nesting survives).
- Tensor side is bare \`X\`.
- T2s side equals the canonical n_ary product of all four t2s factors (hash-based equality is order-independent).

## Test plan

- [x] 3 new typed tests (DeepNesting × 3 dims) + 4 strengthened assertions inside ScalarCoefficientBubblesOutward.
- [x] 1582 → 1585 ctest cases, all green.
- [x] Fuzz suite still 791/791.
- [x] Clean build under \`-Werror\`.