### PR TITLE
Cross-reference the pow-contract note in the div operator

### DIFF
--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -272,6 +272,12 @@ inline expression_holder<tensor_expression> tag_invoke(div_fn, L &&lhs,
 // same pattern used by the t2s ÷ t2s, t2s ÷ scalar, and scalar ÷ t2s
 // overloads in tensor_to_scalar_operators.h. The result reuses the
 // tensor × t2s mul path (#145) plus the t2s pow simplifier.
+//
+// CONTRACT: this overload depends on `pow(t2s, -1)` producing a regular
+// `tensor_to_scalar_pow` node (not a dedicated reciprocal). See the
+// matching CONTRACT NOTE above the t2s `pow(t2s, t2s)` overload in
+// `tensor_to_scalar_std.h` — if you change the inverse representation
+// here, also update that note and the lock-in tests it references.
 template <class L, class R>
 requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<tensor_expression>> &&


### PR DESCRIPTION
Comment-only patch. **Stacked on #156** — merge last in the chain.

## Summary

PR #155 added a CONTRACT NOTE on the t2s \`pow(t2s, t2s)\` free function explaining that \`pow(x, -1)\` is deliberately not short-circuited. The contract is two-sided — the pow function must keep its shape, *and* the div operator must keep relying on it — but only the pow side was documented.

This adds a cross-reference comment at the div operator (\`tensor_operators.h\`) pointing back to the pow note. Now anyone editing either side of the contract finds the other.

## Why a separate PR

Single-line comment change, no rebase cascade needed. Stacked at the tip rather than amended into #155 to keep the existing review history intact.

## Verification

- [x] Comment-only — no behavioural change.
- [x] Clean build under \`-Werror\`.
- [x] 1585 ctest cases, all green.