### PR TITLE
Phase 2 docs: CHANGELOG, CONTRIBUTING, COMMERCIAL.md (#161, #162, #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to NumSim-CAS will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and from v0.1.0 onward the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `tag_invoke(mul_fn, …)` for `tensor × tensor_to_scalar` (and the symmetric pair) with full visitor coverage and a dedicated simplifier handling nested-mul collapse and scalar-coefficient bubbling. Closes #145.
+- `tag_invoke(div_fn, tensor, t2s)` routing through `lhs × pow(rhs, -1)` for `tensor ÷ tensor_to_scalar`. Closes #147.
+- Scalar comparison nodes (`lt`, `gt`, `le`, `ge`, `eq`, `ne`) producing Real-valued indicators (1.0 / 0.0) for the damage-activation idiom and the upcoming `if_then_else`. Closes #136.
+- `numeric_less(scalar_number, scalar_number)` with `__int128`-based safe cross-multiplication for rational comparisons (long-double fallback on MSVC). Closes #142.
+- CONTRACT NOTE comments documenting the bilateral dependency between the t2s pow simplifier and the tensor ÷ t2s div operator (cross-referenced at both sites).
+- Lock-in tests for: cross-rank constant folding, commutative multiplication identity, deep-nesting collapse, zero-precedence in mul / div, pow-of-pow flattening, NaN / complex edge cases.
+
+### Changed
+
+- Visitor type lists consolidated to a single `tensor_visitor_typedef.h` driven by the `NUMSIM_CAS_TENSOR_NODE_LIST` macro.
+
+### Removed
+
+- Dead `tensor_to_scalar_with_tensor_div` AST node (declared but never integrated with the visitor pattern). Closes #149.
+- Dead `tensor_type_defs.h` file (parallel-and-divergent visitor list).
+- Commented-out `tensor_to_scalar_with_tensor_div` printer override.
+
+### Fixed
+
+- Rational comparison overflow in `numeric_less` / `operator<` for numerators near 2^63. Closes #142.
+
+### Documentation
+
+- Documented (with lock-in tests) the deliberate non-IEEE behaviour of NaN under structural-identity comparison folding. Closes #143.
+- Documented (with lock-in tests) the real-then-imag total order used for complex numbers in `numeric_less`. Closes #144.
+- Audited visitor overload coverage in `scalar_differentiation`, `scalar_evaluator`, `tensor_differentiation`, `tensor_evaluator`, `tensor_printer`, `tensor_to_scalar_differentiation`, and `tensor_to_scalar_printer`. Closes #38, #42, #43, #44, #45, #76, #77, #39.
+
+[Unreleased]: https://github.com/NumSim-Stack/numsim-cas/compare/main...HEAD

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,46 @@
+# Commercial License
+
+NumSim-CAS is offered under a dual-license model.
+
+## Open-source use: GPL-3.0
+
+For open-source projects, academic research, and any use compatible with the GNU General Public License v3.0 (GPL-3.0-only), NumSim-CAS is available free of charge under the terms of the [LICENSE](LICENSE) file.
+
+The GPL-3.0 requires that derivative works also be licensed under GPL-3.0 and that source code be made available to recipients of the software.
+
+## Commercial / proprietary use
+
+If your use case is incompatible with the GPL-3.0 — typically because you want to embed NumSim-CAS in a proprietary product without making your source code available under GPL terms — a commercial license is available.
+
+Typical scenarios requiring a commercial license:
+
+- Embedding in a closed-source FEM solver (Abaqus UMAT/VUMAT, ANSYS USERMAT, LS-DYNA, etc.).
+- Distributing a proprietary product that links against or includes NumSim-CAS.
+- Internal use within an organisation that does not wish to make its derivative code GPL-licensed.
+
+The commercial license grants:
+
+- The right to use NumSim-CAS in proprietary products.
+- Freedom from the GPL-3.0 source-disclosure obligation for derivative works.
+- Terms negotiated case-by-case based on use case, distribution scope, and support requirements.
+
+## How to acquire
+
+Contact the maintainer to discuss terms:
+
+- **Email**: peterlenz89.pl@gmail.com
+- **GitHub Discussion**: [start a topic](https://github.com/NumSim-Stack/numsim-cas/discussions) with the `commercial-license` tag.
+
+Please include in your inquiry:
+
+1. A brief description of how you intend to use NumSim-CAS.
+2. The scope of distribution (internal-only vs distributed product, number of seats/instances, public or private deployment).
+3. Any specific support or warranty requirements.
+
+Pricing is determined per inquiry; there is no public price list.
+
+## Contributor rights
+
+All contributions to NumSim-CAS must be offered under terms compatible with both the GPL-3.0 and the commercial license. The project uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) — by adding a `Signed-off-by:` trailer to commits (via `git commit -s`), contributors certify that their work can be re-offered under both licenses.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to NumSim-CAS
+
+Thanks for considering a contribution. NumSim-CAS is a foundational library for symbolic tensor calculus — small, focused changes with strong test coverage are preferred over sweeping refactors.
+
+## Building & testing
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j$(nproc)
+ctest --test-dir build
+```
+
+See [README.md](README.md) for the full set of CMake options.
+
+## Code style
+
+- **C++23**. The repo builds with GCC 14+, Clang 18+, and MSVC.
+- **Strict warnings**. CI enforces `-Wall -Wextra -Wpedantic -Werror` (GCC/Clang) and `/WX` (MSVC). Submissions must compile cleanly.
+- **clang-format**. Run before committing — CI verifies. Project style is in `.clang-format`.
+- **clang-tidy**. Runs in CI; new violations are blocking.
+- **No comments that describe what the code does**. Comments should explain *why*, not *what*. Identifiers carry the *what*.
+
+## Branch + PR workflow
+
+- One branch per issue. Branch naming: `<issue#>-<short-description>` (e.g. `142-rational-overflow`).
+- Stack dependent PRs on each other rather than waiting for upstream merges. State the dependency explicitly in the PR description ("Stacked on #N — merge order: …").
+- Iterate locally — do a self-review pass before opening the PR so reviewers see the polished version, not a work-in-progress.
+- Force-push within your own branch is fine; force-push to shared branches (main) is not.
+
+## Test discipline
+
+- **Lock-in tests before refactoring**. Pin the current contract first, then change the implementation. A passing test suite after a refactor that started with lock-ins is a meaningful signal.
+- **Structural assertions over numeric ones**. `EXPECT_TRUE(is_same<scalar_one>(eq(x, x)))` is cheaper to diagnose than `EXPECT_NEAR(...)`. Use both when both apply.
+- **Typed tests for tensor work**. Cover dims 1, 2, 3 via `TYPED_TEST` to catch dim-dependent bugs (e.g. eye<T,D,4> identity ordering).
+- **Bilateral CONTRACT pattern**. When a behaviour depends on two files (like the t2s pow ↔ div operator pair from #147), add CONTRACT NOTE comments at both sites with cross-references and pin the shape with explicit tests.
+
+## Commit messages
+
+- Imperative mood: "Add" / "Fix" / "Remove", not "Added" / "Fixed".
+- Subject line under 72 characters.
+- Body explains *why* the change is needed when non-obvious.
+- Reference issues with `Closes #N` so GitHub auto-closes on merge.
+- **No Co-Authored-By trailers.** This is project policy.
+
+## License & contributor rights
+
+NumSim-CAS is offered under a dual-license model (see [LICENSE](LICENSE) and [COMMERCIAL.md](COMMERCIAL.md)):
+
+- GPL-3.0 for open-source use.
+- Commercial license for proprietary embedding (FEM solvers, etc.).
+
+To support this model, contributions must be offered under terms compatible with both licenses. We use the **Developer Certificate of Origin (DCO)** — a lightweight alternative to a formal CLA. By adding a `Signed-off-by:` trailer to your commit messages, you certify that you have the right to submit the work under the project's license:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+The `-s` flag adds the trailer automatically. See the [DCO text](https://developercertificate.org/) for the full certification.
+
+If you're contributing under your employer's name, ensure they're aware and have authorized the contribution under DCO terms.
+
+## Issue triage
+
+When opening an issue:
+
+- **Bug**: include a minimal reproducer, expected vs actual behaviour, environment (compiler, OS, build mode).
+- **Feature**: describe the user-facing need first, then propose the implementation if relevant. Architectural design discussions are welcome.
+- **Discussion / design question**: tag the issue clearly so reviewers know not to treat it as a bug report.
+
+## Questions
+
+Open an issue or start a GitHub Discussion. For commercial-license inquiries see [COMMERCIAL.md](COMMERCIAL.md).

--- a/README.md
+++ b/README.md
@@ -114,11 +114,17 @@ core/             ── shared infrastructure (n_ary_tree, domain_traits, visit
 
 Each domain follows the same pattern: expression base class, node types, a virtual visitor for dispatch, and construction-time simplifiers that produce canonical forms.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, code style, and DCO requirements.
+
+Changes are tracked in [CHANGELOG.md](CHANGELOG.md).
+
 ## License
 
 NumSim-CAS is available under a dual-license model:
 
-- **Open Source:** GNU General Public License v3.0 (GPL-3.0-only) — see [LICENSE](LICENSE)
-- **Commercial:** A separate commercial license is available for proprietary/closed-source use.
+- **Open Source:** GNU General Public License v3.0 (GPL-3.0-only) — see [LICENSE](LICENSE).
+- **Commercial:** A separate commercial license is available for proprietary/closed-source use — see [COMMERCIAL.md](COMMERCIAL.md).
 
 If you want to use NumSim-CAS in a closed-source product, you must obtain a commercial license.


### PR DESCRIPTION
Closes #161, #162, #163.

Adds the foundational documentation files for v0.1.0:

- **CHANGELOG.md** — Keep-a-Changelog format. `[Unreleased]` section backfilled with all the substantive changes since the audit-baseline merges. Closes #162.

- **CONTRIBUTING.md** — codifies the workflow already in practice: branch naming, stacked PRs, self-review before opening, lock-in tests before refactoring, the bilateral CONTRACT pattern, and the DCO requirement. Closes #161.

- **COMMERCIAL.md** — documents the dual-license model and the acquisition path ("contact maintainer"). Closes #163.

- **README.md** — adds Contributing section linking the new docs, License section now references COMMERCIAL.md.

#159 (README) is already substantially complete pre-this-PR; closing separately.