### PR TITLE
Fix wrong-sign and unguarded coeff in n_ary_sub_dispatch::dispatch(add, add) (#91)

### DIFF
--- a/include/numsim_cas/core/simplifier/simplifier_sub.h
+++ b/include/numsim_cas/core/simplifier/simplifier_sub.h
@@ -207,22 +207,33 @@ public:
     return add_expr;
   }
 
-  // merge two add expressions
-  // NOTE: this dispatch has a separate pre-existing semantic issue —
-  // `lhs.coeff() + rhs.coeff()` is unguarded against invalid coeffs and uses
-  // `+` where `-` would be correct for subtraction. Documented in
-  // CoreBugFixTest near SubSymbolDispatchSmoke. Conversion below preserves
-  // existing behavior and closes the transitive-collision bug class.
+  // (c_l + a + b + c) - (c_r + a + d) = (c_l - c_r) + b + c - d
+  // Coefficient combines via `-` and is guarded against invalid sides
+  // (functions.h::merge_add carries the same guard pattern for the add side).
+  // Children matching by key combine via `-`; rhs-only children negate.
+  // Zero-valued children are filtered (otherwise (x+y+z)-(x+y) would leave
+  // stray zeros in the result); if the resulting add has no children, the
+  // coefficient (or zero) is returned directly.
   expr_holder_t dispatch(typename Traits::add_type const &rhs) {
     auto expr{make_expression<typename Traits::add_type>()};
     auto &add{expr.template get<typename Traits::add_type>()};
-    add.set_coeff(lhs.coeff() + rhs.coeff());
+    if (lhs.coeff().is_valid() && rhs.coeff().is_valid()) {
+      auto coeff = lhs.coeff() - rhs.coeff();
+      if (!is_same<typename Traits::zero_type>(coeff))
+        add.set_coeff(std::move(coeff));
+    } else if (lhs.coeff().is_valid()) {
+      add.set_coeff(lhs.coeff());
+    } else if (rhs.coeff().is_valid()) {
+      add.set_coeff(-rhs.coeff());
+    }
     std::set<expr_holder_t> used_expr;
     for (auto &child : lhs.symbol_map() | std::views::values) {
       auto pos{rhs.symbol_map().find(child)};
       if (pos != rhs.symbol_map().end()) {
         used_expr.insert(pos->second);
-        add.merge_or_insert(child + pos->second);
+        auto combined = child - pos->second;
+        if (!is_same<typename Traits::zero_type>(combined))
+          add.merge_or_insert(std::move(combined));
       } else {
         add.merge_or_insert(child);
       }
@@ -230,9 +241,17 @@ public:
     if (used_expr.size() != rhs.size()) {
       for (auto &child : rhs.symbol_map() | std::views::values) {
         if (!used_expr.count(child)) {
-          add.merge_or_insert(child);
+          add.merge_or_insert(-child);
         }
       }
+    }
+    // Collapse: no children -> return coeff (or zero); one child + no coeff
+    // -> return the child directly.
+    if (add.symbol_map().empty()) {
+      return add.coeff().is_valid() ? add.coeff() : Traits::zero();
+    }
+    if (add.symbol_map().size() == 1 && !add.coeff().is_valid()) {
+      return add.symbol_map().begin()->second;
     }
     return expr;
   }

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -279,12 +279,23 @@ TEST(CoreBugFix, NegativeSubAddDispatchSmoke) {
   });
 }
 
-// NOTE: a third smoke test for n_ary_sub_dispatch::dispatch(add, add)
-// — e.g. (a+b+c) - (a+b) — would surface a separate, pre-existing latent
-// bug in that dispatch: it computes lhs.coeff() + rhs.coeff() unguarded
-// against invalid coefficients, and uses `+` where `-` would be correct
-// for subtraction semantics. Out of scope for this PR; documenting the
-// gap rather than re-introducing the failing test.
+TEST(CoreBugFix, SubMergeAddDispatchCorrect) {
+  // Regression for issue #91. Previously n_ary_sub_dispatch::dispatch(add, add)
+  // combined coefficients with `+` (instead of `-`) and was unguarded against
+  // invalid coefficients — the latter making (x+y+z) - (x+y) throw on the
+  // unguarded `+` of two invalid holders.
+  auto [x, y, z] = make_scalar_variable("x", "y", "z");
+  auto [a, b] = make_scalar_variable("a", "b");
+  auto two = make_scalar_constant(2);
+  auto one = make_scalar_constant(1);
+
+  // (x+y+z) - (x+y) -> z
+  EXPECT_EQ((x + y + z) - (x + y), z);
+  // (2+x) - (1+x) -> 1
+  EXPECT_EQ((two + x) - (one + x), one);
+  // (a+b) - (a+b) -> 0
+  EXPECT_TRUE(is_same<scalar_zero>((a + b) - (a + b)));
+}
 
 // ---------------------------------------------------------------------------
 // scalar_evaluator::forward_values_to filters non-scalar keys


### PR DESCRIPTION
Closes #91.

This is one of 14 PRs whose content was technically merged on GitHub but never reached main — the original PR #98 merged into the WIP integration stack instead of trunk. Cherry-picked from `685afa3` onto current main.

## The bug

`include/numsim_cas/core/simplifier/simplifier_sub.h::n_ary_sub_dispatch<Traits>::dispatch(typename Traits::add_type const &rhs)` (lines 216–238 on the pre-fix main) used `+` where it should use `-` for the subtraction. Three concrete bugs in one function:

- `add.set_coeff(lhs.coeff() + rhs.coeff())` — should be `lhs.coeff() - rhs.coeff()` (with invalid-side guards).
- For matching children: `add.merge_or_insert(child + pos->second)` — should be `child - pos->second`.
- For rhs-only children: `add.merge_or_insert(child)` — should be `-child`.

`(x+y+z) - (x+y)` produced wrong arithmetic.

## Test plan

Includes the `SubMergeAddDispatchCorrect` regression test that pins the three #91 acceptance criteria. 1660 ctest passing, clean build under `-Werror`.

## Provenance

Same content as the closed-but-not-on-main PR #98. The original branch `95-fix-coredbugfix-merge` ate this merge instead of main. Recovered here.