### PR TITLE
Harden inv() construction-time guards: reject tensor_zero and rank > 2 (closes #187, #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and from v0.1.0 onward the project adheres to [Semantic Versioning](https://semv
 
 - Rational comparison overflow in `numeric_less` / `operator<` for numerators near 2^63. Closes #142.
 - Replaced the regression test for #142 with one that actually exercises int64 overflow (the original test's numerators were divisible by 3 and normalized away from the overflow path). Closes #170.
+- `inv()` now rejects the zero tensor at construction (`inv(tensor_zero)` and the composite `inv(0 · A)` form) with a clear "singular" error instead of silently building a symbolic `inv(0)` node that would NaN/Inf during evaluation. Closes #187.
+- `inv()` now rejects rank > 2 inputs at construction. Previously the function accepted them and built a symbolic `tensor_inv` node that would fail at the tmech evaluator (which is rank-2 only) or silently produce wrong results. The `identity_tensor` short-circuit still fires first, so the rank-4 minor identity remains self-inverse. Closes #192.
 
 ### Documentation
 

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -361,24 +361,39 @@ template <tensor_expr_holder Expr>
 
 template <tensor_expr_holder Expr>
 [[nodiscard]] constexpr inline auto inv(Expr &&expr) {
+  // inv(inv(A)) → A — collapse at any rank. By the time we see a
+  // tensor_inv the inner is already valid (would have been rejected at
+  // its own construction by the guards below if not).
   if (is_same<tensor_inv>(expr))
     return expr.template get<tensor_inv>().expr();
-  // identity_tensor and kronecker_delta are self-inverse. This also avoids
-  // creating symbolic inv() nodes that tmech::inv cannot evaluate for rank-4
-  // tensors lacking minor symmetry (e.g., the minor identity delta_ik
-  // delta_jl).
+  // identity_tensor and kronecker_delta are self-inverse. identity_tensor
+  // is self-inverse at any even rank (the minor identity is its own
+  // inverse under the appropriate contraction); kronecker_delta is
+  // rank-2 by definition. Short-circuit *before* the rank check below so
+  // these stay valid for rank ≥ 4.
   if (is_same<identity_tensor>(expr))
     return std::forward<Expr>(expr);
   if (is_same<kronecker_delta>(expr))
     return std::forward<Expr>(expr);
+  // Singular: inv(0) is undefined. Closes #187.
+  if (is_same<tensor_zero>(expr))
+    throw invalid_expression_error("inv: operand is the zero tensor "
+                                   "(singular)");
+  // Rank gate: only rank-2 inverses are supported. tmech::inv expects
+  // rank-2; higher-rank inversion has no canonical definition in this
+  // codebase (the rank-4 minor identity is a special case handled above).
+  // Reject at construction so downstream evaluation cannot produce
+  // NaN/Inf or a confusing tmech runtime error. Closes #192.
+  if (expr.get().rank() != 2)
+    throw invalid_expression_error(
+        "inv: only rank-2 tensors are supported (got rank " +
+        std::to_string(expr.get().rank()) + ")");
   // A skew-symmetric matrix in odd dimensions is singular (det = 0) by the
   // determinant theorem det(-A^T) = (-1)^n det(A). contains_skew_factor also
   // catches expressions that aren't themselves skew but contain a skew factor
-  // (e.g. B * skew(A)) — still singular. Reject at construction so downstream
-  // evaluation cannot produce NaN/Inf from a silently-invalid expression.
-  // Rank-2 only; rank-4 inverses are a separate concern.
-  if (expr.get().rank() == 2 && expr.get().dim() % 2 != 0 &&
-      contains_skew_factor(expr)) {
+  // (e.g. B * skew(A)) — still singular. The rank check above already
+  // filtered non-rank-2 inputs, so this guard only covers the rank-2 case.
+  if (expr.get().dim() % 2 != 0 && contains_skew_factor(expr)) {
     throw invalid_expression_error(
         "inv: operand contains a skew-symmetric factor in odd dimensions "
         "(singular)");

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -686,8 +686,9 @@ TYPED_TEST(TensorExpressionTest, InvZeroFromScalarMulThrows) {
   // detection isn't bypassed by a non-trivial construction path.
   auto &A = this->A;
   auto zero = numsim::cas::get_scalar_zero();
-  EXPECT_THROW({ [[maybe_unused]] auto r = numsim::cas::inv(zero * A); },
-               numsim::cas::invalid_expression_error);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto r = numsim::cas::inv(zero * A); },
+      numsim::cas::invalid_expression_error);
 }
 
 TYPED_TEST(TensorExpressionTest, InvRank4SymbolThrows) {

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -661,6 +661,61 @@ TYPED_TEST(TensorExpressionTest, InvInvSimplification) {
 }
 
 // -----------------------------------------------------------------------------
+// inv() construction-time singularity / rank guards (#187, #192)
+// -----------------------------------------------------------------------------
+
+TYPED_TEST(TensorExpressionTest, InvZeroTensorThrowsSingular) {
+  // #187: inv(0) is undefined — the zero matrix has no inverse. Without
+  // the guard, evaluation would silently NaN/Inf via tmech::inv. Reject
+  // at construction so the error surfaces where the bug is, not at the
+  // remote evaluator call site.
+  auto &Zero = this->_Zero;
+  try {
+    [[maybe_unused]] auto r = numsim::cas::inv(Zero);
+    FAIL() << "Expected inv(tensor_zero) to throw";
+  } catch (numsim::cas::invalid_expression_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("singular"), std::string::npos)
+        << "error message should mention singularity; got: " << e.what();
+  }
+}
+
+TYPED_TEST(TensorExpressionTest, InvZeroFromScalarMulThrows) {
+  // Same as above via the composite path: 0 · A simplifies to tensor_zero
+  // at construction (via the existing tensor_scalar_mul zero rule), so
+  // inv(0 · A) hits the same guard. Locks in that the singularity
+  // detection isn't bypassed by a non-trivial construction path.
+  auto &A = this->A;
+  auto zero = numsim::cas::get_scalar_zero();
+  EXPECT_THROW({ [[maybe_unused]] auto r = numsim::cas::inv(zero * A); },
+               numsim::cas::invalid_expression_error);
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4SymbolThrows) {
+  // #192: rank > 2 inversion has no canonical definition (the rank-4
+  // minor identity is an explicit special case handled separately).
+  // Reject rank-4 (and higher) symbols at construction.
+  auto &A = this->A; // rank-4 fixture variable
+  try {
+    [[maybe_unused]] auto r = numsim::cas::inv(A);
+    FAIL() << "Expected inv(rank-4 symbol) to throw";
+  } catch (numsim::cas::invalid_expression_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("rank"), std::string::npos)
+        << "error message should mention rank; got: " << e.what();
+  }
+}
+
+TYPED_TEST(TensorExpressionTest, InvIdentityTensorRank4SelfInverse) {
+  // The rank-4 identity_tensor (minor identity δ_ik · δ_jl) is its own
+  // inverse under the appropriate contraction. The rank guard must NOT
+  // reject it — the identity_tensor short-circuit fires first.
+  auto I4 = numsim::cas::make_expression<numsim::cas::identity_tensor>(
+      TestFixture::Dim, std::size_t{4});
+  auto r = numsim::cas::inv(I4);
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::identity_tensor>(r));
+  EXPECT_EQ(r.get().rank(), 4u);
+}
+
+// -----------------------------------------------------------------------------
 // Zero early returns for tensor functions
 // -----------------------------------------------------------------------------
 TYPED_TEST(TensorExpressionTest, TransZeroReturnsZero) {


### PR DESCRIPTION
## Summary

Bundles two related construction-time guards on `inv()`:

- **#187** — `inv(tensor_zero)` throws `"singular"` instead of silently building a symbolic `inv(0)` node that would NaN/Inf at evaluation.
- **#192** — `inv(rank > 2)` throws `"only rank-2 tensors are supported"` instead of accepting and building a symbolic `tensor_inv` node that tmech::inv can't evaluate.

Both belong in the same change because they touch the same function and share the same test-fixture machinery.

## Code

`include/numsim_cas/tensor/tensor_functions.h::inv()` — added two guards. The ordering matters:

```cpp
inv(inv(A))            // 1. collapse: any rank
inv(identity_tensor)   // 2. self-inverse: any even rank (rank-4 minor identity stays valid)
inv(kronecker_delta)   // 3. self-inverse: rank-2 by definition
inv(tensor_zero)       // 4. NEW: throw "singular" (any rank) — closes #187
inv(rank != 2)         // 5. NEW: throw "rank not supported" — closes #192
inv(skew odd-dim)      // 6. throw "singular" (rank-2 only, now unconditional after gate above)
inv(other rank-2)      // 7. build symbolic tensor_inv node
```

The previous misleading `// Rank-2 only; rank-4 inverses are a separate concern.` comment on the skew guard is gone — the rank gate above now enforces what the comment claimed.

## Tests

4 new `TYPED_TEST`s in `TensorExpressionTest.h` (× 3 dims = 12 cases):

- `InvZeroTensorThrowsSingular` — direct `inv(tensor_zero)`
- `InvZeroFromScalarMulThrows` — composite path `inv(0 · A)` where the `0 · A` simplification creates `tensor_zero` at construction
- `InvRank4SymbolThrows` — rank-4 symbol rejection with `"rank"` in the message
- `InvIdentityTensorRank4SelfInverse` — verifies the rank-4 `identity_tensor` short-circuit still fires (so the minor identity remains self-inverse even after the rank gate is added)

Full suite: **1708/1708** passing (was 1696 + 12 new).

## Test plan

- [x] `cmake --build build` clean under `-Werror`.
- [x] `ctest --test-dir build` — 1708/1708.
- [x] Existing `InvInvSimplification`, `InvSkewRejectedInOddDim`, `InvSkewPreservesSkewInEvenDim`, `InvRejectsScaledSkewFactorInTensorMul` all still pass — guard ordering preserves the existing self-inverse and skew semantics.

## Why bundle

Both guards live in the same 5-line function, share test infrastructure, and address the same class of bug ("inv() silently accepts inputs it can't actually invert"). Splitting them would duplicate the test fixture additions.

Closes #187
Closes #192