### PR TITLE
Add tensor pow(I, n) and pow(inv(A), n) simplification rules (closes #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and from v0.1.0 onward the project adheres to [Semantic Versioning](https://semv
 - Renamed `basis_change_imp` → `permute_indices_wrapper`. The class permutes tensor indices (e.g. transpose is `{2,1}`) — it does not change basis. Closes #52.
 - Renamed folder `include/numsim_cas/tensor/functions/` → `include/numsim_cas/tensor/wrappers/`. The files in that directory are AST-node wrapper classes, not free functions; the new name matches the `_wrapper` suffix convention used by the class names themselves. Closes #55.
 - Renamed data-layer `tensor_data_basis_change` → `tensor_data_permute_indices` (file and class) plus the local variables `basis_change_lhs/rhs/temp` in `tensor_data_inner_product.h`. Completes the wrapper-layer rename from #52 — the data class is the runtime evaluator for the AST node `permute_indices_wrapper`, and now uses matching terminology. Closes #182.
+- Two missing tensor `pow()` simplification rules: `pow(identity_tensor, n) → identity_tensor` (the rank-2 identity is its own n-th power) and `pow(inv(A), n) → inv(pow(A, n))` (pulls the inverse outside so the inner `pow(A, n)` can fold further and the evaluator only inverts once). Closes #96.
 - Construction-time simplifier completions for the tensor-function family:
   - `det()`: added `det(identity_tensor) → 1`, `det(inv(A)) → 1/det(A)`, `det(trans(A)) → det(A)`, and `det(u ⊗ v) → 0` (for dim ≥ 2). Closes #70.
   - `inv()`: added `inv(α · A) → inv(A) / α` (recursive). Closes #71.

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -59,6 +59,26 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
     return pow(inner.expr_lhs(), inner.expr_rhs() * expr_rhs);
   }
 
+  // pow(I, n) → I. The rank-2 identity is its own n-th power under
+  // tensor multiplication for any n. Closes part of #96.
+  if (is_same<identity_tensor>(expr_lhs))
+    return std::forward<ExprLHS>(expr_lhs);
+
+  // pow(inv(A), n) → inv(pow(A, n)) — pulls the inverse out so the
+  // pow(A, n) result can fold further and the evaluator only needs to
+  // invert once at the end. Constructed directly via
+  // make_expression<tensor_inv> rather than calling inv() to avoid a
+  // tensor_std.h → tensor_functions.h include cycle; the inv()
+  // construction-time guards (rank-2 / zero / skew, see #187 / #192)
+  // were already enforced when the inner tensor_inv we're matching on
+  // was first built, so bypassing them here is safe.
+  // Closes part of #96.
+  if (is_same<tensor_inv>(expr_lhs)) {
+    auto const &inv_node = expr_lhs.template get<tensor_inv>();
+    return make_expression<tensor_inv>(
+        pow(inv_node.expr(), std::forward<ExprRHS>(expr_rhs)));
+  }
+
   return numsim::cas::make_expression<numsim::cas::tensor_pow>(
       std::forward<ExprLHS>(expr_lhs), std::forward<ExprRHS>(expr_rhs));
 }

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -670,10 +670,10 @@ TYPED_TEST(TensorExpressionTest, TensorPowIdentitySelfPower) {
   // under tensor multiplication).
   auto I = numsim::cas::make_expression<numsim::cas::identity_tensor>(
       TestFixture::Dim, std::size_t{2});
-  EXPECT_TRUE(
-      numsim::cas::is_same<numsim::cas::identity_tensor>(numsim::cas::pow(I, 5)));
-  EXPECT_TRUE(
-      numsim::cas::is_same<numsim::cas::identity_tensor>(numsim::cas::pow(I, 0)));
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::identity_tensor>(
+      numsim::cas::pow(I, 5)));
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::identity_tensor>(
+      numsim::cas::pow(I, 0)));
 }
 
 TYPED_TEST(TensorExpressionTest, TensorPowOfInvLiftsToInvOfPow) {

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -661,6 +661,35 @@ TYPED_TEST(TensorExpressionTest, InvInvSimplification) {
 }
 
 // -----------------------------------------------------------------------------
+// #96: tensor pow construction-time rules — pow(I, n) → I, pow(inv(A), n) →
+// inv(pow(A, n)). Existing rules (pow(0, n) → 0, pow(A, 0) → I, pow(A, 1) → A,
+// pow(pow(A, m), n) → pow(A, m·n)) are already locked in elsewhere.
+// -----------------------------------------------------------------------------
+TYPED_TEST(TensorExpressionTest, TensorPowIdentitySelfPower) {
+  // pow(I, n) → I for any n (rank-2 identity is its own n-th power
+  // under tensor multiplication).
+  auto I = numsim::cas::make_expression<numsim::cas::identity_tensor>(
+      TestFixture::Dim, std::size_t{2});
+  EXPECT_TRUE(
+      numsim::cas::is_same<numsim::cas::identity_tensor>(numsim::cas::pow(I, 5)));
+  EXPECT_TRUE(
+      numsim::cas::is_same<numsim::cas::identity_tensor>(numsim::cas::pow(I, 0)));
+}
+
+TYPED_TEST(TensorExpressionTest, TensorPowOfInvLiftsToInvOfPow) {
+  // pow(inv(A), n) → inv(pow(A, n)): pulls the inverse out so the pow
+  // can fold further and the evaluator only inverts once at the end.
+  auto &X = this->X;
+  EXPECT_PRINT(numsim::cas::pow(numsim::cas::inv(X), 2), "inv(pow(X,2))");
+  EXPECT_PRINT(numsim::cas::pow(numsim::cas::inv(X), 3), "inv(pow(X,3))");
+  // Composes with inv(inv(A)) → A: pow(inv(inv(A)), 2) should collapse
+  // to pow(A, 2) — the inv(inv) collapses *before* this rule fires
+  // because tensor_inv short-circuit runs first inside inv().
+  EXPECT_PRINT(numsim::cas::pow(numsim::cas::inv(numsim::cas::inv(X)), 2),
+               "pow(X,2)");
+}
+
+// -----------------------------------------------------------------------------
 // inv() construction-time singularity / rank guards (#187, #192)
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #96. Adds two construction-time tensor `pow()` rules listed in the issue but not previously implemented:

| Rule | Effect |
|------|--------|
| `pow(identity_tensor, n) → identity_tensor` | The rank-2 identity is its own n-th power under tensor multiplication for any n. |
| `pow(inv(A), n) → inv(pow(A, n))` | Pulls the inverse outside so the inner `pow(A, n)` can fold further (with later pow-of-pow chains) and the evaluator only inverts once at the end. |

Pre-existing rules (`pow(0, n) → 0`, `pow(A, 0) → I`, `pow(A, 1) → A`, `pow(pow(A, m), n) → pow(A, m·n)`) unchanged.

## Implementation note

The lifted-inverse uses `make_expression<tensor_inv>` directly rather than calling the public `inv()` to sidestep a `tensor_std.h` → `tensor_functions.h` include cycle. The `inv()` construction-time guards (rank-2 / zero / skew, see #187 / #192) were already enforced when the inner `tensor_inv` that we're matching on was first built — so bypassing them at the lifted-inverse construction site is safe.

## Lock-in tests

6 cases (typed × 3 dims):

- `TensorPowIdentitySelfPower` — verifies `pow(I, n)` is `identity_tensor` for `n ∈ {0, 5}`.
- `TensorPowOfInvLiftsToInvOfPow` — verifies `pow(inv(X), n) == inv(pow(X, n))` for `n ∈ {2, 3}`, and that composition with `inv(inv) → A` still fires before the lift: `pow(inv(inv(X)), 2) → pow(X, 2)`.

## Out of scope

**#109** (architectural unification of tensor `pow` into the dispatcher pattern used by scalar/t2s) stays open. This PR adds the missing rules in the existing inline-short-circuit style; #109 is the broader refactor that moves all of `pow()` into a visitor pipeline.

## Test plan

- [x] Clean build under `-Werror`.
- [x] `ctest --test-dir build` — **1743/1743 passing** (was 1737 + 6 new).
- [x] Probed all 5 cases (identity n=0/5, inv-of-A n=2/3, inv(inv) interaction) — all produce the expected canonical form.

Closes #96