### PR TITLE
Re-open: Tensor-function simplifier completions (closes #70, #71, #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and from v0.1.0 onward the project adheres to [Semantic Versioning](https://semv
 - Replaced the rank-2-only `kronecker_delta` node with the general `identity_tensor` node. The two were doing the same work at rank 2 (every visitor delegated to a common helper); the only behavioural difference was the printer. Differentiation results are now consistent across paths — both `diff(A, A)` and `diff(trace(A), A)` produce `identity_tensor`. Added comprehensive Doxygen to `identity_tensor.h` and a new "Identity Tensor" section in `docs/tensor.md` documenting the rank-2 (Kronecker delta) and rank-2R (minor identity) forms, plus the `tmech::eye` vs `tmech::otimesu` footgun for rank ≥ 4. Closes #188.
 - Renamed `basis_change_imp` → `permute_indices_wrapper`. The class permutes tensor indices (e.g. transpose is `{2,1}`) — it does not change basis. Closes #52.
 - Renamed folder `include/numsim_cas/tensor/functions/` → `include/numsim_cas/tensor/wrappers/`. The files in that directory are AST-node wrapper classes, not free functions; the new name matches the `_wrapper` suffix convention used by the class names themselves. Closes #55.
+- Construction-time simplifier completions for the tensor-function family:
+  - `det()`: added `det(identity_tensor) → 1`, `det(inv(A)) → 1/det(A)`, `det(trans(A)) → det(A)`, and `det(u ⊗ v) → 0` (for dim ≥ 2). Closes #70.
+  - `inv()`: added `inv(α · A) → inv(A) / α` (recursive). Closes #71.
+  - `trace()`: added `trace(identity_tensor) → dim` (the existing `kronecker_delta` rule didn't cover the general identity_tensor node that appears in differentiation results). Closes #72.
 
 ### Removed
 

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -386,6 +386,15 @@ template <tensor_expr_holder Expr>
     throw invalid_expression_error(
         "inv: only rank-2 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
+  // inv(α·A) = inv(A) / α. The scalar pulls out of the inverse as its
+  // reciprocal. Recurse so e.g. inv(α·inv(A)) folds via tensor_inv → A,
+  // not just one layer. (Placed after the rank gate so rank > 2 inputs
+  // produce the dedicated "rank not supported" error rather than
+  // recursing into a deeper inv call.) Closes #71.
+  if (is_same<tensor_scalar_mul>(expr)) {
+    auto const &sm = expr.template get<tensor_scalar_mul>();
+    return inv(sm.expr_rhs()) / sm.expr_lhs();
+  }
   // A skew-symmetric matrix in odd dimensions is singular (det = 0) by the
   // determinant theorem det(-A^T) = (-1)^n det(A). contains_skew_factor also
   // catches expressions that aren't themselves skew but contain a skew factor

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -40,7 +40,8 @@ trace(expression_holder<tensor_expression> const &expr) {
     return make_expression<tensor_to_scalar_zero>();
 
   // trace(I) = dim. The asserted rank-2 input means any identity_tensor
-  // reaching here is the Kronecker delta (rank-2 identity).
+  // reaching here is the rank-2 Kronecker delta (since #188 unified
+  // kronecker_delta into identity_tensor).
   if (is_same<identity_tensor>(expr)) {
     auto dim = expr.get().dim();
     return make_expression<tensor_to_scalar_scalar_wrapper>(
@@ -92,9 +93,35 @@ det(expression_holder<tensor_expression> const &expr) {
     return make_expression<tensor_to_scalar_zero>();
 
   // det(I) = 1 at rank 2 (the asserted rank-2 input means any
-  // identity_tensor reaching here is the rank-2 Kronecker delta).
+  // identity_tensor reaching here is the rank-2 Kronecker delta;
+  // kronecker_delta was unified into identity_tensor by #188).
   if (is_same<identity_tensor>(expr))
     return make_expression<tensor_to_scalar_one>();
+
+  // det(inv(A)) = 1/det(A). Routes through the t2s div operator which
+  // composes via pow(rhs, -1) — produces canonical pow(det(A), -1).
+  if (is_same<tensor_inv>(expr)) {
+    auto const &inner = expr.get<tensor_inv>().expr();
+    return make_expression<tensor_to_scalar_one>() / det(inner);
+  }
+
+  // det(trans(A)) = det(A). trans() builds permute_indices_wrapper with
+  // sequence{2, 1}; det is rank-2 only (asserted), so any
+  // permute_indices_wrapper reaching here is necessarily the transpose.
+  // Still match on the index sequence so a future caller passing a
+  // non-transpose permutation doesn't get a wrong simplification.
+  if (is_same<permute_indices_wrapper>(expr)) {
+    auto const &perm = expr.get<permute_indices_wrapper>();
+    if (perm.indices() == sequence{2, 1})
+      return det(perm.expr());
+  }
+
+  // det(u ⊗ v) = 0 for dim ≥ 2. The outer product u ⊗ v of two rank-1
+  // tensors is a rank-2 matrix of rank 1 (linear-algebra sense), so its
+  // determinant is zero for any n×n with n ≥ 2. For dim = 1 the matrix
+  // is the 1×1 scalar u₀·v₀ — don't fold.
+  if (is_same<outer_product_wrapper>(expr) && expr.get().dim() >= 2)
+    return make_expression<tensor_to_scalar_zero>();
 
   if (is_same<tensor_scalar_mul>(expr)) {
     auto const &sm = expr.get<tensor_scalar_mul>();

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -717,6 +717,28 @@ TYPED_TEST(TensorExpressionTest, InvIdentityTensorRank4SelfInverse) {
 }
 
 // -----------------------------------------------------------------------------
+// #71: inv(α·A) → inv(A) / α
+// -----------------------------------------------------------------------------
+TYPED_TEST(TensorExpressionTest, InvScalarMulSimplification) {
+  auto &X = this->X;
+  auto &x = this->x;
+  auto &_2 = this->_2;
+
+  // inv(x·A) → inv(A) / x (symbolic scalar)
+  EXPECT_PRINT(numsim::cas::inv(x * X), "inv(X)/x");
+
+  // inv(2·A) → (1/2)*inv(A). The numeric reciprocal is folded into a
+  // scalar coefficient at construction time (via the standard
+  // tensor_scalar_mul canonicalisation), so the printed form is
+  // "(1/2)*inv(X)" rather than "inv(X)/2".
+  EXPECT_PRINT(numsim::cas::inv(_2 * X), "(1/2)*inv(X)");
+
+  // Recurse: inv(x·inv(A)) → A / x  (the inner inv(inv(...)) collapses,
+  // the outer inv(x·A_inner) pulls out x).
+  EXPECT_PRINT(numsim::cas::inv(x * numsim::cas::inv(X)), "X/x");
+}
+
+// -----------------------------------------------------------------------------
 // Zero early returns for tensor functions
 // -----------------------------------------------------------------------------
 TYPED_TEST(TensorExpressionTest, TransZeroReturnsZero) {

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -540,6 +540,14 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_TraceSimplification) {
   // trace(I) → dim
   EXPECT_PRINT(trace(One), std::to_string(TestFixture::Dim));
 
+  // #72: trace(identity_tensor) → dim. identity_tensor is a separate
+  // node from kronecker_delta (kronecker_delta is rank-2-only; the
+  // general identity_tensor carries a rank parameter and arises from
+  // differentiation results).
+  auto Ident = numsim::cas::make_expression<numsim::cas::identity_tensor>(
+      TestFixture::Dim, 2);
+  EXPECT_PRINT(trace(Ident), std::to_string(TestFixture::Dim));
+
   // trace(s*A) → s*trace(A)
   EXPECT_PRINT(trace(_2 * X), "2*tr(X)");
   EXPECT_PRINT(trace(x * X), "x*tr(X)");
@@ -559,11 +567,71 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_DetSimplification) {
   // det(0) → 0
   EXPECT_PRINT(det(Zero), "0");
 
-  // det(I) → 1
+  // det(I) → 1 (kronecker_delta form)
   EXPECT_PRINT(det(One), "1");
 
   // normal case unchanged
   EXPECT_PRINT(det(X), "det(X)");
+}
+
+// ---------- det() construction-time rules added by #70 ----------
+TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_DetExtendedRules) {
+  auto &X = this->X;
+  constexpr auto Dim = TestFixture::Dim;
+
+  using numsim::cas::det;
+  using numsim::cas::inv;
+  using numsim::cas::otimes;
+  using numsim::cas::trans;
+
+  // #70: det(identity_tensor) → 1 (general identity, distinct node from
+  // kronecker_delta which is already covered above).
+  auto Ident =
+      numsim::cas::make_expression<numsim::cas::identity_tensor>(Dim, 2);
+  EXPECT_PRINT(det(Ident), "1");
+
+  // #70: det(inv(A)) → 1/det(A)
+  EXPECT_PRINT(det(inv(X)), "pow(det(X),-1)");
+
+  // #70: det(trans(A)) → det(A)
+  EXPECT_PRINT(det(trans(X)), "det(X)");
+
+  // #70: det(u ⊗ v) → 0 for dim ≥ 2. For dim = 1 the outer product is
+  // a 1×1 scalar whose determinant is the scalar itself — don't fold.
+  auto u = numsim::cas::make_expression<numsim::cas::tensor>(
+      "u", static_cast<std::size_t>(Dim), std::size_t{1});
+  auto v = numsim::cas::make_expression<numsim::cas::tensor>(
+      "v", static_cast<std::size_t>(Dim), std::size_t{1});
+  if constexpr (Dim >= 2) {
+    EXPECT_PRINT(det(otimes(u, v)), "0");
+  }
+}
+
+// ---------- Composition: #70 × #71 interaction ----------
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_DetInvScalarComposition) {
+  auto &X = this->X;
+  auto &x = this->x;
+  constexpr auto Dim = TestFixture::Dim;
+
+  using numsim::cas::det;
+  using numsim::cas::inv;
+
+  // det(inv(inv(A))) → det(A). Tests that the inner inv(inv) collapses
+  // to A before det() sees it (rather than redundantly forming
+  // pow(pow(det(A),-1),-1)).
+  EXPECT_PRINT(det(inv(inv(X))), "det(X)");
+
+  // det(x · inv(A)) → x^dim / det(A). Exercises both rules together:
+  // the scalar pulls out as x^dim (existing rule), and the inv reduces
+  // to 1/det(A) (new #70 rule). Locks in the interaction.
+  if constexpr (Dim == 1) {
+    EXPECT_PRINT(det(x * inv(X)), "x/det(X)");
+  } else if constexpr (Dim == 2) {
+    EXPECT_PRINT(det(x * inv(X)), "pow(x,2)/det(X)");
+  } else if constexpr (Dim == 3) {
+    EXPECT_PRINT(det(x * inv(X)), "pow(x,3)/det(X)");
+  }
 }
 
 // ---------- norm() simplification ----------


### PR DESCRIPTION
Re-opened after revert PR #199. Stacked on #189-reopened (depends on the identity_tensor unification).

Originally landed as #186 (squash `5252027`) on 2026-05-25; reverted as part of #199.

See the original PR #186 description for full details.

Closes #70
Closes #71
Closes #72