### PR TITLE
Fix clang-format-18 violation in tensor_functions.h

### DIFF
--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -307,10 +307,8 @@ template <tensor_expr_holder Expr>
   // resulting expression — silently wrong.
   if (indices.size() != expr.get().rank())
     throw invalid_expression_error(
-        "permute_indices: indices size (" +
-        std::to_string(indices.size()) +
-        ") must equal tensor rank (" +
-        std::to_string(expr.get().rank()) + ")");
+        "permute_indices: indices size (" + std::to_string(indices.size()) +
+        ") must equal tensor rank (" + std::to_string(expr.get().rank()) + ")");
   // For symmetric rank-2 tensors, any permutation of two indices is identity
   if (expr.get().rank() == 2) {
     if (auto const &sp = expr.get().space()) {


### PR DESCRIPTION
## Summary

Pure formatting fix. `clang-format-18` was rejecting `permute_indices()`'s multi-line error-message construction (lines 310-312); v18 prefers joining the short fragments. Running `clang-format-18 -i` produces exactly the diff in this PR.

```diff
-        "permute_indices: indices size (" +
-        std::to_string(indices.size()) +
-        ") must equal tensor rank (" +
-        std::to_string(expr.get().rank()) + ")");
+        "permute_indices: indices size (" + std::to_string(indices.size()) +
+        ") must equal tensor rank (" + std::to_string(expr.get().rank()) + ")");
```

## Why ship this on its own

The violation lives on `main`, so the CI clang-format check fails on *every* open PR that inherits it. Fixing it here, on its own tiny branch, unblocks all the in-flight PRs without bundling unrelated changes.

## Verification

- `clang-format-18 --dry-run --Werror include/numsim_cas/tensor/tensor_functions.h` — clean after fix.
- Full build: clean.
- Full test suite: 1737/1737 pass (no behaviour change expected; pure formatting).