### PR TITLE
Parser scaffold: error types + symbol_table (phase 1 of #214)

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -25,6 +25,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DNUMSIM_CAS_BUILD_TESTS=OFF
           -DNUMSIM_CAS_BUILD_EXAMPLES=OFF
+          -DNUMSIM_CAS_BUILD_PARSER=ON
 
       - name: Run clang-tidy
         run: |

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -40,12 +40,16 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             build_type: Release
-          # ── Ubuntu: GCC-14 + ASAN/UBSAN ────────────────
+          # ── Ubuntu: GCC-14 + ASAN/UBSAN + parser ───────
+          # The parser library (issue #214) is built only on this row.
+          # Pairing it with ASan/UBSan catches memory issues in the
+          # action-stack manipulation and snippet-renderer paths.
           - os: ubuntu-24.04
             c_compiler: gcc-14
             cpp_compiler: g++-14
             build_type: Debug
             sanitizers: ON
+            parser: ON
           # ── Windows: MSVC ──────────────────────────────
           - os: windows-latest
             c_compiler: cl
@@ -70,6 +74,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DNUMSIM_CAS_BUILD_EXAMPLES=ON
         -DNUMSIM_CAS_SANITIZERS=${{ matrix.sanitizers || 'OFF' }}
+        -DNUMSIM_CAS_BUILD_PARSER=${{ matrix.parser || 'OFF' }}
         -S ${{ github.workspace }}
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and from v0.1.0 onward the project adheres to [Semantic Versioning](https://semv
 
 ### Added
 
+- Optional `NumSim_CAS::Parser` library (CMake option `NUMSIM_CAS_BUILD_PARSER=ON`, default OFF). Phase 1 of issue #214: error-class hierarchy (`parse_error` + 8 specialised subclasses) with snippet-with-caret rendering in `what()`; on-the-fly typed `symbol_table` with implicit scalar declarations, explicit `Name{rank,dim}` tensor declarations, redeclaration / cross-type collision detection. 18 lock-in tests gated on `NUMSIM_CAS_PARSER_ENABLED`. Phase 2 will add the PEGTL grammar and the parse entry points.
 - DCO (Developer Certificate of Origin) enforcement via `.github/workflows/dco-check.yml`. Non-merge PR commits must carry a `Signed-off-by:` trailer. Closes part of #171.
 - `NOTICE` file at the repo root asserting petlenz's copyright and the GPL-3.0 OR commercial dual-license model, with SPDX identifiers. Closes part of #171.
 - `LICENSES/LicenseRef-Commercial.txt` so REUSE-compliant tooling can resolve the SPDX `LicenseRef-Commercial` identifier; points at COMMERCIAL.md for the actual acquisition path.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,14 +176,40 @@ endif()
 # Optional parser sub-library (issue #214)
 # -----------------------------
 # When enabled, builds NumSim_CAS_Parser as a separate static/shared
-# library target. Phase 1: error types + symbol_table (no PEGTL yet).
-# Phase 2 will add parser.cpp and link taocpp::pegtl. Keeping the
-# library skeleton in place from phase 1 onwards lets downstreams
-# adopt the dependency once without churn.
+# library target. Phase 1 shipped error types + symbol_table.
+# Phase 2 adds the PEGTL grammar + actions + top-level parse() entry
+# points.
 if(NUMSIM_CAS_BUILD_PARSER)
+  # taocpp/PEGTL — header-only, pulled from upstream when the parser
+  # is opted in. Pinned to a stable tag rather than a moving branch
+  # so CI is deterministic across reruns.
+  find_package(pegtl QUIET)
+  if(NOT pegtl_FOUND)
+    FetchContent_Declare(
+      pegtl
+      GIT_REPOSITORY https://github.com/taocpp/PEGTL.git
+      GIT_TAG        3.2.8
+    )
+    set(PEGTL_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
+    set(PEGTL_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(PEGTL_INSTALL        OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(pegtl)
+    # Suppress warnings from third-party PEGTL headers.
+    get_target_property(_pegtl_real taocpp::pegtl ALIASED_TARGET)
+    if(NOT _pegtl_real)
+      set(_pegtl_real taocpp::pegtl)
+    endif()
+    get_target_property(_pegtl_inc ${_pegtl_real} INTERFACE_INCLUDE_DIRECTORIES)
+    if(_pegtl_inc)
+      set_target_properties(${_pegtl_real} PROPERTIES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_pegtl_inc}")
+    endif()
+  endif()
+
   add_library(NumSim_CAS_Parser
     src/numsim_cas/parser/parse_error.cpp
     src/numsim_cas/parser/symbol_table.cpp
+    src/numsim_cas/parser/parser.cpp
   )
   add_library(NumSim_CAS::Parser ALIAS NumSim_CAS_Parser)
 
@@ -195,6 +221,7 @@ if(NUMSIM_CAS_BUILD_PARSER)
 
   target_link_libraries(NumSim_CAS_Parser
     PUBLIC NumSim_CAS::NumSim_CAS
+    PRIVATE taocpp::pegtl
   )
 
   target_compile_features(NumSim_CAS_Parser PUBLIC cxx_std_23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(NUMSIM_CAS_INSTALL_LIBRARY "Install NumSim_CAS into default locations" ${
 option(NUMSIM_CAS_BUILD_EXAMPLES "Build NumSim_CAS examples" OFF)
 option(NUMSIM_CAS_BUILD_TESTS "Build NumSim_CAS test suite" ON)
 option(NUMSIM_CAS_BUILD_BENCHMARK "Build NumSim_CAS benchmark" OFF)
+option(NUMSIM_CAS_BUILD_PARSER "Build the optional PEGTL-based string parser (issue #214)" OFF)
 option(NUMSIM_CAS_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
 set(INSTALL_GTEST OFF CACHE BOOL "Install GoogleTest" FORCE)
@@ -78,6 +79,13 @@ file(GLOB_RECURSE NUMSIM_CAS_SOURCES CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cxx"
 )
+
+# Parser sources (in src/numsim_cas/parser/ and include/numsim_cas/parser/)
+# live in their own opt-in library. Exclude them from the main library's
+# globs so a default NUMSIM_CAS_BUILD_PARSER=OFF build sees no parser code
+# at all.
+list(FILTER NUMSIM_CAS_SOURCES EXCLUDE REGEX "/parser/")
+list(FILTER NUMSIM_CAS_HEADERS EXCLUDE REGEX "/parser/")
 
 # A shared library needs at least one translation unit
 if(NUMSIM_CAS_SOURCES STREQUAL "")
@@ -165,6 +173,60 @@ if(WIN32)
 endif()
 
 # -----------------------------
+# Optional parser sub-library (issue #214)
+# -----------------------------
+# When enabled, builds NumSim_CAS_Parser as a separate static/shared
+# library target. Phase 1: error types + symbol_table (no PEGTL yet).
+# Phase 2 will add parser.cpp and link taocpp::pegtl. Keeping the
+# library skeleton in place from phase 1 onwards lets downstreams
+# adopt the dependency once without churn.
+if(NUMSIM_CAS_BUILD_PARSER)
+  add_library(NumSim_CAS_Parser
+    src/numsim_cas/parser/parse_error.cpp
+    src/numsim_cas/parser/symbol_table.cpp
+  )
+  add_library(NumSim_CAS::Parser ALIAS NumSim_CAS_Parser)
+
+  target_include_directories(NumSim_CAS_Parser
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+
+  target_link_libraries(NumSim_CAS_Parser
+    PUBLIC NumSim_CAS::NumSim_CAS
+  )
+
+  target_compile_features(NumSim_CAS_Parser PUBLIC cxx_std_23)
+
+  set_target_properties(NumSim_CAS_Parser PROPERTIES
+    VERSION   ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    CXX_EXTENSIONS OFF
+  )
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(NumSim_CAS_Parser PRIVATE
+      -Wall -Wextra -Wpedantic)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(NumSim_CAS_Parser PRIVATE
+      /W4 /EHsc /utf-8 /permissive- /Zc:preprocessor)
+  endif()
+
+  if(NUMSIM_CAS_SANITIZERS)
+    target_compile_options(NumSim_CAS_Parser PUBLIC
+      -fsanitize=address,undefined -fno-omit-frame-pointer)
+    target_link_options(NumSim_CAS_Parser PUBLIC
+      -fsanitize=address,undefined)
+  endif()
+
+  if(WIN32)
+    set_target_properties(NumSim_CAS_Parser PROPERTIES
+      WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+endif()
+
+# -----------------------------
 # Install
 # -----------------------------
 if(NUMSIM_CAS_INSTALL_LIBRARY)
@@ -190,6 +252,21 @@ if(NUMSIM_CAS_INSTALL_LIBRARY)
     install(EXPORT NumSim_CASTargets
       NAMESPACE NumSim_CAS::
       DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/NumSim_CAS"
+    )
+  endif()
+
+  # Parser library + its public headers (conditional on the option).
+  if(NUMSIM_CAS_BUILD_PARSER)
+    install(TARGETS NumSim_CAS_Parser
+      EXPORT NumSim_CASTargets
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/numsim_cas/parser/"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/numsim_cas/parser"
+      FILES_MATCHING PATTERN "*.h"
     )
   endif()
 endif()

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,3 +93,4 @@ auto dd = diff(d, X);    // det(X) * inv(trans(X))
 | [Tensor-to-Scalar Domain](tensor-to-scalar.md) | 13 node types, trace/det/norm functions, simplifiers |
 | [Cross-Domain Interactions](cross-domain.md) | Cross-domain nodes, expression lifecycle, build system |
 | [Differentiation](differentiation.md) | Symbolic differentiation rules with mathematical notation |
+| [String Parser](parser.md) | PEGTL-based parser: grammar, type system, error catalogue, build flag |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,284 @@
+# String Parser
+
+The string parser converts source-code expressions into the same
+`expression_holder<...>` ASTs that the rest of the library builds via
+C++ factories and operator overloads. Implemented with
+[taocpp/PEGTL](https://github.com/taocpp/PEGTL); lives behind the
+`NUMSIM_CAS_BUILD_PARSER=ON` CMake option (default OFF), so consumers
+that don't need it pay no compile cost.
+
+Tracked under [#214](https://github.com/NumSim-Stack/numsim-cas/issues/214).
+
+## Quick Start
+
+```cpp
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/visitors/scalar_evaluator.h>
+
+namespace cas = numsim::cas;
+
+cas::parser::symbol_table syms;
+auto e = cas::parser::parse_scalar("a*x^2 + b*x + c", syms);
+
+cas::scalar_evaluator<double> ev;
+ev.set(syms.get_or_declare_scalar("a"), 1.0);
+ev.set(syms.get_or_declare_scalar("b"), -3.0);
+ev.set(syms.get_or_declare_scalar("c"), 2.0);
+ev.set(syms.get_or_declare_scalar("x"), 1.0);
+
+double y = ev.apply(e);  // 0 — a root of (x-1)(x-2)
+```
+
+Four worked examples live under `examples/`:
+[`parser_basics.cpp`](../examples/parser_basics.cpp),
+[`parser_symbol_table.cpp`](../examples/parser_symbol_table.cpp),
+[`parser_error_handling.cpp`](../examples/parser_error_handling.cpp),
+[`parser_tensor_diff.cpp`](../examples/parser_tensor_diff.cpp).
+
+## Pipeline
+
+```mermaid
+graph LR
+    SRC[Source string]
+    GR[PEGTL grammar<br/>src/.../grammar.h]
+    AC[Actions<br/>src/.../actions.h]
+    REG[Function registry<br/>src/.../function_registry.h]
+    SYM[symbol_table]
+    AST[parsed_expression<br/>variant&lt;scalar, tensor, t2s&gt;]
+
+    SRC --> GR
+    GR -->|each rule match| AC
+    AC -->|function calls| REG
+    AC <-->|declare/lookup| SYM
+    AC -->|value stack| AST
+```
+
+Source is fed to the PEGTL grammar. Each rule match fires an action
+that pushes onto a value stack; binary-op tails pop two values and
+push the combined result. Function-call rules look the name up in
+the registry, type-check the argument kinds, and call the dispatch
+lambda. The final stack value is returned as the
+`parsed_expression` variant.
+
+## Grammar (EBNF)
+
+Operator precedence runs lowest to highest:
+
+| Level | Operators | Associativity | Example |
+|-------|-----------|---------------|---------|
+| 1 | `==` `!=`            | left          | `a == b` |
+| 2 | `<` `<=` `>` `>=`    | left          | `a < b < c` (C-style) |
+| 3 | `+` `-` (binary)     | left          | `a - b - c = (a-b) - c` |
+| 4 | `*` `/`              | left          | `a / b / c = (a/b) / c` |
+| 5 | `-` (unary)          | right         | `--x = -(-x)` |
+| 6 | `^` (power)          | right         | `2^3^2 = 2^(3^2) = 512` |
+
+```ebnf
+expression       = eq_term ;
+eq_term          = cmp_term  , { ('==' | '!=') , cmp_term  } ;
+cmp_term         = add_term  , { ('<' | '<=' | '>' | '>=') , add_term  } ;
+add_term         = mul_term  , { ('+' | '-') , mul_term  } ;
+mul_term         = unary     , { ('*' | '/') , unary     } ;
+unary            = '-' , unary | power ;
+power            = primary , [ '^' , power ] ;                  (* right-recursive *)
+primary          = number | function_call | tensor_decl
+                 | identifier | '(' , expression , ')' ;
+
+number           = digits , [ '.' , [ digits ] ] | '.' , digits ;
+digits           = digit , { digit } ;
+identifier       = (alpha | '_') , { alnum | '_' } ;
+
+function_call    = identifier , '(' , [ arg_list ] , ')' ;
+arg_list         = arg_item , { ',' , arg_item } ;
+arg_item         = index_list_literal | expression ;
+index_list_literal = '[' , integer , { ',' , integer } , ']' ;  (* 1-based *)
+
+tensor_decl      = identifier , '{' , tensor_kv_list , '}' ;
+tensor_kv_list   = tensor_kv , { ',' , tensor_kv } ;
+tensor_kv        = ('rank' | 'dim') , '=' , integer ;
+```
+
+Whitespace (`[ \t\n\r]+`) is freely skipped between tokens but never
+inside identifiers or numbers. Comparison operators evaluate to scalar
+indicators (`1.0` / `0.0`), so `a < b < c` parses C-style as
+`(a < b) < c`, **not** as math-style `(a < b) AND (b < c)`. Number
+parsing uses `std::from_chars` and is locale-independent — `1.5` is
+always one-and-a-half, regardless of `LC_NUMERIC`.
+
+## Type System
+
+Identifiers are typed lazily by the parser:
+
+- **Bare identifier in scalar position** → implicit scalar declaration on first use. Repeated references resolve to the same holder.
+- **`Name{rank=R, dim=D}`** → tensor declaration. After the first use, bare `Name` references resolve to the same tensor holder via the symbol table.
+- **Identical re-declaration** (`A{rank=2, dim=3}` after a prior `A{rank=2, dim=3}`) is a no-op.
+- **Mismatched re-declaration** (different `rank` or `dim`) raises `redeclaration_error`.
+- **Cross-type collision** (`x` as scalar then `x{rank=2, dim=3}` as tensor, or vice versa) raises `type_collision_error`.
+
+### Mixed-domain operator coercion
+
+The supported `tag_invoke` surface is hand-listed in the parser's
+`can_mul` / `can_div` predicates (see `src/numsim_cas/parser/actions.h`).
+The parser is intentionally narrower than the full library coercion
+surface — combinations needed for non-trivial mechanics expressions
+are in, the rest throw `type_mismatch_error`.
+
+`+` and `-` require **same-domain** operands:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `+` `-`  | scalar | scalar | scalar |
+| `+` `-`  | tensor | tensor | tensor |
+| `+` `-`  | t2s    | t2s    | t2s    |
+
+`*` allows scalar-coefficient flow into either tensor side and
+same-domain on t2s:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `*`      | scalar | scalar | scalar |
+| `*`      | scalar | tensor | tensor |
+| `*`      | tensor | scalar | tensor |
+| `*`      | scalar | t2s    | t2s    |
+| `*`      | t2s    | scalar | t2s    |
+| `*`      | t2s    | t2s    | t2s    |
+
+`/` is even narrower — scalar denominators only, plus same-domain
+on t2s:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `/`      | scalar | scalar | scalar |
+| `/`      | tensor | scalar | tensor |
+| `/`      | t2s    | scalar | t2s    |
+| `/`      | t2s    | t2s    | t2s    |
+
+Notable exclusions: `tensor * tensor` (use `inner_product` /
+`dot_product` explicitly), `tensor * t2s` / `t2s * tensor` (no
+auto-coercion in either direction), `tensor / t2s`. The plan
+originally listed broader coverage; the implementation narrowed
+to what `tag_invoke` overloads exist in the codebase today.
+
+## Function Registry
+
+Functions are dispatched through a static table in
+`function_registry.h`. Current entries:
+
+| Group | Functions | Signature |
+|-------|-----------|-----------|
+| Scalar unary | `sin` `cos` `tan` `asin` `acos` `atan` `sinh` `cosh` `tanh` `asinh` `acosh` `atanh` `exp` `log` `log10` `sqrt` `abs` `sign` | scalar → scalar |
+| Scalar binary | `pow` `lt` `le` `gt` `ge` `eq` `ne` | (scalar, scalar) → scalar |
+| Tensor → tensor | `trans` `inv` | tensor → tensor |
+| Tensor → t2s | `trace` `det` `norm` `dot` | tensor → t2s |
+| Contraction → tensor | `inner_product` | (tensor, `[i…]`, tensor, `[i…]`) → tensor |
+| Contraction → t2s | `dot_product` | (tensor, `[i…]`, tensor, `[i…]`) → t2s |
+
+Indices inside `[…]` are **1-based** in the source language and
+converted to 0-based `sequence` internally. Out-of-range index
+validation is deferred to the underlying library at evaluation time.
+
+Still to land (currently throws `unknown_function_error`):
+`max`, `min`, `if_then_else`, `macauley_plus`, `macauley_minus`,
+`heaviside`, `smoothed_macauley`, `dev`, `sym`, `vol`, `skew`,
+`outer_product`. These depend on PRs not yet merged to `main`
+(#207, #208, #209, plus the projector stack).
+
+## Ten Example Expressions
+
+All ten parse against the current registry:
+
+| # | Input | Domain | Notes |
+|---|-------|--------|-------|
+| 1 | `42` | scalar | integer literal |
+| 2 | `3.14` | scalar | decimal literal (locale-independent; no exponent — `1.5e3` is unsupported) |
+| 3 | `sin(x)^2 + cos(x)^2` | scalar | implicit scalar `x`; differentiates to 0 |
+| 4 | `a*x^2 + b*x + c` | scalar | four implicit scalars |
+| 5 | `2 ^ 3 ^ 2` | scalar | right-assoc → 512, not 64 |
+| 6 | `pow(x, 3) - 2*pow(x, 2) + x` | scalar | function-call form of `^`, mixed with scalar `*` |
+| 7 | `lt(x, 0) * x + ge(x, 0) * x` | scalar | comparisons produce `0.0` / `1.0` indicators |
+| 8 | `trace(A{rank=2, dim=3})` | t2s | declares `A`; `diff(., A) = I` |
+| 9 | `2 * trace(A{rank=2, dim=3}) + det(A)` | t2s | scalar coefficients into t2s, declared `A` reused bare |
+| 10 | `inner_product(A{rank=4, dim=3}, [3, 4], B{rank=2, dim=3}, [1, 2])` | tensor | full contraction with 1-based index sequences |
+
+### Eventually-supported
+
+These will parse once the upstream dependencies land — currently they
+raise `unknown_function_error`:
+
+- `if_then_else(gt(x, 0), x, -x)` — would be `abs(x)`; blocked on
+  [#207](https://github.com/NumSim-Stack/numsim-cas/issues/207)
+- `max(0, sin(x))` / `macauley_plus(sin(x))` — blocked on
+  [#208](https://github.com/NumSim-Stack/numsim-cas/issues/208) and
+  [#209](https://github.com/NumSim-Stack/numsim-cas/issues/209)
+- `trans(A{rank=2, dim=3}) + sym(A)` — `sym`/`dev`/`vol`/`skew` blocked on
+  the projector stack (`projection_tensor.h` is unmerged)
+- `outer_product(...)` — no top-level free function on this branch yet
+
+## Error Catalogue
+
+All parser errors inherit from `numsim::cas::parser::parse_error`
+which itself inherits from `cas_error`. Each carries `position()`,
+`line()`, `column()`, and renders `what()` with a snippet plus caret.
+
+| Subclass | When fired | Extra fields |
+|----------|-----------|--------------|
+| `lexical_error` | malformed literal: `[0, …]` (1-based index), bracket-list overflow | — |
+| `syntax_error` | unexpected token, missing `)` / `}` / `]`, premature EOF, zero rank/dim in tensor decl, duplicate `rank=` / `dim=` keyword, PEGTL `must<>` failure | — |
+| `unknown_function_error` | identifier in call position not in the registry | `name()` |
+| `arity_error` | function called with wrong number of arguments | `function()`, `expected_arity()`, `actual_arity()` |
+| `type_mismatch_error` | wrong domain for an operator or function argument (e.g. `sin(A{…})`) | — |
+| `redeclaration_error` | tensor re-declared with mismatched `(rank, dim)` | — |
+| `type_collision_error` | identifier used as both scalar and tensor in either order | — |
+| `unknown_symbol_error` | **currently unreachable from the parser** — every bare identifier in scalar position is implicitly declared. Class exists for potential future strict-mode use; constructed directly by tests. | `name()` |
+
+### Example diagnostic output
+
+```text
+parse error at 1:1: function 'sin' expects 1 argument, got 2
+  sin(x, y)
+  ^
+```
+
+```text
+parse error at 1:7: tensor declaration 'A': rank must be >= 1, got 0
+  trace(A{rank=0, dim=3})
+        ^
+```
+
+## Build
+
+```cmake
+option(NUMSIM_CAS_BUILD_PARSER "Build the PEGTL string parser" OFF)
+```
+
+When ON, the build fetches PEGTL 3.2.8 via FetchContent, compiles
+the `NumSim_CAS_Parser` library, and exposes it as the
+`NumSim_CAS::Parser` alias. Link against both `NumSim_CAS` and
+`NumSim_CAS::Parser` (or just the latter — `NumSim_CAS` is
+transitively re-exported).
+
+The public parser headers (`<numsim_cas/parser/*.h>`) **do not**
+transitively include PEGTL. Consumers that include only those
+headers pay no PEGTL template compile cost; the grammar
+instantiations are contained inside the parser library's
+translation units. The example programs under `examples/` act as
+a lock-in for that constraint.
+
+## Symbol Table Semantics
+
+`symbol_table` is the parser's identifier→holder map.
+
+- **Reentrant** on **distinct** instances — multiple parses can run
+  concurrently if each has its own table.
+- **Not** thread-safe across one shared table.
+- **Non-transactional on parse failure**: declarations that landed
+  before a throw stay in the table. For interactive surfaces (REPL,
+  retry-on-error), discard the table or hold an external snapshot.
+  Tracked as [#222](https://github.com/NumSim-Stack/numsim-cas/issues/222).
+
+## Known Follow-Ups
+
+- [#217](https://github.com/NumSim-Stack/numsim-cas/issues/217) — derive registry `arg_kinds` from dispatch lambda signature (single source of truth)
+- [#221](https://github.com/NumSim-Stack/numsim-cas/issues/221) — umbrella header `numsim_cas/numsim_cas.h` doesn't pull in tensor / t2s diff routes
+- [#222](https://github.com/NumSim-Stack/numsim-cas/issues/222) — transactional symbol_table for interactive parsing

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,24 @@ add_numsim_cas_example(tensor_basics tensor_basics.cpp)
 add_numsim_cas_example(tensor_to_scalar_basics tensor_to_scalar_basics.cpp)
 add_numsim_cas_example(linear_elasticity linear_elasticity.cpp)
 
+# Parser examples — only built when NUMSIM_CAS_BUILD_PARSER=ON, since
+# they link against the parser library target. Beyond demonstrating
+# the public API, these examples act as an include-hygiene check: if
+# any of the public parser headers ever started transitively
+# including PEGTL, that leak would surface here as new symbols in
+# downstream TUs that don't otherwise touch PEGTL.
+macro(add_numsim_cas_parser_example TARGET_NAME)
+    add_executable(${TARGET_NAME} ${ARGN})
+    target_link_libraries(${TARGET_NAME} PRIVATE NumSim_CAS NumSim_CAS::Parser)
+endmacro()
+
+if(NUMSIM_CAS_BUILD_PARSER)
+    add_numsim_cas_parser_example(parser_basics parser_basics.cpp)
+    add_numsim_cas_parser_example(parser_symbol_table parser_symbol_table.cpp)
+    add_numsim_cas_parser_example(parser_error_handling parser_error_handling.cpp)
+    add_numsim_cas_parser_example(parser_tensor_diff parser_tensor_diff.cpp)
+endif()
+
 # Examples with programmatic asserts run as CTest tests so bit-rot is
 # caught in CI. Add new examples here only if they exit non-zero on
 # numerical mismatch.

--- a/examples/parser_basics.cpp
+++ b/examples/parser_basics.cpp
@@ -1,0 +1,45 @@
+// Parser basics — parse a scalar expression, declare variable bindings
+// through the symbol_table the parser populated, and evaluate.
+//
+// Include-hygiene: this file uses only the PUBLIC parser headers
+// (`<numsim_cas/parser/*.h>`). It deliberately does NOT include any
+// PEGTL header. If it builds, the public-headers-don't-leak-PEGTL
+// constraint holds — internal grammar template instantiations stay
+// inside `NumSim_CAS_Parser`'s translation units.
+
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/visitors/scalar_evaluator.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser Basics ===\n\n";
+
+  // Parse a quadratic; implicitly declares a, b, c, x as scalars.
+  cas::parser::symbol_table syms;
+  auto e = cas::parser::parse_scalar("a*x^2 + b*x + c", syms);
+  std::cout << "parsed: " << cas::to_string(e) << "\n";
+  // The printer reorders terms by hash (canonical form), so the
+  // printed expression won't match the input order character for
+  // character — it's the same expression, terms permuted.
+  std::cout << "(printer canonicalizes term order; same expression)\n\n";
+
+  // Evaluate (a=1, b=-3, c=2) at several x; the roots of x^2 - 3x + 2
+  // are 1 and 2.
+  cas::scalar_evaluator<double> ev;
+  ev.set(syms.get_or_declare_scalar("a"), 1.0);
+  ev.set(syms.get_or_declare_scalar("b"), -3.0);
+  ev.set(syms.get_or_declare_scalar("c"), 2.0);
+
+  std::cout << "f(x) = x^2 - 3x + 2 sampled:\n";
+  for (double x : {0.0, 1.0, 1.5, 2.0, 3.0}) {
+    ev.set(syms.get_or_declare_scalar("x"), x);
+    std::cout << "  f(" << x << ") = " << ev.apply(e) << "\n";
+  }
+
+  return 0;
+}

--- a/examples/parser_error_handling.cpp
+++ b/examples/parser_error_handling.cpp
@@ -1,0 +1,81 @@
+// Parser error handling — demonstrate the diagnostic story.
+//
+// Every parse failure raises a specific parse_error subclass. The
+// formatted what() includes a "parse error at line:col:" header, the
+// offending source line, and a caret. Subclasses carry extra fields
+// for structured handling (e.g. unknown_function_error::name(),
+// arity_error::expected_arity()) — useful if you want to surface a
+// custom UI message rather than the default formatted string.
+
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <iostream>
+#include <string_view>
+
+namespace cas = numsim::cas;
+
+// Print a horizontal rule for readability.
+static void rule() { std::cout << "-----\n"; }
+
+// Try to parse; catch each specific subclass and print structured
+// info plus the rendered what(). Falls back to parse_error for any
+// subclass we don't handle explicitly.
+static void try_parse(std::string_view source) {
+  std::cout << "input: " << source << "\n";
+  cas::parser::symbol_table syms;
+  try {
+    [[maybe_unused]] auto e = cas::parser::parse(source, syms);
+    std::cout << "  (parsed successfully)\n";
+  } catch (cas::parser::arity_error const &e) {
+    std::cout << "  arity_error\n";
+    std::cout << "    function       = " << e.function() << "\n";
+    std::cout << "    expected_arity = " << e.expected_arity() << "\n";
+    std::cout << "    actual_arity   = " << e.actual_arity() << "\n";
+    std::cout << e.what() << "\n";
+  } catch (cas::parser::unknown_function_error const &e) {
+    std::cout << "  unknown_function_error\n";
+    std::cout << "    name = " << e.name() << "\n";
+    std::cout << e.what() << "\n";
+  } catch (cas::parser::lexical_error const &e) {
+    std::cout << "  lexical_error\n" << e.what() << "\n";
+  } catch (cas::parser::type_mismatch_error const &e) {
+    std::cout << "  type_mismatch_error\n" << e.what() << "\n";
+  } catch (cas::parser::redeclaration_error const &e) {
+    std::cout << "  redeclaration_error\n" << e.what() << "\n";
+  } catch (cas::parser::type_collision_error const &e) {
+    std::cout << "  type_collision_error\n" << e.what() << "\n";
+  } catch (cas::parser::syntax_error const &e) {
+    std::cout << "  syntax_error\n" << e.what() << "\n";
+  } catch (cas::parser::parse_error const &e) {
+    std::cout << "  parse_error (base)\n" << e.what() << "\n";
+  }
+  std::cout << "\n";
+}
+
+int main() {
+  std::cout << "=== Parser: Error Handling ===\n\n";
+
+  try_parse("sin(x)");
+  rule();
+  try_parse("sin(x, y)"); // arity
+  rule();
+  try_parse("no_such_fn(x)"); // unknown function
+  rule();
+  try_parse("trans(x)"); // type mismatch — trans wants tensor
+  rule();
+  try_parse("sin(x"); // missing close paren
+  rule();
+  try_parse("trace(A{rank=0, dim=3})"); // zero rank from action
+  rule();
+  try_parse("dot_product(A{rank=2, dim=3}, [0, 1], "
+            "B{rank=2, dim=3}, [1, 2])"); // lexical: zero index
+  rule();
+  try_parse("x + x{rank=2, dim=3}"); // scalar then tensor — collision
+  rule();
+  try_parse("trace(A{rank=2, dim=3}) + "
+            "dot(A{rank=4, dim=3})"); // shape mismatch in one parse
+
+  return 0;
+}

--- a/examples/parser_symbol_table.cpp
+++ b/examples/parser_symbol_table.cpp
@@ -1,0 +1,66 @@
+// Parser symbol_table lifecycle — the REPL-style usage pattern.
+//
+// One symbol_table threaded through multiple parse() calls. Tensors
+// declared once via `Name{rank=R, dim=D}` can then be referenced
+// bare in later expressions (lookup-first identifier resolution).
+// Scalars are implicitly declared on first bare use.
+
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser: Symbol Table Lifecycle ===\n\n";
+
+  cas::parser::symbol_table syms;
+
+  // (1) Declare A as a rank-2 tensor on the right of a t2s function.
+  auto e1 = cas::parser::parse_t2s("trace(A{rank=2, dim=3})", syms);
+  std::cout << "1. parsed: " << cas::to_string(e1) << "\n";
+  auto shape = syms.tensor_shape("A");
+  std::cout << "   A registered as rank=" << shape->first
+            << ", dim=" << shape->second << "\n\n";
+
+  // (2) Reuse A bare — same holder resolves through symbol_table.
+  auto e2 = cas::parser::parse_t2s("trace(A) + det(A)", syms);
+  std::cout << "2. parsed: " << cas::to_string(e2) << "\n\n";
+
+  // (3) Mix declared tensor with implicit scalar in one expression.
+  //     `lambda` is bare → implicitly declared as scalar.
+  auto e3 = cas::parser::parse_t2s("lambda * trace(A)", syms);
+  std::cout << "3. parsed: " << cas::to_string(e3) << "\n";
+  std::cout << "   lambda now declared as scalar: " << std::boolalpha
+            << syms.has("lambda") << "\n\n";
+
+  // (4) Identical re-declaration is allowed — same (rank, dim). The
+  //     symbol_table treats this as a no-op: shape stays {2, 3} and
+  //     the bare `A` in subsequent parses still resolves to the
+  //     original holder.
+  auto shape_before = syms.tensor_shape("A");
+  auto e4 = cas::parser::parse_t2s("det(A{rank=2, dim=3})", syms);
+  auto shape_after = syms.tensor_shape("A");
+  std::cout << "4. parsed: " << cas::to_string(e4) << "\n";
+  std::cout << "   shape before re-declaration: rank=" << shape_before->first
+            << ", dim=" << shape_before->second << "\n";
+  std::cout << "   shape after re-declaration:  rank=" << shape_after->first
+            << ", dim=" << shape_after->second
+            << "  (unchanged → re-declaration was a no-op)\n\n";
+
+  // (5) Re-declaring with a DIFFERENT shape throws redeclaration_error.
+  //     Catch and demonstrate the diagnostic.
+  std::cout << "5. attempting A{rank=4, dim=3} (mismatched shape)...\n";
+  try {
+    [[maybe_unused]] auto e5 =
+        cas::parser::parse_tensor("A{rank=4, dim=3}", syms);
+  } catch (cas::parser::redeclaration_error const &e) {
+    std::cout << "   threw redeclaration_error:\n";
+    std::cout << "   " << e.what() << "\n";
+  }
+
+  return 0;
+}

--- a/examples/parser_tensor_diff.cpp
+++ b/examples/parser_tensor_diff.cpp
@@ -1,0 +1,62 @@
+// Parser ↔ rest-of-library — parse a tensor-to-scalar expression,
+// differentiate it w.r.t. the parser-declared tensor variable, print
+// the result.
+//
+// Shows that parser output is a normal `expression_holder` that the
+// existing symbolic algebra (diff, simplification, printing) accepts
+// transparently — there's nothing parser-specific downstream.
+
+#include <numsim_cas/numsim_cas.h>
+// The umbrella header above doesn't currently pull in the
+// tensor-to-scalar diff routing; include it explicitly so
+// `cas::diff(t2s_expr, tensor_holder)` resolves.
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser: Tensor Differentiation ===\n\n";
+
+  // f(A) = trace(A) — d/dA = rank-2 identity tensor I.
+  {
+    cas::parser::symbol_table syms;
+    auto f = cas::parser::parse_t2s("trace(A{rank=2, dim=3})", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto df = cas::diff(f, A);
+    std::cout << "f(A)   = " << cas::to_string(f) << "\n";
+    std::cout << "df/dA  = " << cas::to_string(df) << "  (rank-2 identity)\n\n";
+  }
+
+  // g(A) = trace(A) * trace(A) = (tr A)^2 — d/dA = 2 * trace(A) * I.
+  {
+    cas::parser::symbol_table syms;
+    auto g = cas::parser::parse_t2s("trace(A{rank=2, dim=3}) * trace(A)", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto dg = cas::diff(g, A);
+    std::cout << "g(A)   = " << cas::to_string(g) << "\n";
+    std::cout << "dg/dA  = " << cas::to_string(dg) << "\n\n";
+  }
+
+  // h(A) = norm(A) — d/dA = A / norm(A) mathematically. The printer
+  // reveals the chain rule's literal form: a `pow(norm(A), -1)`
+  // scalar times an `A : I{4}` contraction (A inner-product'd with
+  // the rank-4 identity). Downstream simplification could fold
+  // `A : I{4}` back to `A`, but the diff visitor doesn't perform
+  // that fold inline.
+  {
+    cas::parser::symbol_table syms;
+    auto h = cas::parser::parse_t2s("norm(A{rank=2, dim=3})", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto dh = cas::diff(h, A);
+    std::cout << "h(A)   = " << cas::to_string(h) << "\n";
+    std::cout << "dh/dA  = " << cas::to_string(dh) << "\n";
+    std::cout << "  (≡ A / norm(A); the I{4} contraction is the "
+                 "chain rule's literal form)\n";
+  }
+
+  return 0;
+}

--- a/include/numsim_cas/parser/parse_error.h
+++ b/include/numsim_cas/parser/parse_error.h
@@ -79,6 +79,15 @@ public:
 
 /// An identifier was used where typing forces a tensor (e.g. inside
 /// `trace(...)`), but no tensor by that name has been declared.
+///
+/// @note Currently **unreachable from the parser** — every bare
+/// identifier in scalar position is implicitly declared as a scalar
+/// (see `symbol_table::get_or_declare_scalar`), so the "undeclared
+/// identifier in tensor position" path is never taken. Pinned by
+/// `ParserErrorCoverage.UnknownSymbolErrorIsUnreachableFromParser`.
+/// The class is preserved for a potential future strict mode that
+/// disables implicit scalar declaration, and is exercised directly
+/// at the constructor level by `ParseError.UnknownSymbolErrorCarriesName`.
 class unknown_symbol_error : public parse_error {
 public:
   unknown_symbol_error(std::string name, std::size_t byte_offset,

--- a/include/numsim_cas/parser/parse_error.h
+++ b/include/numsim_cas/parser/parse_error.h
@@ -1,0 +1,151 @@
+#ifndef NUMSIM_CAS_PARSER_PARSE_ERROR_H
+#define NUMSIM_CAS_PARSER_PARSE_ERROR_H
+
+#include <numsim_cas/core/cas_error.h>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace numsim::cas::parser {
+
+/**
+ * @class parse_error
+ * @brief Base class for all errors raised by the string parser.
+ *
+ * Carries a byte offset into the source, a 1-based line and column, and
+ * (when a source string is supplied) renders a snippet-with-caret in
+ * `what()` for direct presentation to the user:
+ *
+ * ```text
+ * parse error at 1:11: expected ')' to close call to 'sin'
+ *   sin(x + 2 + y
+ *             ^
+ * ```
+ *
+ * When constructed without a source (or with an empty source view) the
+ * formatted message degrades to just the body — this is the path used
+ * by `symbol_table` which has no source context. Phase-2 parser
+ * actions will catch and re-throw position-less errors with full
+ * context.
+ *
+ * All subclasses inherit from `cas_error` so calling code can use a
+ * single `catch (cas_error const&)` to handle parsing and evaluation
+ * failures uniformly.
+ */
+class parse_error : public cas_error {
+public:
+  /// Construct with optional source context. Pass an empty `source` and
+  /// `byte_offset = 0` for errors raised outside the parser.
+  parse_error(std::string message, std::size_t byte_offset,
+              std::string_view source);
+
+  /// Byte offset into the source where the error was detected, clamped
+  /// to `source.size()`. Returns 0 if no source was supplied.
+  [[nodiscard]] std::size_t position() const noexcept { return m_pos; }
+
+  /// 1-based line number. Returns 1 if no source was supplied.
+  [[nodiscard]] std::size_t line() const noexcept { return m_line; }
+
+  /// 1-based column number within the line. Returns 1 if no source
+  /// was supplied.
+  [[nodiscard]] std::size_t column() const noexcept { return m_col; }
+
+  /// True if a non-empty source view was supplied at construction.
+  /// When false, `what()` contains just the body — no line/column or
+  /// snippet rendering.
+  [[nodiscard]] bool has_position() const noexcept { return m_has_position; }
+
+protected:
+  std::size_t m_pos = 0;
+  std::size_t m_line = 1;
+  std::size_t m_col = 1;
+  bool m_has_position = false;
+};
+
+/// Lexer-level error: unrecognised character, malformed numeric literal,
+/// etc. Raised before any grammar rule could match.
+class lexical_error : public parse_error {
+public:
+  using parse_error::parse_error;
+};
+
+/// Grammar-level error: unexpected token, missing closing
+/// paren/brace/bracket, premature end of input.
+class syntax_error : public parse_error {
+public:
+  using parse_error::parse_error;
+};
+
+/// An identifier was used where typing forces a tensor (e.g. inside
+/// `trace(...)`), but no tensor by that name has been declared.
+class unknown_symbol_error : public parse_error {
+public:
+  unknown_symbol_error(std::string name, std::size_t byte_offset,
+                       std::string_view source);
+
+  [[nodiscard]] std::string const &name() const noexcept { return m_name; }
+
+private:
+  std::string m_name;
+};
+
+/// A function name appeared in call position but is not in the
+/// parser's known-functions registry.
+class unknown_function_error : public parse_error {
+public:
+  unknown_function_error(std::string name, std::size_t byte_offset,
+                         std::string_view source);
+
+  [[nodiscard]] std::string const &name() const noexcept { return m_name; }
+
+private:
+  std::string m_name;
+};
+
+/// A function was called with the wrong number of arguments.
+class arity_error : public parse_error {
+public:
+  arity_error(std::string function_name, std::size_t expected_arity,
+              std::size_t actual_arity, std::size_t byte_offset,
+              std::string_view source);
+
+  [[nodiscard]] std::string const &function() const noexcept {
+    return m_function;
+  }
+  [[nodiscard]] std::size_t expected_arity() const noexcept {
+    return m_expected;
+  }
+  [[nodiscard]] std::size_t actual_arity() const noexcept { return m_actual; }
+
+private:
+  std::string m_function;
+  std::size_t m_expected;
+  std::size_t m_actual;
+};
+
+/// An operator was applied to operand types it does not support
+/// (e.g. `sin(A)` where `A` is a tensor, or `tensor + scalar` which is
+/// not in the codebase's `tag_invoke` surface).
+class type_mismatch_error : public parse_error {
+public:
+  using parse_error::parse_error;
+};
+
+/// A tensor was re-declared with a different rank or dim than its
+/// prior declaration. Raised by `symbol_table::get_or_declare_tensor`.
+class redeclaration_error : public parse_error {
+public:
+  using parse_error::parse_error;
+};
+
+/// An identifier was used as both a scalar and a tensor (in either
+/// order). Raised by `symbol_table`.
+class type_collision_error : public parse_error {
+public:
+  using parse_error::parse_error;
+};
+
+} // namespace numsim::cas::parser
+
+#endif // NUMSIM_CAS_PARSER_PARSE_ERROR_H

--- a/include/numsim_cas/parser/parser.h
+++ b/include/numsim_cas/parser/parser.h
@@ -1,0 +1,88 @@
+#ifndef NUMSIM_CAS_PARSER_PARSER_H
+#define NUMSIM_CAS_PARSER_PARSER_H
+
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/scalar_expression.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+
+#include <string_view>
+#include <variant>
+
+namespace numsim::cas::parser {
+
+/**
+ * @brief Result of `parse()` — a discriminated union over the three
+ *        expression domains.
+ *
+ * The variant alternative tells the caller which domain the top-level
+ * expression landed in. Use `std::visit` or `std::holds_alternative`
+ * to dispatch, or one of the `parse_scalar` / `parse_tensor` /
+ * `parse_t2s` convenience wrappers if you already know which domain
+ * to expect.
+ */
+using parsed_expression =
+    std::variant<expression_holder<scalar_expression>,
+                 expression_holder<tensor_expression>,
+                 expression_holder<tensor_to_scalar_expression>>;
+
+/**
+ * @brief Parse `source` into an expression, populating `syms` with any
+ *        identifier declarations encountered during the parse.
+ *
+ * Identifiers are typed lazily:
+ *   - Bare identifiers (`x`, `velocity`) are scalar variables, declared
+ *     implicitly on first use.
+ *   - `Name{rank=R, dim=D}` is a tensor declaration. Subsequent bare
+ *     references to `Name` resolve to the same tensor.
+ *
+ * Re-declarations must match; cross-type collisions are rejected. See
+ * `symbol_table` for the full rules.
+ *
+ * @throws parse_error (or any subclass) on lexical / syntactic /
+ *         semantic failure. The exception's `what()` includes a
+ *         snippet-with-caret rendering of the offending source line.
+ *
+ * **Symbol-table semantics on failure**: declarations are
+ * non-transactional — anything declared before the failure stays in
+ * `syms`. Caller can discard the table for all-or-nothing semantics.
+ *
+ * **Thread-safety**: not reentrant on the same `symbol_table`. Use
+ * one table per concurrent parse, or guard with external
+ * synchronisation.
+ */
+[[nodiscard]] parsed_expression parse(std::string_view source,
+                                      symbol_table &syms);
+
+/**
+ * @brief Parse and require a scalar result.
+ *
+ * @throws type_mismatch_error if the parsed expression is not in the
+ *         scalar domain.
+ * @throws parse_error (or subclass) on parse failure.
+ */
+[[nodiscard]] expression_holder<scalar_expression>
+parse_scalar(std::string_view source, symbol_table &syms);
+
+/**
+ * @brief Parse and require a tensor result.
+ *
+ * @throws type_mismatch_error if the parsed expression is not in the
+ *         tensor domain.
+ */
+[[nodiscard]] expression_holder<tensor_expression>
+parse_tensor(std::string_view source, symbol_table &syms);
+
+/**
+ * @brief Parse and require a tensor-to-scalar result.
+ *
+ * @throws type_mismatch_error if the parsed expression is not in the
+ *         tensor-to-scalar domain.
+ */
+[[nodiscard]] expression_holder<tensor_to_scalar_expression>
+parse_t2s(std::string_view source, symbol_table &syms);
+
+} // namespace numsim::cas::parser
+
+#endif // NUMSIM_CAS_PARSER_PARSER_H

--- a/include/numsim_cas/parser/symbol_table.h
+++ b/include/numsim_cas/parser/symbol_table.h
@@ -89,6 +89,18 @@ public:
   [[nodiscard]] std::optional<std::pair<std::size_t, std::size_t>>
   tensor_shape(std::string_view name) const;
 
+  /// Result of `get(name)` — a variant over the two declarable
+  /// holder types. Used by the parser's identifier action to
+  /// dispatch on the existing declaration's type instead of forcing
+  /// scalar.
+  using lookup_result = std::variant<expression_holder<scalar_expression>,
+                                     expression_holder<tensor_expression>>;
+
+  /// Look up an existing declaration. Returns `nullopt` if `name` is
+  /// unknown. Does NOT implicitly declare anything — distinct from
+  /// `get_or_declare_scalar`.
+  [[nodiscard]] std::optional<lookup_result> get(std::string_view name) const;
+
   /// Number of declarations currently in the table.
   [[nodiscard]] std::size_t size() const noexcept { return m_entries.size(); }
 

--- a/include/numsim_cas/parser/symbol_table.h
+++ b/include/numsim_cas/parser/symbol_table.h
@@ -1,0 +1,111 @@
+#ifndef NUMSIM_CAS_PARSER_SYMBOL_TABLE_H
+#define NUMSIM_CAS_PARSER_SYMBOL_TABLE_H
+
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/scalar/scalar_expression.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+
+namespace numsim::cas::parser {
+
+/**
+ * @class symbol_table
+ * @brief Maps identifier names to scalar / tensor variable holders,
+ *        populated on the fly as the parser encounters identifiers.
+ *
+ * Lookup rules:
+ *  - **Scalars** are declared implicitly on first reference. Calling
+ *    `get_or_declare_scalar("x")` creates the holder if absent,
+ *    returns the same holder on every subsequent call.
+ *  - **Tensors** must be declared explicitly via
+ *    `get_or_declare_tensor("A", rank=2, dim=3)`. Subsequent calls
+ *    with the same (rank, dim) return the same holder. Mismatched
+ *    (rank, dim) on re-declaration raise `redeclaration_error`.
+ *
+ * Cross-type rules:
+ *  - Using an identifier as a scalar after it was declared as a tensor
+ *    (or vice versa) raises `type_collision_error`.
+ *
+ * Errors raised from `symbol_table` carry no source position — they
+ * are constructed with an empty source view. When the parser is the
+ * caller, Phase-2 actions catch and re-throw with full position
+ * context. Direct user calls receive position-less errors with a
+ * descriptive message.
+ *
+ * **Thread-safety**: instances are not thread-safe. Multiple parses
+ * sharing one table is undefined behaviour. Use one table per parse,
+ * or guard with external synchronisation.
+ *
+ * **Persistence on parse failure**: declarations are committed as
+ * they happen. If parsing throws partway through, declarations made
+ * up to that point remain in the table. Callers that want
+ * all-or-nothing semantics should discard the table and start over
+ * on failure.
+ */
+class symbol_table {
+public:
+  symbol_table() = default;
+  symbol_table(symbol_table const &) = default;
+  symbol_table(symbol_table &&) noexcept = default;
+  symbol_table &operator=(symbol_table const &) = default;
+  symbol_table &operator=(symbol_table &&) noexcept = default;
+  ~symbol_table() = default;
+
+  /**
+   * @brief Look up an existing scalar declaration or declare a new one.
+   *
+   * @throws type_collision_error if `name` was previously declared
+   *         as a tensor.
+   */
+  expression_holder<scalar_expression>
+  get_or_declare_scalar(std::string_view name);
+
+  /**
+   * @brief Look up an existing tensor declaration or declare a new one.
+   *
+   * On re-declaration the (rank, dim) must match the prior values.
+   *
+   * @throws redeclaration_error if `name` was previously declared as
+   *         a tensor with different (rank, dim).
+   * @throws type_collision_error if `name` was previously declared
+   *         as a scalar.
+   */
+  expression_holder<tensor_expression>
+  get_or_declare_tensor(std::string_view name, std::size_t rank,
+                        std::size_t dim);
+
+  /// True if any declaration exists for the given name.
+  [[nodiscard]] bool has(std::string_view name) const noexcept;
+
+  /// If `name` is a tensor, returns `{rank, dim}`; otherwise `nullopt`.
+  /// `nullopt` is also returned for an unknown name or a scalar.
+  [[nodiscard]] std::optional<std::pair<std::size_t, std::size_t>>
+  tensor_shape(std::string_view name) const;
+
+  /// Number of declarations currently in the table.
+  [[nodiscard]] std::size_t size() const noexcept { return m_entries.size(); }
+
+private:
+  struct scalar_entry {
+    expression_holder<scalar_expression> expr;
+  };
+  struct tensor_entry {
+    expression_holder<tensor_expression> expr;
+    std::size_t rank;
+    std::size_t dim;
+  };
+  using entry = std::variant<scalar_entry, tensor_entry>;
+
+  std::unordered_map<std::string, entry> m_entries;
+};
+
+} // namespace numsim::cas::parser
+
+#endif // NUMSIM_CAS_PARSER_SYMBOL_TABLE_H

--- a/src/numsim_cas/parser/actions.h
+++ b/src/numsim_cas/parser/actions.h
@@ -1,0 +1,699 @@
+#ifndef NUMSIM_CAS_PARSER_ACTIONS_H
+#define NUMSIM_CAS_PARSER_ACTIONS_H
+
+// PEGTL actions for the numsim-cas expression parser (issue #214).
+//
+// SRC-PRIVATE header — includes PEGTL and pulls in factory functions
+// across all three expression domains.
+//
+// Design: a single value-stack of `parsed_expression` variants.
+// Operand-level rules (number_literal, identifier, paren_expression)
+// push exactly one value when they match. Operator-tail rules
+// (mul_tail, add_tail) push the right operand THEN combine it with
+// the previous top using the matched operator — so by the time the
+// outer `mul_term` / `add_term` finishes, the top of the stack is
+// the fully-folded result of that precedence level.
+//
+// Phase 2a: numbers, identifiers, + - * /. No mixed-domain coercion
+// yet (phase 2d wires up the full type-coercion table); for now
+// every value on the stack is scalar.
+
+#include "function_registry.h"
+#include "grammar.h"
+
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/scalar_operators.h>
+#include <numsim_cas/scalar/scalar_std.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
+
+#include <tao/pegtl.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace numsim::cas::parser::actions {
+
+namespace pegtl = tao::pegtl;
+
+/**
+ * @struct parser_state
+ * @brief Mutable state threaded through every PEGTL action.
+ *
+ * Holds:
+ *   - the value stack (variants of holder types across the three domains),
+ *   - a reference to the caller-supplied symbol_table,
+ *   - the original source view (for error rendering).
+ *
+ * The operator-tail rules (`mul_tail_star`, `add_tail_plus`, …) are
+ * split per-operator in the grammar so each action template
+ * specialisation knows its op statically. No `pending_op` field is
+ * needed — that approach was attempted and was fragile under nested
+ * operator firings.
+ */
+struct parser_state {
+  // Phase 2e: values stack is the wider `registry::parser_value`
+  // variant (parsed_expression alternatives + index_list_value) so
+  // bracket-list args can flow through the same stack as
+  // expressions. At the end of `parse()`, the final stack entry
+  // must be one of the three expression alternatives — an
+  // index_list_value at the top is a syntax error (caught
+  // explicitly in parser.cpp).
+  std::vector<registry::parser_value> values;
+
+  // Stack of value-stack depths at function-call '(' marks. Pushed by
+  // `function_call_open`'s action, popped by `function_call`'s — the
+  // difference between the current size and the popped mark is the
+  // number of arguments pushed by the enclosed expression list.
+  // Stack-of-marks supports nested calls like `max(sin(x), cos(x))`.
+  std::vector<std::size_t> arg_marks;
+
+  // Pending kv pairs for the current tensor declaration. Both must be
+  // present by the time the closing brace fires the tensor_decl
+  // action. Flat fields (not a stack) because tensor_decl bodies
+  // can't nest — the RHS of `rank=` / `dim=` must be an integer
+  // literal, not an expression.
+  std::optional<std::size_t> pending_rank;
+  std::optional<std::size_t> pending_dim;
+
+  symbol_table &syms;
+  std::string_view source;
+
+  explicit parser_state(symbol_table &s, std::string_view src) noexcept
+      : syms(s), source(src) {}
+};
+
+// Helper: extract a scalar holder from a value-stack entry. Used by
+// scalar-only operators (+, -, ^, comparisons, unary -). The stack
+// now holds `parser_value` which includes `index_list_value`; that
+// alternative is rejected here (operators can't take index lists).
+inline expression_holder<scalar_expression> &
+require_scalar(registry::parser_value &v, std::size_t pos,
+               std::string_view source) {
+  if (auto *s = std::get_if<expression_holder<scalar_expression>>(&v))
+    return *s;
+  throw type_mismatch_error("operator expects scalar operands; got non-scalar",
+                            pos, source);
+}
+
+// Same-domain combinator: lhs OP rhs only when both values are in
+// the SAME alternative AND that alternative is an expression
+// (not index_list_value). Used by +, -, and the comparison
+// operators.
+template <typename Op>
+void combine_same_domain(parser_state &state, std::size_t pos, Op &&op,
+                         char const *op_name) {
+  if (state.values.size() < 2) {
+    throw syntax_error("operator missing left or right operand", pos,
+                       state.source);
+  }
+  auto rhs = std::move(state.values.back());
+  state.values.pop_back();
+  auto lhs = std::move(state.values.back());
+  state.values.pop_back();
+  // Reject index_list_value either side — operators don't take
+  // bracket-lists.
+  if (std::holds_alternative<registry::index_list_value>(lhs) ||
+      std::holds_alternative<registry::index_list_value>(rhs)) {
+    throw type_mismatch_error(std::string("operator '") + op_name +
+                                  "' does not accept bracket-list arguments",
+                              pos, state.source);
+  }
+  if (lhs.index() != rhs.index()) {
+    throw type_mismatch_error(std::string("operator '") + op_name +
+                                  "' requires both operands in the same domain "
+                                  "(scalar+scalar, tensor+tensor, or t2s+t2s)",
+                              pos, state.source);
+  }
+  state.values.emplace_back(std::visit(
+      [&](auto &&l, auto &&r) -> registry::parser_value {
+        using L = std::decay_t<decltype(l)>;
+        using R = std::decay_t<decltype(r)>;
+        if constexpr (std::is_same_v<L, registry::index_list_value> ||
+                      std::is_same_v<R, registry::index_list_value>) {
+          // Unreachable — guarded above. The throw exists so the
+          // lambda compiles for those instantiations; if it ever
+          // does fire (logic bug), the message + real position keep
+          // the diagnostic useful instead of pointing at byte 0.
+          throw type_mismatch_error("internal: index_list slipped past guard",
+                                    pos, state.source);
+        } else if constexpr (std::is_same_v<L, R>) {
+          return op(std::move(l), std::move(r));
+        } else {
+          // Unreachable — guarded by lhs.index() == rhs.index() above.
+          throw type_mismatch_error("internal: domain mismatch slipped past "
+                                    "same-domain guard",
+                                    0, std::string_view{});
+        }
+      },
+      std::move(lhs), std::move(rhs)));
+}
+
+// Scalar-only combinator: both operands must be scalar. Used by ^
+// (power) and the six comparison operators.
+template <typename Op>
+void combine_scalar_only(parser_state &state, std::size_t pos, Op &&op) {
+  if (state.values.size() < 2) {
+    throw syntax_error("operator missing left or right operand", pos,
+                       state.source);
+  }
+  auto rhs = require_scalar(state.values.back(), pos, state.source);
+  state.values.pop_back();
+  auto lhs = require_scalar(state.values.back(), pos, state.source);
+  state.values.pop_back();
+  state.values.emplace_back(op(std::move(lhs), std::move(rhs)));
+}
+
+// Compile-time table: which (L, R) pairs the codebase's `operator*`
+// supports as a user-facing call producing a valid result holder.
+// We hand-list rather than relying on `requires { l * r; }` SFINAE
+// because the codebase's `cas_binary_op` concept is permissive
+// enough to admit some pairs whose body then fails — the failure
+// is inside the operator, not at overload resolution, so SFINAE
+// doesn't filter it. Hand-listing matches the documented
+// type-coercion table in the plan.
+template <typename L, typename R>
+constexpr bool can_mul =
+    (std::is_same_v<L, expression_holder<scalar_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<scalar_expression>> &&
+     std::is_same_v<R, expression_holder<tensor_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<scalar_expression>> &&
+     std::is_same_v<R, expression_holder<tensor_to_scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_to_scalar_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_to_scalar_expression>> &&
+     std::is_same_v<R, expression_holder<tensor_to_scalar_expression>>);
+
+// `operator/` has a NARROWER set: scalar denominators only, plus
+// the (t2s,t2s) same-domain case. (s/t) and (s/t2s) intentionally
+// excluded — these aren't in the codebase's tag_invoke surface.
+template <typename L, typename R>
+constexpr bool can_div =
+    (std::is_same_v<L, expression_holder<scalar_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_to_scalar_expression>> &&
+     std::is_same_v<R, expression_holder<scalar_expression>>) ||
+    (std::is_same_v<L, expression_holder<tensor_to_scalar_expression>> &&
+     std::is_same_v<R, expression_holder<tensor_to_scalar_expression>>);
+
+// Mixed-domain `*`: use `can_mul` table. The `can_mul` predicate is
+// false for any pair involving `index_list_value`, so those fall
+// into the else branch and throw — no extra guard needed.
+template <typename Op>
+void combine_mul(parser_state &state, std::size_t pos, Op &&op) {
+  if (state.values.size() < 2) {
+    throw syntax_error("operator missing left or right operand", pos,
+                       state.source);
+  }
+  auto rhs = std::move(state.values.back());
+  state.values.pop_back();
+  auto lhs = std::move(state.values.back());
+  state.values.pop_back();
+  state.values.emplace_back(std::visit(
+      [&](auto &&l, auto &&r) -> registry::parser_value {
+        using L = std::decay_t<decltype(l)>;
+        using R = std::decay_t<decltype(r)>;
+        if constexpr (can_mul<L, R>) {
+          return op(std::move(l), std::move(r));
+        } else {
+          throw type_mismatch_error(
+              "operator '*' is not defined for this combination of "
+              "operand types",
+              pos, state.source);
+        }
+      },
+      std::move(lhs), std::move(rhs)));
+}
+
+// Mixed-domain `/`: use `can_div` table.
+template <typename Op>
+void combine_div(parser_state &state, std::size_t pos, Op &&op) {
+  if (state.values.size() < 2) {
+    throw syntax_error("operator missing left or right operand", pos,
+                       state.source);
+  }
+  auto rhs = std::move(state.values.back());
+  state.values.pop_back();
+  auto lhs = std::move(state.values.back());
+  state.values.pop_back();
+  state.values.emplace_back(std::visit(
+      [&](auto &&l, auto &&r) -> registry::parser_value {
+        using L = std::decay_t<decltype(l)>;
+        using R = std::decay_t<decltype(r)>;
+        if constexpr (can_div<L, R>) {
+          return op(std::move(l), std::move(r));
+        } else {
+          throw type_mismatch_error(
+              "operator '/' is not defined for this combination of "
+              "operand types",
+              pos, state.source);
+        }
+      },
+      std::move(lhs), std::move(rhs)));
+}
+
+// Pop the top scalar operand and replace it with op(top). Used by
+// unary minus (scalar-only on this branch).
+template <typename Op>
+void replace_top(parser_state &state, std::size_t pos, Op &&op) {
+  if (state.values.empty()) {
+    throw syntax_error("unary operator missing operand", pos, state.source);
+  }
+  auto v = require_scalar(state.values.back(), pos, state.source);
+  state.values.pop_back();
+  state.values.emplace_back(op(std::move(v)));
+}
+
+// ─── Default action: do nothing ───────────────────────────────────
+template <typename Rule> struct action : pegtl::nothing<Rule> {};
+
+// ─── Operand actions ──────────────────────────────────────────────
+
+// number_literal: parse the matched range with std::from_chars (locale-
+// independent) and push a scalar_constant.
+template <> struct action<grammar::number_literal> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    auto sv = in.string_view();
+    // Decimal point in the matched range tells us it's a double.
+    if (sv.find('.') != std::string_view::npos) {
+      double value = 0.0;
+      auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+      if (ec != std::errc{} || ptr != sv.data() + sv.size()) {
+        throw lexical_error("malformed decimal literal", in.position().byte,
+                            state.source);
+      }
+      state.values.emplace_back(make_scalar_constant(value));
+    } else {
+      std::int64_t value = 0;
+      auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+      if (ec != std::errc{} || ptr != sv.data() + sv.size()) {
+        throw lexical_error("malformed integer literal", in.position().byte,
+                            state.source);
+      }
+      state.values.emplace_back(make_scalar_constant(value));
+    }
+  }
+};
+
+// identifier: look up the symbol table first — if `name` already
+// exists, push the existing entry (scalar or tensor). Only declare
+// as a fresh scalar when the name is unknown. This lets the user
+// do `A{rank=2, dim=3}` once and then refer to `A` bare in the
+// rest of the expression.
+template <> struct action<grammar::identifier> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    auto name = in.string_view();
+    if (auto existing = state.syms.get(name)) {
+      std::visit([&](auto const &expr) { state.values.emplace_back(expr); },
+                 *existing);
+      return;
+    }
+    try {
+      auto expr = state.syms.get_or_declare_scalar(name);
+      state.values.emplace_back(std::move(expr));
+    } catch (parse_error const &e) {
+      // symbol_table threw a position-less error; re-throw with our
+      // input context attached. Shouldn't fire on the get-first path
+      // but kept defensively.
+      throw type_collision_error(e.what(), in.position().byte, state.source);
+    }
+  }
+};
+
+// ─── Per-op tail actions ──────────────────────────────────────────
+// Each rule is one specific operator paired with its RHS operand, so
+// the action knows which op fired statically.
+
+template <> struct action<grammar::mul_tail_star> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_mul(state, in.position().byte,
+                [](auto &&a, auto &&b) { return a * b; });
+  }
+};
+template <> struct action<grammar::mul_tail_slash> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_div(state, in.position().byte,
+                [](auto &&a, auto &&b) { return a / b; });
+  }
+};
+template <> struct action<grammar::add_tail_plus> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_same_domain(
+        state, in.position().byte, [](auto &&a, auto &&b) { return a + b; },
+        "+");
+  }
+};
+template <> struct action<grammar::add_tail_minus> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_same_domain(
+        state, in.position().byte, [](auto &&a, auto &&b) { return a - b; },
+        "-");
+  }
+};
+
+// ─── Power (right-associative) ────────────────────────────────────
+// `power_tail` matches `^ <power>` where the inner `power` recurses
+// — by the time this action fires, the inner power has fully
+// reduced and pushed its result. So the stack has [..., lhs, rhs].
+template <> struct action<grammar::power_tail> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return pow(a, b); });
+  }
+};
+
+// ─── Unary minus ──────────────────────────────────────────────────
+// `unary_minus` is `'-' unary` (right-recursive). The inner `unary`
+// pushes the value first; we replace the top with its negation.
+template <> struct action<grammar::unary_minus> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    replace_top(state, in.position().byte, [](auto &&v) { return -v; });
+  }
+};
+
+// ─── Comparison ops ───────────────────────────────────────────────
+// Each comparison combines two scalars into a scalar indicator
+// (1.0 / 0.0) via the codebase's `lt`/`gt`/`le`/`ge`/`eq`/`ne` free
+// functions (Option B predicates from #136).
+template <> struct action<grammar::cmp_tail_lt> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return lt(a, b); });
+  }
+};
+template <> struct action<grammar::cmp_tail_le> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return le(a, b); });
+  }
+};
+template <> struct action<grammar::cmp_tail_gt> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return gt(a, b); });
+  }
+};
+template <> struct action<grammar::cmp_tail_ge> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return ge(a, b); });
+  }
+};
+template <> struct action<grammar::eq_tail_eq> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return eq(a, b); });
+  }
+};
+template <> struct action<grammar::eq_tail_ne> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    combine_scalar_only(state, in.position().byte,
+                        [](auto &&a, auto &&b) { return ne(a, b); });
+  }
+};
+
+// ─── Function calls ───────────────────────────────────────────────
+// The opening '(' of a function call records the current value-stack
+// depth. By the time the matching ')' fires the function_call action,
+// values pushed since the mark are exactly the call's arguments.
+
+template <> struct action<grammar::function_call_open> {
+  static void apply0(parser_state &state) {
+    state.arg_marks.push_back(state.values.size());
+  }
+};
+
+template <> struct action<grammar::function_call> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    auto pos = in.position().byte;
+    auto matched = in.string_view();
+
+    // Function name = matched range up to first non-identifier char.
+    std::size_t name_end = 0;
+    while (name_end < matched.size() &&
+           (std::isalnum(static_cast<unsigned char>(matched[name_end])) ||
+            matched[name_end] == '_')) {
+      ++name_end;
+    }
+    std::string name(matched.substr(0, name_end));
+
+    // Pop the arg mark recorded by function_call_open's action.
+    if (state.arg_marks.empty()) {
+      throw syntax_error("internal: missing arg-mark for function call", pos,
+                         state.source);
+    }
+    auto mark = state.arg_marks.back();
+    state.arg_marks.pop_back();
+    auto arg_count = state.values.size() - mark;
+
+    // Resolve in the polymorphic registry.
+    auto const &reg = registry::function_registry();
+    auto it = reg.find(name);
+    if (it == reg.end()) {
+      throw unknown_function_error(std::move(name), pos, state.source);
+    }
+    auto const &entry = it->second;
+    if (arg_count != entry.arg_kinds.size()) {
+      throw arity_error(std::move(name), entry.arg_kinds.size(), arg_count, pos,
+                        state.source);
+    }
+
+    // Collect args in source order. The stack has them in push order
+    // (= source order); pop from back and reverse at the end.
+    registry::arg_vec args;
+    args.reserve(arg_count);
+    for (std::size_t i = 0; i < arg_count; ++i) {
+      args.push_back(std::move(state.values.back()));
+      state.values.pop_back();
+    }
+    std::reverse(args.begin(), args.end());
+
+    // Type-check each arg against the entry's declared kinds before
+    // calling dispatch — dispatch uses unchecked `std::get` so a
+    // mismatch here would throw `std::bad_variant_access` rather
+    // than our nicer type_mismatch_error.
+    for (std::size_t i = 0; i < arg_count; ++i) {
+      bool ok = false;
+      switch (entry.arg_kinds[i]) {
+      case registry::arg_kind::scalar:
+        ok = std::holds_alternative<expression_holder<scalar_expression>>(
+            args[i]);
+        break;
+      case registry::arg_kind::tensor:
+        ok = std::holds_alternative<expression_holder<tensor_expression>>(
+            args[i]);
+        break;
+      case registry::arg_kind::index_list:
+        ok = std::holds_alternative<registry::index_list_value>(args[i]);
+        break;
+      }
+      if (!ok) {
+        throw type_mismatch_error(
+            "function '" + name + "': argument " + std::to_string(i + 1) +
+                " has wrong type for the expected signature",
+            pos, state.source);
+      }
+    }
+
+    // Dispatch returns `parsed_expression` (3-variant); convert up to
+    // the wider `parser_value` (4-variant) before pushing onto the
+    // parser-internal stack.
+    auto result = entry.dispatch(std::move(args));
+    state.values.emplace_back(std::visit(
+        [](auto &&v) -> registry::parser_value { return std::move(v); },
+        std::move(result)));
+  }
+};
+
+// ─── Bracket-list index literal: [i1, i2, ...] ────────────────────
+// Parses the matched range, extracting digit runs as 1-based indices.
+// Pushes an index_list_value onto the parser-internal value stack
+// for the enclosing function_call action to consume.
+//
+// The grammar's `list<integer_literal, ...>` guarantees at least one
+// integer matched before this action fires, so we don't re-check for
+// emptiness here.
+template <> struct action<grammar::index_list_literal> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    auto pos = in.position().byte;
+    auto sv = in.string_view();
+    registry::index_list_value v;
+    std::size_t i = 0;
+    while (i < sv.size()) {
+      if (std::isdigit(static_cast<unsigned char>(sv[i]))) {
+        std::size_t j = i;
+        while (j < sv.size() &&
+               std::isdigit(static_cast<unsigned char>(sv[j]))) {
+          ++j;
+        }
+        std::size_t value = 0;
+        auto [ptr, ec] = std::from_chars(sv.data() + i, sv.data() + j, value);
+        if (ec == std::errc::result_out_of_range) {
+          throw lexical_error(
+              "index in bracket-list exceeds maximum representable value",
+              pos + i, state.source);
+        }
+        if (ec != std::errc{} || value < 1) {
+          throw lexical_error(
+              "index in bracket-list must be a positive 1-based integer",
+              pos + i, state.source);
+        }
+        v.indices.push_back(value);
+        i = j;
+      } else {
+        ++i;
+      }
+    }
+    state.values.emplace_back(std::move(v));
+  }
+};
+
+// ─── Tensor declarations: A{rank=R, dim=D} ────────────────────────
+// `rank_kv` / `dim_kv` actions parse the matched integer literal and
+// store it in parser_state. `tensor_decl` consumes both, declares
+// the tensor in the symbol_table, and pushes the holder.
+
+namespace detail_kv {
+inline std::size_t parse_kv_integer(std::string_view matched, std::size_t pos,
+                                    std::string_view source) {
+  // The matched range starts with the keyword ('rank' or 'dim'),
+  // contains ws + '=' + ws, then the integer literal at the end.
+  // Scan backwards for the start of the digit run.
+  std::size_t end = matched.size();
+  while (end > 0 &&
+         std::isdigit(static_cast<unsigned char>(matched[end - 1]))) {
+    --end;
+  }
+  std::size_t start = end;
+  while (start < matched.size() &&
+         std::isdigit(static_cast<unsigned char>(matched[start]))) {
+    ++start;
+  }
+  if (start == end) {
+    throw lexical_error("internal: kv value missing digit run", pos, source);
+  }
+  std::size_t value = 0;
+  auto const *first = matched.data() + end;
+  auto const *last = matched.data() + start;
+  auto [ptr, ec] = std::from_chars(first, last, value);
+  if (ec != std::errc{}) {
+    throw lexical_error("malformed integer in tensor declaration", pos, source);
+  }
+  return value;
+}
+} // namespace detail_kv
+
+template <> struct action<grammar::rank_kv> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    if (state.pending_rank.has_value()) {
+      throw syntax_error("tensor declaration: duplicate 'rank=' keyword",
+                         in.position().byte, state.source);
+    }
+    state.pending_rank = detail_kv::parse_kv_integer(
+        in.string_view(), in.position().byte, state.source);
+  }
+};
+template <> struct action<grammar::dim_kv> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    if (state.pending_dim.has_value()) {
+      throw syntax_error("tensor declaration: duplicate 'dim=' keyword",
+                         in.position().byte, state.source);
+    }
+    state.pending_dim = detail_kv::parse_kv_integer(
+        in.string_view(), in.position().byte, state.source);
+  }
+};
+
+template <> struct action<grammar::tensor_decl> {
+  template <typename Input>
+  static void apply(Input const &in, parser_state &state) {
+    auto pos = in.position().byte;
+    auto matched = in.string_view();
+    // Tensor name = matched range up to first non-identifier char.
+    std::size_t name_end = 0;
+    while (name_end < matched.size() &&
+           (std::isalnum(static_cast<unsigned char>(matched[name_end])) ||
+            matched[name_end] == '_')) {
+      ++name_end;
+    }
+    std::string name(matched.substr(0, name_end));
+
+    if (!state.pending_rank.has_value() || !state.pending_dim.has_value()) {
+      // Defensive: even though if_must should have caught the missing
+      // brace path, reset pending fields before throwing in case some
+      // partial state lingers from a prior failed kv match.
+      state.pending_rank.reset();
+      state.pending_dim.reset();
+      throw syntax_error("tensor declaration '" + name +
+                             "{…}' must specify both rank= and dim=",
+                         pos, state.source);
+    }
+    auto rank = *state.pending_rank;
+    auto dim = *state.pending_dim;
+    state.pending_rank.reset();
+    state.pending_dim.reset();
+
+    // Validate rank and dim before handing to the tensor constructor.
+    // The constructor takes both verbatim; without this check, rank=0
+    // or dim=0 silently builds a degenerate tensor that explodes
+    // downstream at a confusing site.
+    if (rank == 0) {
+      throw syntax_error("tensor declaration '" + name +
+                             "': rank must be >= 1, got 0",
+                         pos, state.source);
+    }
+    if (dim == 0) {
+      throw syntax_error("tensor declaration '" + name +
+                             "': dim must be >= 1, got 0",
+                         pos, state.source);
+    }
+
+    try {
+      auto expr = state.syms.get_or_declare_tensor(name, rank, dim);
+      state.values.emplace_back(std::move(expr));
+    } catch (parse_error const &e) {
+      // symbol_table threw position-less; re-throw with our pos.
+      // dynamic_cast preserves the redeclaration_error subtype so a
+      // caller can pattern-match on the error kind.
+      if (dynamic_cast<redeclaration_error const *>(&e)) {
+        throw redeclaration_error(e.what(), pos, state.source);
+      }
+      throw type_collision_error(e.what(), pos, state.source);
+    }
+  }
+};
+
+} // namespace numsim::cas::parser::actions
+
+#endif // NUMSIM_CAS_PARSER_ACTIONS_H

--- a/src/numsim_cas/parser/function_registry.h
+++ b/src/numsim_cas/parser/function_registry.h
@@ -1,0 +1,212 @@
+#ifndef NUMSIM_CAS_PARSER_FUNCTION_REGISTRY_H
+#define NUMSIM_CAS_PARSER_FUNCTION_REGISTRY_H
+
+// Static registry mapping function names to arity + polymorphic
+// dispatch. SRC-PRIVATE.
+//
+// Phase 2c: scalar→scalar functions (trig family, hyperbolic family,
+// exp/log/sqrt/abs/sign, pow, six comparisons).
+// Phase 2d: tensor→tensor (trans, inv) and tensor→t2s (trace, det,
+// norm, dot) added to the same table. Entries now return
+// `parsed_expression` and type-check their args against `arg_kinds`.
+//
+// Not yet registered (still on unmerged PRs): max, min, if_then_else,
+// macauley_plus, macauley_minus, heaviside, smoothed_macauley
+// (#207/#208/#209). dev/sym/vol/skew projectors and inner_product /
+// outer_product / dot_product also still missing — the latter need
+// bracket-list index notation in the grammar, which is the next
+// integration after #207-#209 land. Calls to any of those names
+// fire `unknown_function_error`.
+
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/scalar/scalar_expression.h>
+#include <numsim_cas/scalar/scalar_operators.h>
+#include <numsim_cas/scalar/scalar_std.h>
+#include <numsim_cas/tensor/sequence.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor/tensor_functions.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace numsim::cas::parser::registry {
+
+using scalar_expr = expression_holder<scalar_expression>;
+using tensor_expr = expression_holder<tensor_expression>;
+using t2s_expr = expression_holder<tensor_to_scalar_expression>;
+
+/// A bracket-list literal like `[1, 2]` as an argument to a
+/// contraction function. Carries 1-based indices as the user wrote
+/// them; the dispatch converts to numsim_cas's 0-based `sequence`.
+struct index_list_value {
+  std::vector<std::size_t> indices; // 1-based, as parsed
+};
+
+/// Parser-internal value stack alternative. Public `parsed_expression`
+/// is the narrower subset returned by `parse()`; this richer variant
+/// lets index-list literals flow through the value stack to the
+/// function-call action that consumes them. At parse end, the final
+/// value must be one of the three expression alternatives —
+/// index_list_value at the top is a syntax error (caught explicitly
+/// in parser.cpp).
+using parser_value =
+    std::variant<scalar_expr, tensor_expr, t2s_expr, index_list_value>;
+using arg_vec = std::vector<parser_value>;
+
+/// Which kind each positional arg must be in. Checked by the
+/// `function_call` action before calling `dispatch` — wrong kind
+/// raises `type_mismatch_error` with the call's position.
+enum class arg_kind { scalar, tensor, index_list };
+
+struct function_entry {
+  // arg_kinds.size() == arity.
+  std::vector<arg_kind> arg_kinds;
+  std::function<parsed_expression(arg_vec)> dispatch;
+};
+
+namespace detail {
+
+inline function_entry scalar_unary(auto fn) {
+  return {{arg_kind::scalar},
+          [fn = std::move(fn)](arg_vec a) -> parsed_expression {
+            auto &s = std::get<scalar_expr>(a[0]);
+            return fn(std::move(s));
+          }};
+}
+inline function_entry scalar_binary(auto fn) {
+  return {{arg_kind::scalar, arg_kind::scalar},
+          [fn = std::move(fn)](arg_vec a) -> parsed_expression {
+            auto &l = std::get<scalar_expr>(a[0]);
+            auto &r = std::get<scalar_expr>(a[1]);
+            return fn(std::move(l), std::move(r));
+          }};
+}
+inline function_entry tensor_unary(auto fn) {
+  return {{arg_kind::tensor},
+          [fn = std::move(fn)](arg_vec a) -> parsed_expression {
+            auto &t = std::get<tensor_expr>(a[0]);
+            return fn(std::move(t));
+          }};
+}
+inline function_entry tensor_to_scalar_unary(auto fn) {
+  return {{arg_kind::tensor},
+          [fn = std::move(fn)](arg_vec a) -> parsed_expression {
+            auto &t = std::get<tensor_expr>(a[0]);
+            return fn(std::move(t));
+          }};
+}
+
+// Convert a parsed index_list_value (1-based) to numsim_cas's
+// `sequence` (0-based internally; sequence accepts a count then
+// per-element writes via `operator[]`).
+inline sequence to_sequence(index_list_value const &iv) {
+  sequence s(iv.indices.size());
+  for (std::size_t i = 0; i < iv.indices.size(); ++i) {
+    // 1-based input → 0-based storage, matching sequence's
+    // initializer_list ctor semantics. The parser already
+    // validated that indices are >= 1 — see the index_list_literal
+    // action in actions.h.
+    s[i] = iv.indices[i] - 1;
+  }
+  return s;
+}
+
+// Contraction helpers: (tensor, index_list, tensor, index_list).
+// The first 4-arg variant returns a tensor (inner_product), the
+// second returns a t2s (dot_product). Same arg-kind table.
+inline function_entry inner_product_entry() {
+  return {{arg_kind::tensor, arg_kind::index_list, arg_kind::tensor,
+           arg_kind::index_list},
+          [](arg_vec a) -> parsed_expression {
+            auto &lhs = std::get<tensor_expr>(a[0]);
+            auto lhs_seq = to_sequence(std::get<index_list_value>(a[1]));
+            auto &rhs = std::get<tensor_expr>(a[2]);
+            auto rhs_seq = to_sequence(std::get<index_list_value>(a[3]));
+            return inner_product(std::move(lhs), std::move(lhs_seq),
+                                 std::move(rhs), std::move(rhs_seq));
+          }};
+}
+
+inline function_entry dot_product_entry() {
+  return {{arg_kind::tensor, arg_kind::index_list, arg_kind::tensor,
+           arg_kind::index_list},
+          [](arg_vec a) -> parsed_expression {
+            auto &lhs = std::get<tensor_expr>(a[0]);
+            auto lhs_seq = to_sequence(std::get<index_list_value>(a[1]));
+            auto &rhs = std::get<tensor_expr>(a[2]);
+            auto rhs_seq = to_sequence(std::get<index_list_value>(a[3]));
+            return dot_product(lhs, std::move(lhs_seq), rhs,
+                               std::move(rhs_seq));
+          }};
+}
+
+} // namespace detail
+
+inline std::unordered_map<std::string, function_entry> const &
+function_registry() {
+  static auto const r = [] {
+    std::unordered_map<std::string, function_entry> m;
+    using detail::scalar_binary;
+    using detail::scalar_unary;
+    using detail::tensor_to_scalar_unary;
+    using detail::tensor_unary;
+
+    // ─── Scalar unary ──────────────────────────────────────────
+    m.emplace("sin", scalar_unary([](auto x) { return sin(x); }));
+    m.emplace("cos", scalar_unary([](auto x) { return cos(x); }));
+    m.emplace("tan", scalar_unary([](auto x) { return tan(x); }));
+    m.emplace("asin", scalar_unary([](auto x) { return asin(x); }));
+    m.emplace("acos", scalar_unary([](auto x) { return acos(x); }));
+    m.emplace("atan", scalar_unary([](auto x) { return atan(x); }));
+    m.emplace("sinh", scalar_unary([](auto x) { return sinh(x); }));
+    m.emplace("cosh", scalar_unary([](auto x) { return cosh(x); }));
+    m.emplace("tanh", scalar_unary([](auto x) { return tanh(x); }));
+    m.emplace("asinh", scalar_unary([](auto x) { return asinh(x); }));
+    m.emplace("acosh", scalar_unary([](auto x) { return acosh(x); }));
+    m.emplace("atanh", scalar_unary([](auto x) { return atanh(x); }));
+    m.emplace("exp", scalar_unary([](auto x) { return exp(x); }));
+    m.emplace("log", scalar_unary([](auto x) { return log(x); }));
+    m.emplace("log10", scalar_unary([](auto x) { return log10(x); }));
+    m.emplace("sqrt", scalar_unary([](auto x) { return sqrt(x); }));
+    m.emplace("abs", scalar_unary([](auto x) { return abs(x); }));
+    m.emplace("sign", scalar_unary([](auto x) { return sign(x); }));
+
+    // ─── Scalar binary ─────────────────────────────────────────
+    m.emplace("pow", scalar_binary([](auto a, auto b) { return pow(a, b); }));
+    m.emplace("lt", scalar_binary([](auto a, auto b) { return lt(a, b); }));
+    m.emplace("le", scalar_binary([](auto a, auto b) { return le(a, b); }));
+    m.emplace("gt", scalar_binary([](auto a, auto b) { return gt(a, b); }));
+    m.emplace("ge", scalar_binary([](auto a, auto b) { return ge(a, b); }));
+    m.emplace("eq", scalar_binary([](auto a, auto b) { return eq(a, b); }));
+    m.emplace("ne", scalar_binary([](auto a, auto b) { return ne(a, b); }));
+
+    // ─── Tensor → tensor ───────────────────────────────────────
+    m.emplace("trans", tensor_unary([](auto t) { return trans(t); }));
+    m.emplace("inv", tensor_unary([](auto t) { return inv(t); }));
+
+    // ─── Tensor → t2s ──────────────────────────────────────────
+    m.emplace("trace", tensor_to_scalar_unary([](auto t) { return trace(t); }));
+    m.emplace("det", tensor_to_scalar_unary([](auto t) { return det(t); }));
+    m.emplace("norm", tensor_to_scalar_unary([](auto t) { return norm(t); }));
+    m.emplace("dot", tensor_to_scalar_unary([](auto t) { return dot(t); }));
+
+    // ─── Contraction (tensor, [idx], tensor, [idx]) ────────────
+    m.emplace("inner_product", detail::inner_product_entry());
+    m.emplace("dot_product", detail::dot_product_entry());
+
+    return m;
+  }();
+  return r;
+}
+
+} // namespace numsim::cas::parser::registry
+
+#endif // NUMSIM_CAS_PARSER_FUNCTION_REGISTRY_H

--- a/src/numsim_cas/parser/grammar.h
+++ b/src/numsim_cas/parser/grammar.h
@@ -1,0 +1,237 @@
+#ifndef NUMSIM_CAS_PARSER_GRAMMAR_H
+#define NUMSIM_CAS_PARSER_GRAMMAR_H
+
+// PEGTL grammar for the numsim-cas expression parser (issue #214).
+//
+// This is a SRC-PRIVATE header — it includes PEGTL and pulls in
+// substantial template code. Public consumers go through
+// `<numsim_cas/parser/parser.h>` which does NOT include this file.
+//
+// Phase 2a coverage: numbers (int + decimal), bare identifiers,
+// parentheses, `+ - * /`.
+// Phase 2b additions: right-associative `^`, unary `-`, comparison
+// operators (`<`, `<=`, `>`, `>=`, `==`, `!=`).
+// Phase 2c additions: function calls — scalar→scalar functions
+// (trig + hyperbolic + exp/log/sqrt/abs/sign + pow + comparisons)
+// are dispatched through a static registry in function_registry.h.
+// The grammar uses a distinct `function_name` rule (no action) so
+// the bare-identifier action doesn't fire when matching the prefix
+// of a call; if_must<(> commits once the open paren is consumed so
+// backtracking past it can't smear state.
+// Phase 2d additions: tensor declarations (`A{rank=R, dim=D}`),
+// tensor→tensor functions (trans, inv) and tensor→t2s functions
+// (trace, det, norm, dot). Bare identifiers now look up their
+// existing declaration in the symbol_table and push the existing
+// holder (scalar or tensor) — only fall back to implicit scalar
+// declaration when the name is unknown.
+// Phase 2e additions: bracket-list index notation `[i, j]` for
+// `inner_product(A, [3,4], B, [1,2])` and
+// `dot_product(A, [1,2], B, [1,2])`. The index list is a new
+// grammar primary inside `arg_item` — it's only accepted in
+// function-call arg lists, not as a free-standing primary.
+// (`outer_product` has no top-level free function on this branch,
+// so it isn't in the registry.)
+//
+// What's still missing (deferred to a future phase or to the
+// upstream library): max/min/if_then_else/Macauley family (need
+// #207/#208/#209 to land on main); dev/sym/vol/skew projectors
+// (need projection_tensor.h, also from the unmerged stack);
+// upper-bound validation on contraction indices (delegated to the
+// underlying library at evaluation time).
+
+#include <tao/pegtl.hpp>
+
+namespace numsim::cas::parser::grammar {
+
+namespace pegtl = tao::pegtl;
+
+// ─── Whitespace ────────────────────────────────────────────────────
+// Skipped freely between tokens, never inside identifiers or numbers.
+struct ws : pegtl::star<pegtl::space> {};
+
+// ─── Numeric literals ─────────────────────────────────────────────
+// integer:  one or more digits
+// decimal:  digits '.' digits   OR   digits '.'   (e.g. "2.")
+// number:   decimal | integer  (decimal first so the parser doesn't
+//           greedily consume the leading digits as an integer)
+struct integer_literal : pegtl::plus<pegtl::digit> {};
+struct decimal_literal : pegtl::seq<pegtl::plus<pegtl::digit>, pegtl::one<'.'>,
+                                    pegtl::star<pegtl::digit>> {};
+struct number_literal : pegtl::sor<decimal_literal, integer_literal> {};
+
+// ─── Identifiers ──────────────────────────────────────────────────
+// `[a-zA-Z_][a-zA-Z0-9_]*`. The parser treats every bare identifier
+// as a scalar variable (declared implicitly on first use).
+struct identifier_first : pegtl::sor<pegtl::alpha, pegtl::one<'_'>> {};
+struct identifier_rest : pegtl::sor<pegtl::alnum, pegtl::one<'_'>> {};
+struct identifier : pegtl::seq<identifier_first, pegtl::star<identifier_rest>> {
+};
+
+// ─── Operator tokens ──────────────────────────────────────────────
+// Single-character tokens. Multi-character tokens are listed below
+// in priority order (try multi-char first when alternatives share a
+// prefix, e.g. `<=` before `<`).
+struct plus_op : pegtl::one<'+'> {};
+struct minus_op : pegtl::one<'-'> {};
+struct star_op : pegtl::one<'*'> {};
+struct slash_op : pegtl::one<'/'> {};
+struct caret_op : pegtl::one<'^'> {};
+
+// Comparison tokens. Two-char variants must come before their
+// single-char siblings in the `sor<>` that wraps them — otherwise
+// `<=` parses as `<` followed by `=` which doesn't match anything.
+struct eq_eq_op : pegtl::string<'=', '='> {};
+struct ne_op : pegtl::string<'!', '='> {};
+struct le_op : pegtl::string<'<', '='> {};
+struct ge_op : pegtl::string<'>', '='> {};
+struct lt_op : pegtl::one<'<'> {};
+struct gt_op : pegtl::one<'>'> {};
+
+// ─── Forward decls ────────────────────────────────────────────────
+struct expression;
+struct unary;
+struct power;
+
+// ─── Function calls ───────────────────────────────────────────────
+// `function_name` has the same shape as `identifier` but is a
+// distinct PEGTL rule so we don't share its action template
+// specialisation. That keeps the bare-identifier scalar-variable
+// push out of the function-call match path.
+//
+// `function_call_open` / `function_call_close` are distinct from
+// the generic `(` / `)` used in `paren_expression` for the same
+// reason — their action records the value-stack depth so we know
+// how many args were pushed by the time the call finishes.
+//
+// Once `(` is matched, the rest is wrapped in `if_must` so a
+// missing close-paren (or malformed argument) raises a hard error
+// rather than backtracking to try `identifier` and leaving state
+// in an inconsistent shape.
+struct function_name
+    : pegtl::seq<identifier_first, pegtl::star<identifier_rest>> {};
+struct function_call_open : pegtl::one<'('> {};
+struct function_call_close : pegtl::one<')'> {};
+
+// ─── Bracket-list index literal (phase 2e) ────────────────────────
+// `[i1, i2, …]` — only accepted as an `arg_item`, not as a primary.
+// Inside contraction-function arg lists (`inner_product`,
+// `dot_product`). Indices are 1-based positive integers; the action
+// converts to 0-based when constructing the `sequence`.
+//
+// `[` is the commit point: once consumed, the rest MUST follow.
+// That way malformed `[]` / `[1` / `[1, ]` raise an error pointing
+// at the actual problem inside the bracket-list rather than at the
+// outer function-call's `)` after generic backtracking. `[` doesn't
+// start any valid expression, so committing here can't smother a
+// legitimate alternative in `arg_item`.
+struct index_list_open : pegtl::one<'['> {};
+struct index_list_close : pegtl::one<']'> {};
+struct index_list_literal
+    : pegtl::if_must<index_list_open, ws,
+                     pegtl::list<integer_literal,
+                                 pegtl::pad<pegtl::one<','>, pegtl::space>>,
+                     ws, index_list_close> {};
+
+// An arg in a function call is either an index_list literal or a
+// full expression. Order matters: index_list must come first so the
+// `[` token isn't (mis)parsed as something else.
+struct arg_item : pegtl::sor<index_list_literal, expression> {};
+struct arg_list
+    : pegtl::list<arg_item, pegtl::pad<pegtl::one<','>, pegtl::space>> {};
+struct function_call
+    : pegtl::seq<function_name, ws,
+                 pegtl::if_must<function_call_open, ws, pegtl::opt<arg_list>,
+                                ws, function_call_close>> {};
+
+// ─── Tensor declarations: Name{rank=R, dim=D} ─────────────────────
+// Same no-action-on-name + if_must<brace> pattern as function_call.
+// The kv pairs may appear in either order. Re-declaration with a
+// different (rank, dim) raises redeclaration_error from the
+// symbol_table; identical re-declaration is a no-op.
+struct rank_keyword : pegtl::string<'r', 'a', 'n', 'k'> {};
+struct dim_keyword : pegtl::string<'d', 'i', 'm'> {};
+struct kv_eq : pegtl::one<'='> {};
+struct rank_kv : pegtl::seq<rank_keyword, ws, kv_eq, ws, integer_literal> {};
+struct dim_kv : pegtl::seq<dim_keyword, ws, kv_eq, ws, integer_literal> {};
+struct tensor_kv : pegtl::sor<rank_kv, dim_kv> {};
+struct tensor_kv_list
+    : pegtl::list<tensor_kv, pegtl::pad<pegtl::one<','>, pegtl::space>> {};
+
+struct tensor_name
+    : pegtl::seq<identifier_first, pegtl::star<identifier_rest>> {};
+struct tensor_decl_open : pegtl::one<'{'> {};
+struct tensor_decl_close : pegtl::one<'}'> {};
+struct tensor_decl
+    : pegtl::seq<tensor_name, ws,
+                 pegtl::if_must<tensor_decl_open, ws, tensor_kv_list, ws,
+                                tensor_decl_close>> {};
+
+// ─── Primary: literal | function_call | tensor_decl | identifier | parens
+// Order matters: function_call before tensor_decl before identifier
+// so `name(` / `name{` prefixes aren't consumed as bare scalar
+// variables. Both compound alternatives backtrack cleanly when their
+// distinguishing token (`(` or `{`) doesn't follow the name.
+struct paren_expression
+    : pegtl::seq<pegtl::one<'('>, ws, expression, ws, pegtl::one<')'>> {};
+
+struct primary : pegtl::sor<number_literal, function_call, tensor_decl,
+                            identifier, paren_expression> {};
+
+// ─── Power level (highest precedence): primary ('^' power)? ──────
+// Right-recursive: the `^`'s right operand is `power` itself, NOT
+// `primary`. That makes `2 ^ 3 ^ 2` parse as `2 ^ (3 ^ 2) = 512`.
+// (PEGTL's `list<X, Y>` is left-associative; the right-recursion
+// here is the canonical workaround.)
+struct power_tail : pegtl::seq<ws, caret_op, ws, power> {};
+struct power : pegtl::seq<primary, pegtl::opt<power_tail>> {};
+
+// ─── Unary minus: '-' unary | power ──────────────────────────────
+// Unary `-` binds tighter than `*` (so `-2 * x = (-2) * x`) but
+// looser than `^` (so `-x^2 = -(x^2)`). Right-recursive too so
+// `- - x` parses as `-(-x)` (which the construction-time simplifier
+// then folds to x).
+struct unary_minus : pegtl::seq<minus_op, ws, unary> {};
+struct unary : pegtl::sor<unary_minus, power> {};
+
+// ─── Multiplicative level: unary (('*'|'/') unary)* ──────────────
+// Per-op tail rules so each action specialisation dispatches
+// statically. See the doc comment at the head of this file for why
+// the single-tail-with-sor-over-ops approach was rejected.
+struct mul_tail_star : pegtl::seq<ws, star_op, ws, unary> {};
+struct mul_tail_slash : pegtl::seq<ws, slash_op, ws, unary> {};
+struct mul_tail : pegtl::sor<mul_tail_star, mul_tail_slash> {};
+struct mul_term : pegtl::seq<unary, pegtl::star<mul_tail>> {};
+
+// ─── Additive level: mul_term (('+'|'-') mul_term)* ──────────────
+struct add_tail_plus : pegtl::seq<ws, plus_op, ws, mul_term> {};
+struct add_tail_minus : pegtl::seq<ws, minus_op, ws, mul_term> {};
+struct add_tail : pegtl::sor<add_tail_plus, add_tail_minus> {};
+struct add_term : pegtl::seq<mul_term, pegtl::star<add_tail>> {};
+
+// ─── Comparison level: add_term ((< | <= | > | >=) add_term)* ────
+// Comparisons evaluate to scalar indicators (1.0 / 0.0) following
+// Option B from #136. The two-char variants come first in `sor`.
+struct cmp_tail_le : pegtl::seq<ws, le_op, ws, add_term> {};
+struct cmp_tail_ge : pegtl::seq<ws, ge_op, ws, add_term> {};
+struct cmp_tail_lt : pegtl::seq<ws, lt_op, ws, add_term> {};
+struct cmp_tail_gt : pegtl::seq<ws, gt_op, ws, add_term> {};
+struct cmp_tail
+    : pegtl::sor<cmp_tail_le, cmp_tail_ge, cmp_tail_lt, cmp_tail_gt> {};
+struct cmp_term : pegtl::seq<add_term, pegtl::star<cmp_tail>> {};
+
+// ─── Equality level (lowest precedence): cmp_term ((== | !=) cmp_term)* ──
+struct eq_tail_eq : pegtl::seq<ws, eq_eq_op, ws, cmp_term> {};
+struct eq_tail_ne : pegtl::seq<ws, ne_op, ws, cmp_term> {};
+struct eq_tail : pegtl::sor<eq_tail_eq, eq_tail_ne> {};
+struct eq_term : pegtl::seq<cmp_term, pegtl::star<eq_tail>> {};
+
+// Top-level expression production.
+struct expression : eq_term {};
+
+// Grammar root: optional leading/trailing whitespace, must consume
+// to end of input.
+struct grammar : pegtl::must<ws, expression, ws, pegtl::eof> {};
+
+} // namespace numsim::cas::parser::grammar
+
+#endif // NUMSIM_CAS_PARSER_GRAMMAR_H

--- a/src/numsim_cas/parser/parse_error.cpp
+++ b/src/numsim_cas/parser/parse_error.cpp
@@ -1,0 +1,108 @@
+#include <numsim_cas/parser/parse_error.h>
+
+#include <algorithm>
+#include <sstream>
+#include <utility>
+
+namespace numsim::cas::parser {
+
+namespace {
+
+struct line_info {
+  std::size_t line;
+  std::size_t column;
+  std::size_t line_start;
+  std::size_t line_end;
+};
+
+// Walk the source to find the line, column, and bounding newlines for
+// the byte offset. O(N) in the source length; runs at most twice per
+// parse_error construction (once in format_message, once in the body).
+// Parse errors are rare so the duplication is negligible.
+line_info resolve_line(std::string_view source, std::size_t pos) noexcept {
+  pos = std::min(pos, source.size());
+  line_info info{1, 1, 0, source.size()};
+  for (std::size_t i = 0; i < pos; ++i) {
+    if (source[i] == '\n') {
+      ++info.line;
+      info.line_start = i + 1;
+    }
+  }
+  for (std::size_t i = pos; i < source.size(); ++i) {
+    if (source[i] == '\n') {
+      info.line_end = i;
+      break;
+    }
+  }
+  info.column = pos - info.line_start + 1;
+  return info;
+}
+
+// Build the formatted what() string. Two formats depending on whether
+// source context was supplied:
+//   - non-empty source: full snippet with line:col header and caret
+//   - empty source:     just "parse error: <body>"
+std::string format_message(std::string_view body, std::string_view source,
+                           std::size_t byte_offset) {
+  if (source.empty()) {
+    std::string out = "parse error: ";
+    out.append(body);
+    return out;
+  }
+  auto info = resolve_line(source, byte_offset);
+  std::ostringstream oss;
+  oss << "parse error at " << info.line << ":" << info.column << ": " << body;
+  if (info.line_start <= info.line_end) {
+    auto line_text =
+        source.substr(info.line_start, info.line_end - info.line_start);
+    oss << "\n  " << line_text;
+    oss << "\n  " << std::string(info.column - 1, ' ') << '^';
+  }
+  return oss.str();
+}
+
+} // namespace
+
+parse_error::parse_error(std::string message, std::size_t byte_offset,
+                         std::string_view source)
+    : cas_error(format_message(message, source, byte_offset)) {
+  if (!source.empty()) {
+    auto info = resolve_line(source, byte_offset);
+    m_pos = std::min(byte_offset, source.size());
+    m_line = info.line;
+    m_col = info.column;
+    m_has_position = true;
+  }
+}
+
+unknown_symbol_error::unknown_symbol_error(std::string name,
+                                           std::size_t byte_offset,
+                                           std::string_view source)
+    : parse_error("unknown identifier: '" + name + "'", byte_offset, source),
+      m_name(std::move(name)) {}
+
+unknown_function_error::unknown_function_error(std::string name,
+                                               std::size_t byte_offset,
+                                               std::string_view source)
+    : parse_error("unknown function: '" + name + "'", byte_offset, source),
+      m_name(std::move(name)) {}
+
+namespace {
+std::string format_arity(std::string_view function, std::size_t expected,
+                         std::size_t actual) {
+  std::ostringstream oss;
+  oss << "function '" << function << "' expects " << expected << " argument"
+      << (expected == 1 ? "" : "s") << ", got " << actual;
+  return oss.str();
+}
+} // namespace
+
+arity_error::arity_error(std::string function_name, std::size_t expected_arity_,
+                         std::size_t actual_arity_, std::size_t byte_offset,
+                         std::string_view source)
+    : parse_error(format_arity(function_name, expected_arity_, actual_arity_),
+                  byte_offset, source),
+      m_function(std::move(function_name)), m_expected(expected_arity_),
+      m_actual(actual_arity_) {}
+
+} // namespace numsim::cas::parser

--- a/src/numsim_cas/parser/parser.cpp
+++ b/src/numsim_cas/parser/parser.cpp
@@ -1,0 +1,126 @@
+#include <numsim_cas/parser/parser.h>
+
+#include "actions.h"
+#include "grammar.h"
+
+#include <numsim_cas/parser/parse_error.h>
+
+#include <tao/pegtl.hpp>
+#include <tao/pegtl/contrib/parse_tree.hpp>
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace numsim::cas::parser {
+
+namespace pegtl = tao::pegtl;
+
+namespace {
+
+// Translate PEGTL's own parse_error (raised when `must<>` rules fail
+// or when a default action wraps an exception) into our syntax_error,
+// preserving position info.
+//
+// Return type is `syntax_error` (NOT the base `parse_error`) — a
+// return-by-value of the base type would slice the subclass off, and
+// the subsequent `throw` would propagate a sliced base-only object.
+// Callers downstream that catch by `syntax_error` would then miss it.
+syntax_error translate_pegtl_error(pegtl::parse_error const &e,
+                                   std::string_view source) {
+  // pegtl::parse_error stores positions; pull the first.
+  std::size_t byte = 0;
+  if (!e.positions().empty()) {
+    byte = e.positions().front().byte;
+  }
+  // Use e.what() (std::exception interface) — pegtl::parse_error
+  // returns a string_view from message() which can't directly
+  // construct a std::string by '='.
+  std::string msg(e.message());
+  return syntax_error(std::move(msg), byte, source);
+}
+
+} // namespace
+
+parsed_expression parse(std::string_view source, symbol_table &syms) {
+  // Make a copy into a std::string-backed input — PEGTL's
+  // memory_input takes ownership of the source view (it doesn't
+  // copy) so callers must keep the string alive across the parse.
+  // string_input copies the data internally, which is safer for our
+  // public API where we accept a string_view by value.
+  pegtl::string_input input{std::string(source), "<source>"};
+
+  actions::parser_state state(syms, source);
+
+  try {
+    pegtl::parse<grammar::grammar, actions::action>(input, state);
+  } catch (parse_error const &) {
+    // One of our actions threw — already has the right type +
+    // position + snippet. Propagate.
+    throw;
+  } catch (pegtl::parse_error const &e) {
+    // PEGTL's internal error — translate to our type.
+    throw translate_pegtl_error(e, source);
+  }
+
+  if (state.values.size() != 1) {
+    throw syntax_error("parser ended with " +
+                           std::to_string(state.values.size()) +
+                           " expressions on the stack (expected exactly 1)",
+                       source.size(), source);
+  }
+  // Convert from the parser-internal `parser_value` (which can hold an
+  // index_list_value as a 4th alternative) to the public
+  // `parsed_expression`. An index_list_value at the top is a syntax
+  // error — bracket-list literals are only valid inside contraction
+  // function arg lists, never as a top-level expression.
+  return std::visit(
+      [&](auto &&v) -> parsed_expression {
+        using V = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<V, registry::index_list_value>) {
+          throw syntax_error(
+              "bracket-list literal '[...]' cannot be a top-level expression",
+              source.size(), source);
+        } else {
+          return std::move(v);
+        }
+      },
+      std::move(state.values.front()));
+}
+
+expression_holder<scalar_expression> parse_scalar(std::string_view source,
+                                                  symbol_table &syms) {
+  auto result = parse(source, syms);
+  if (auto *s = std::get_if<expression_holder<scalar_expression>>(&result)) {
+    return std::move(*s);
+  }
+  throw type_mismatch_error(
+      "parse_scalar called on expression that did not resolve to scalar", 0,
+      source);
+}
+
+expression_holder<tensor_expression> parse_tensor(std::string_view source,
+                                                  symbol_table &syms) {
+  auto result = parse(source, syms);
+  if (auto *t = std::get_if<expression_holder<tensor_expression>>(&result)) {
+    return std::move(*t);
+  }
+  throw type_mismatch_error(
+      "parse_tensor called on expression that did not resolve to tensor", 0,
+      source);
+}
+
+expression_holder<tensor_to_scalar_expression>
+parse_t2s(std::string_view source, symbol_table &syms) {
+  auto result = parse(source, syms);
+  if (auto *t = std::get_if<expression_holder<tensor_to_scalar_expression>>(
+          &result)) {
+    return std::move(*t);
+  }
+  throw type_mismatch_error(
+      "parse_t2s called on expression that did not resolve to "
+      "tensor_to_scalar",
+      0, source);
+}
+
+} // namespace numsim::cas::parser

--- a/src/numsim_cas/parser/symbol_table.cpp
+++ b/src/numsim_cas/parser/symbol_table.cpp
@@ -1,0 +1,75 @@
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/scalar/scalar.h>
+#include <numsim_cas/tensor/tensor.h>
+
+#include <sstream>
+
+namespace numsim::cas::parser {
+
+expression_holder<scalar_expression>
+symbol_table::get_or_declare_scalar(std::string_view name) {
+  std::string key(name);
+  auto it = m_entries.find(key);
+  if (it == m_entries.end()) {
+    auto expr = make_expression<scalar>(key);
+    m_entries.emplace(std::move(key), scalar_entry{expr});
+    return expr;
+  }
+  if (auto *s = std::get_if<scalar_entry>(&it->second)) {
+    return s->expr;
+  }
+  // Existing entry is a tensor — cross-type collision.
+  throw type_collision_error(
+      "'" + key + "' is already declared as a tensor; cannot reuse as a scalar",
+      0, std::string_view{});
+}
+
+expression_holder<tensor_expression>
+symbol_table::get_or_declare_tensor(std::string_view name, std::size_t rank,
+                                    std::size_t dim) {
+  std::string key(name);
+  auto it = m_entries.find(key);
+  if (it == m_entries.end()) {
+    auto expr = make_expression<tensor>(key, dim, rank);
+    m_entries.emplace(std::move(key), tensor_entry{expr, rank, dim});
+    return expr;
+  }
+  if (auto *t = std::get_if<tensor_entry>(&it->second)) {
+    if (t->rank != rank || t->dim != dim) {
+      std::ostringstream oss;
+      oss << "'" << key
+          << "' is already declared as a tensor with rank=" << t->rank
+          << ", dim=" << t->dim << "; cannot redeclare with rank=" << rank
+          << ", dim=" << dim;
+      throw redeclaration_error(oss.str(), 0, std::string_view{});
+    }
+    return t->expr;
+  }
+  // Existing entry is a scalar — cross-type collision.
+  throw type_collision_error(
+      "'" + key + "' is already declared as a scalar; cannot reuse as a tensor",
+      0, std::string_view{});
+}
+
+bool symbol_table::has(std::string_view name) const noexcept {
+  // unordered_map::find takes string; we materialise a key.
+  // C++20 heterogeneous lookup would avoid the allocation but requires
+  // a custom hash/equal — not worth the complexity for occasional lookup.
+  return m_entries.find(std::string(name)) != m_entries.end();
+}
+
+std::optional<std::pair<std::size_t, std::size_t>>
+symbol_table::tensor_shape(std::string_view name) const {
+  auto it = m_entries.find(std::string(name));
+  if (it == m_entries.end())
+    return std::nullopt;
+  if (auto const *t = std::get_if<tensor_entry>(&it->second)) {
+    return std::make_pair(t->rank, t->dim);
+  }
+  return std::nullopt;
+}
+
+} // namespace numsim::cas::parser

--- a/src/numsim_cas/parser/symbol_table.cpp
+++ b/src/numsim_cas/parser/symbol_table.cpp
@@ -72,4 +72,16 @@ symbol_table::tensor_shape(std::string_view name) const {
   return std::nullopt;
 }
 
+std::optional<symbol_table::lookup_result>
+symbol_table::get(std::string_view name) const {
+  auto it = m_entries.find(std::string(name));
+  if (it == m_entries.end())
+    return std::nullopt;
+  if (auto const *s = std::get_if<scalar_entry>(&it->second))
+    return s->expr;
+  if (auto const *t = std::get_if<tensor_entry>(&it->second))
+    return t->expr;
+  return std::nullopt;
+}
+
 } // namespace numsim::cas::parser

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_numsim_cas_test(numsim_cas_test
     CoreBugFixTest.h
     SolveTest.h
     LimitVisitorTest.h
+    ParserTest.h
     ScalarAssumptionTest.h
     ScalarComparisonTest.h
     ScalarDifferentiationTest.h
@@ -69,3 +70,11 @@ foreach(target numsim_cas_test numsim_cas_fuzz_test)
         target_compile_options(${target} PRIVATE /WX /bigobj /Zc:preprocessor)
     endif()
 endforeach()
+
+# Parser tests (issue #214) — only enabled when the parser is built.
+# ParserTest.h is always in the source list (for IDE visibility) but
+# its body is gated on NUMSIM_CAS_PARSER_ENABLED, defined here.
+if(NUMSIM_CAS_BUILD_PARSER)
+    target_compile_definitions(numsim_cas_test PRIVATE NUMSIM_CAS_PARSER_ENABLED)
+    target_link_libraries(numsim_cas_test PRIVATE NumSim_CAS::Parser)
+endif()

--- a/tests/ParserTest.h
+++ b/tests/ParserTest.h
@@ -13,10 +13,24 @@
 
 #include <gtest/gtest.h>
 
-#include <numsim_cas/parser/parse_error.h>
-#include <numsim_cas/parser/symbol_table.h>
+#include "cas_test_helpers.h"
 
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/scalar_diff.h>
+#include <numsim_cas/scalar/visitors/scalar_evaluator.h>
+#include <numsim_cas/tensor/data/tensor_data.h>
+#include <numsim_cas/tensor/identity_tensor.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
+#include <numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h>
+
+#include <cmath>
+#include <locale>
+#include <memory>
+#include <stdexcept>
 #include <string>
+#include <variant>
 
 namespace numsim::cas::parser_test {
 
@@ -24,11 +38,25 @@ namespace numsim::cas::parser_test {
 // bodies readable. Restricted to this anonymous-ish translation-unit
 // namespace; doesn't leak to other test files.
 using numsim::cas::parser::arity_error;
+using numsim::cas::parser::lexical_error;
+using numsim::cas::parser::parse;
 using numsim::cas::parser::parse_error;
+using numsim::cas::parser::parse_scalar;
+using numsim::cas::parser::parse_t2s;
+using numsim::cas::parser::parse_tensor;
+using numsim::cas::parser::parsed_expression;
 using numsim::cas::parser::redeclaration_error;
 using numsim::cas::parser::symbol_table;
+using numsim::cas::parser::syntax_error;
 using numsim::cas::parser::type_collision_error;
+using numsim::cas::parser::type_mismatch_error;
+using numsim::cas::parser::unknown_function_error;
 using numsim::cas::parser::unknown_symbol_error;
+
+// numsim_cas core API used by integration tests.
+using numsim::cas::diff;
+using numsim::cas::identity_tensor;
+using numsim::cas::make_expression;
 
 // ─── symbol_table: scalar declarations ─────────────────────────────
 
@@ -202,6 +230,1151 @@ TEST(ParseError, ArityErrorCarriesCounts) {
   EXPECT_NE(std::string(e.what()).find("sin"), std::string::npos);
   EXPECT_NE(std::string(e.what()).find("1"), std::string::npos);
   EXPECT_NE(std::string(e.what()).find("2"), std::string::npos);
+}
+
+// ─── Grammar (phase 2a): numbers, identifiers, + - * / and parens ──
+
+// Helper: evaluate a scalar expression with all named scalar symbols
+// in `bindings` bound to the given doubles. Returns the result.
+inline double eval_scalar(
+    expression_holder<scalar_expression> const &expr, symbol_table &syms,
+    std::initializer_list<std::pair<std::string, double>> bindings = {}) {
+  numsim::cas::scalar_evaluator<double> ev;
+  for (auto const &[name, value] : bindings) {
+    ev.set(syms.get_or_declare_scalar(name), value);
+  }
+  return ev.apply(expr);
+}
+
+TEST(ParserGrammar, IntegerLiteralEvaluatesToValue) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("42", syms), syms), 42.0);
+}
+
+TEST(ParserGrammar, DecimalLiteralEvaluatesToValue) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("3.14", syms), syms), 3.14);
+}
+
+TEST(ParserGrammar, IdentifierResolvesToScalarVariable) {
+  symbol_table syms;
+  auto e = parse_scalar("x", syms);
+  EXPECT_TRUE(syms.has("x"));
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 7.0}}), 7.0);
+}
+
+TEST(ParserGrammar, AdditionLeftAssociative) {
+  symbol_table syms;
+  // a + b + c parses as ((a + b) + c). Either is fine for + since it's
+  // associative, but the lock-in test pins evaluation regardless.
+  auto e = parse_scalar("a + b + c", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 1}, {"b", 2}, {"c", 3}}), 6.0);
+}
+
+TEST(ParserGrammar, SubtractionLeftAssociative) {
+  symbol_table syms;
+  // a - b - c must parse as ((a - b) - c) = a - b - c, NOT a - (b - c).
+  auto e = parse_scalar("10 - 3 - 2", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 5.0)
+      << "Subtraction must be left-associative.";
+}
+
+TEST(ParserGrammar, MultiplicationBindsTighterThanAddition) {
+  symbol_table syms;
+  // 2 + 3 * 4 should be 14, not 20.
+  auto e = parse_scalar("2 + 3 * 4", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 14.0);
+}
+
+TEST(ParserGrammar, DivisionLeftAssociative) {
+  symbol_table syms;
+  // 100 / 10 / 2 must be 5, not 20.
+  auto e = parse_scalar("100 / 10 / 2", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 5.0)
+      << "Division must be left-associative.";
+}
+
+TEST(ParserGrammar, ParensOverridePrecedence) {
+  symbol_table syms;
+  auto e = parse_scalar("(2 + 3) * 4", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 20.0);
+}
+
+TEST(ParserGrammar, NestedParensEvaluateCorrectly) {
+  symbol_table syms;
+  auto e = parse_scalar("((1 + 2) * (3 + 4))", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 21.0);
+}
+
+TEST(ParserGrammar, WhitespaceIsSkippedFreely) {
+  symbol_table syms;
+  auto e = parse_scalar("  1  +  2  *  3  ", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms), 7.0);
+}
+
+TEST(ParserGrammar, IdentifierAndLiteralCombine) {
+  symbol_table syms;
+  auto e = parse_scalar("2 * x + 3", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 5}}), 13.0);
+}
+
+TEST(ParserGrammar, SameIdentifierTwiceUsesSameVariable) {
+  // Critical: `x + x` should evaluate to `2x`, NOT to `x + freshly-
+  // declared-x`. Verifies the symbol_table lookup-or-declare path
+  // returns the same holder on both lookups.
+  symbol_table syms;
+  auto e = parse_scalar("x + x", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 4}}), 8.0);
+}
+
+TEST(ParserGrammar, ParserReturnsScalarVariant) {
+  symbol_table syms;
+  auto result = parse("1 + 2", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<scalar_expression>>(result))
+      << "Top-level scalar expression should land in the scalar variant "
+         "alternative.";
+}
+
+TEST(ParserGrammar, ParseTensorOnScalarExpressionThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_tensor("1 + 2", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, ParseT2sOnScalarExpressionThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_t2s("1 + 2", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, MalformedInputThrowsSyntaxError) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("1 +", syms); }, parse_error);
+}
+
+TEST(ParserGrammar, TrailingGarbageThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("1 + 2 banana", syms); },
+      parse_error);
+}
+
+// ─── Phase 2b: power, unary minus, comparisons ─────────────────────
+
+TEST(ParserGrammar, PowerBasic) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("2 ^ 3", syms), syms), 8.0);
+}
+
+TEST(ParserGrammar, PowerRightAssociative) {
+  // 2 ^ 3 ^ 2 must be 2^(3^2) = 2^9 = 512, NOT (2^3)^2 = 64.
+  // Lock-in for the right-recursive grammar (the known PEGTL gotcha
+  // documented in grammar.h).
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("2 ^ 3 ^ 2", syms), syms), 512.0);
+}
+
+TEST(ParserGrammar, PowerBindsTighterThanMul) {
+  // 2 * 3 ^ 2 = 2 * 9 = 18, NOT (2*3)^2 = 36.
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("2 * 3 ^ 2", syms), syms), 18.0);
+}
+
+TEST(ParserGrammar, UnaryMinusOnLiteral) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("-5", syms), syms), -5.0);
+}
+
+TEST(ParserGrammar, UnaryMinusOnIdentifier) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("-x", syms), syms, {{"x", 3.0}}),
+                   -3.0);
+}
+
+TEST(ParserGrammar, UnaryMinusBindsTighterThanMul) {
+  // -2 * x = (-2) * x, evaluated at x=4 → -8.
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(parse_scalar("-2 * x", syms), syms, {{"x", 4.0}}), -8.0);
+}
+
+TEST(ParserGrammar, PowerBindsTighterThanUnaryMinus) {
+  // -x^2 = -(x^2), evaluated at x=3 → -9.
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(parse_scalar("-x ^ 2", syms), syms, {{"x", 3.0}}), -9.0);
+}
+
+TEST(ParserGrammar, DoubleUnaryMinusCancels) {
+  // - -x = -(-x) = x. The construction-time simplifier folds the
+  // double-negation away; either evaluation order gives the same
+  // numeric result.
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("- -x", syms), syms, {{"x", 5.0}}),
+                   5.0);
+}
+
+TEST(ParserGrammar, BinaryMinusVsUnaryMinusAfterBinary) {
+  // 5 - -3 should be 5 + 3 = 8 (binary minus then unary minus on 3).
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("5 - -3", syms), syms), 8.0);
+}
+
+TEST(ParserGrammar, ComparisonLtReturnsIndicator) {
+  // Comparisons produce Option B scalar indicators: 1.0 if true, else 0.0.
+  symbol_table syms;
+  auto e = parse_scalar("x < y", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 1}, {"y", 2}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 5}, {"y", 2}}), 0.0);
+  // Equal evaluates as not-less-than.
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 2}, {"y", 2}}), 0.0);
+}
+
+TEST(ParserGrammar, ComparisonLeIncludesEquality) {
+  symbol_table syms;
+  auto e = parse_scalar("x <= y", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 2}, {"y", 2}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 3}, {"y", 2}}), 0.0);
+}
+
+TEST(ParserGrammar, ComparisonGtAndGe) {
+  symbol_table syms;
+  auto egt = parse_scalar("a > b", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(egt, syms, {{"a", 5}, {"b", 2}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(egt, syms, {{"a", 2}, {"b", 5}}), 0.0);
+  auto ege = parse_scalar("a >= b", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(ege, syms, {{"a", 2}, {"b", 2}}), 1.0);
+}
+
+TEST(ParserGrammar, ComparisonEqAndNe) {
+  symbol_table syms;
+  auto eq_e = parse_scalar("a == b", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(eq_e, syms, {{"a", 3}, {"b", 3}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(eq_e, syms, {{"a", 3}, {"b", 4}}), 0.0);
+  auto ne_e = parse_scalar("a != b", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(ne_e, syms, {{"a", 3}, {"b", 3}}), 0.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(ne_e, syms, {{"a", 3}, {"b", 4}}), 1.0);
+}
+
+TEST(ParserGrammar, ComparisonBindsLooserThanArithmetic) {
+  // x + 1 < y * 2 must parse as (x+1) < (y*2), not as x + (1 < y) * 2.
+  symbol_table syms;
+  auto e = parse_scalar("x + 1 < y * 2", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 2}, {"y", 3}}), 1.0); // 3 < 6
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 9}, {"y", 3}}), 0.0); // 10 < 6
+}
+
+TEST(ParserGrammar, EqualityBindsLooserThanComparison) {
+  // a < b == c parses as (a < b) == c, not a < (b == c).
+  // With a=1, b=2, c=1: (1 < 2)=1, 1 == 1 → 1.
+  // With a=3, b=2, c=1: (3 < 2)=0, 0 == 1 → 0.
+  symbol_table syms;
+  auto e = parse_scalar("a < b == c", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 1}, {"b", 2}, {"c", 1}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 3}, {"b", 2}, {"c", 1}}), 0.0);
+}
+
+// ─── Phase 2c: function calls ──────────────────────────────────────
+
+TEST(ParserGrammar, UnaryFunctionSin) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("sin(0)", syms), syms), 0.0);
+}
+
+TEST(ParserGrammar, UnaryFunctionCos) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("cos(0)", syms), syms), 1.0);
+}
+
+TEST(ParserGrammar, UnaryFunctionExp) {
+  symbol_table syms;
+  EXPECT_NEAR(eval_scalar(parse_scalar("exp(1)", syms), syms), std::exp(1.0),
+              1e-12);
+}
+
+TEST(ParserGrammar, UnaryFunctionLog) {
+  symbol_table syms;
+  EXPECT_NEAR(eval_scalar(parse_scalar("log(exp(2))", syms), syms), 2.0, 1e-12);
+}
+
+TEST(ParserGrammar, UnaryFunctionSqrt) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("sqrt(9)", syms), syms), 3.0);
+}
+
+TEST(ParserGrammar, UnaryFunctionAbs) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(parse_scalar("abs(x)", syms), syms, {{"x", -5.0}}), 5.0);
+}
+
+TEST(ParserGrammar, UnaryFunctionSinOnIdentifier) {
+  symbol_table syms;
+  auto e = parse_scalar("sin(x)", syms);
+  EXPECT_NEAR(eval_scalar(e, syms, {{"x", 1.5}}), std::sin(1.5), 1e-12);
+}
+
+TEST(ParserGrammar, HyperbolicTanh) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("tanh(0)", syms), syms), 0.0);
+}
+
+TEST(ParserGrammar, BinaryFunctionPow) {
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("pow(2, 8)", syms), syms), 256.0);
+}
+
+TEST(ParserGrammar, BinaryFunctionLt) {
+  symbol_table syms;
+  auto e = parse_scalar("lt(x, y)", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 1}, {"y", 2}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 5}, {"y", 2}}), 0.0);
+}
+
+TEST(ParserGrammar, FunctionCallNestedInArithmetic) {
+  // sin(x)^2 + cos(x)^2 == 1 for any x — the classic identity.
+  symbol_table syms;
+  auto e = parse_scalar("sin(x) ^ 2 + cos(x) ^ 2", syms);
+  EXPECT_NEAR(eval_scalar(e, syms, {{"x", 0.7}}), 1.0, 1e-12);
+  EXPECT_NEAR(eval_scalar(e, syms, {{"x", -2.3}}), 1.0, 1e-12);
+}
+
+TEST(ParserGrammar, FunctionCallNestedInsideFunctionCall) {
+  // exp(sin(0)) == exp(0) == 1.
+  symbol_table syms;
+  auto e = parse_scalar("exp(sin(x))", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 0.0}}), 1.0);
+}
+
+TEST(ParserGrammar, FunctionCallWithComplexArguments) {
+  // pow(x + 1, 2 * y) — args are full expressions.
+  symbol_table syms;
+  auto e = parse_scalar("pow(x + 1, 2 * y)", syms);
+  // (3 + 1) ^ (2 * 1.5) = 4 ^ 3 = 64.
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"x", 3}, {"y", 1.5}}), 64.0);
+}
+
+TEST(ParserGrammar, UnknownFunctionThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("nope(x)", syms); },
+      unknown_function_error);
+}
+
+TEST(ParserGrammar, ArityMismatchThrows) {
+  symbol_table syms;
+  // sin is unary. Two args is an arity error.
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("sin(x, y)", syms); },
+      arity_error);
+  // pow is binary. One arg is an arity error.
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("pow(2)", syms); }, arity_error);
+  // pow with zero args.
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("pow()", syms); }, arity_error);
+}
+
+TEST(ParserGrammar, IdentifierWithoutParensIsScalarNotFunction) {
+  // `sin` without parens is a bare identifier (scalar variable).
+  // The grammar must NOT consume "sin" as a function-call prefix
+  // and leave the parse in a bad state.
+  symbol_table syms;
+  auto e = parse_scalar("sin + 3", syms);
+  EXPECT_TRUE(syms.has("sin"))
+      << "'sin' without '(' should be declared as a scalar variable.";
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"sin", 4.0}}), 7.0);
+}
+
+TEST(ParserGrammar, FunctionCallMissingCloseParenThrows) {
+  // Once `(` is consumed, the if_must<> in the grammar makes a
+  // missing `)` a hard error rather than silent backtracking.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("sin(x", syms); }, parse_error);
+}
+
+// ─── Phase 2d: tensor declarations, tensor & t2s functions ────────
+
+TEST(ParserGrammar, TensorDeclarationRegistersTensor) {
+  symbol_table syms;
+  auto e = parse_tensor("A{rank=2, dim=3}", syms);
+  EXPECT_TRUE(e.is_valid());
+  EXPECT_EQ(e.get().rank(), 2u);
+  EXPECT_EQ(e.get().dim(), 3u);
+  auto shape = syms.tensor_shape("A");
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(shape->first, 2u);
+  EXPECT_EQ(shape->second, 3u);
+}
+
+TEST(ParserGrammar, TensorDeclarationKvOrderIndependent) {
+  symbol_table syms;
+  auto e1 = parse_tensor("A{rank=4, dim=3}", syms);
+  symbol_table syms2;
+  auto e2 = parse_tensor("A{dim=3, rank=4}", syms2);
+  EXPECT_EQ(e1.get().rank(), 4u);
+  EXPECT_EQ(e1.get().dim(), 3u);
+  EXPECT_EQ(e2.get().rank(), 4u);
+  EXPECT_EQ(e2.get().dim(), 3u);
+}
+
+TEST(ParserGrammar, BareIdentAfterTensorDeclResolvesToTensor) {
+  symbol_table syms;
+  [[maybe_unused]] auto decl = parse_tensor("A{rank=2, dim=3}", syms);
+  auto result = parse("A", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_expression>>(result))
+      << "Bare ident after tensor decl should resolve to the existing tensor.";
+}
+
+TEST(ParserGrammar, TensorDeclWithoutBothKvsThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_tensor("A{rank=2}", syms); },
+      parse_error);
+}
+
+TEST(ParserGrammar, TensorRedeclarationMismatchThrows) {
+  symbol_table syms;
+  [[maybe_unused]] auto decl = parse_tensor("A{rank=2, dim=3}", syms);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_tensor("A{rank=4, dim=3}", syms); },
+      redeclaration_error);
+}
+
+TEST(ParserGrammar, TraceReturnsT2s) {
+  symbol_table syms;
+  auto result = parse("trace(A{rank=2, dim=3})", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_to_scalar_expression>>(
+          result))
+      << "trace(tensor) should land in the tensor_to_scalar variant.";
+}
+
+TEST(ParserGrammar, TransReturnsTensor) {
+  symbol_table syms;
+  auto result = parse("trans(A{rank=2, dim=3})", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_expression>>(result))
+      << "trans(tensor) should land in the tensor variant.";
+}
+
+TEST(ParserGrammar, InvOfTensorReturnsTensor) {
+  symbol_table syms;
+  auto result = parse_tensor("inv(A{rank=2, dim=3})", syms);
+  EXPECT_TRUE(result.is_valid());
+}
+
+TEST(ParserGrammar, TraceOfScalarThrowsTypeMismatch) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("trace(x)", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, SinOfTensorThrowsTypeMismatch) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("sin(A{rank=2, dim=3})", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, ScalarTimesTensorReturnsTensor) {
+  symbol_table syms;
+  auto result = parse("2 * A{rank=2, dim=3}", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_expression>>(result));
+}
+
+TEST(ParserGrammar, TensorTimesScalarReturnsTensor) {
+  symbol_table syms;
+  auto result = parse("A{rank=2, dim=3} * 2", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_expression>>(result));
+}
+
+TEST(ParserGrammar, TensorPlusScalarThrowsTypeMismatch) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("A{rank=2, dim=3} + 2", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, ScalarDivTensorThrowsTypeMismatch) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("2 / A{rank=2, dim=3}", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, TraceCompositionAcrossTwoTensors) {
+  symbol_table syms;
+  auto result =
+      parse("trace(A{rank=2, dim=3}) + trace(B{rank=2, dim=3})", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_to_scalar_expression>>(
+          result));
+}
+
+TEST(ParserGrammar, ScalarTimesTraceReturnsT2s) {
+  symbol_table syms;
+  auto result = parse("2 * trace(A{rank=2, dim=3})", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_to_scalar_expression>>(
+          result));
+}
+
+// ─── Phase 2d review-pass additions ────────────────────────────────
+
+TEST(ParserGrammar, TensorDeclDuplicateRankThrows) {
+  // Review finding (bug 1): the kv_list grammar accepts repeated
+  // kvs, and without an explicit guard the second one silently
+  // overwrites the first. Pin the explicit-throw contract.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e =
+            parse_tensor("A{rank=2, rank=4, dim=3}", syms);
+      },
+      syntax_error);
+}
+
+TEST(ParserGrammar, TensorDeclDuplicateDimThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e = parse_tensor("A{rank=2, dim=3, dim=4}", syms);
+      },
+      syntax_error);
+}
+
+TEST(ParserGrammar, TensorDeclZeroRankThrows) {
+  // Review finding (bug 2): the tensor constructor takes rank/dim
+  // verbatim; degenerate values explode at evaluation. Validate at
+  // the parser level instead.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_tensor("A{rank=0, dim=3}", syms); },
+      syntax_error);
+}
+
+TEST(ParserGrammar, TensorDeclZeroDimThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_tensor("A{rank=2, dim=0}", syms); },
+      syntax_error);
+}
+
+TEST(ParserGrammar, ChainedComparisonIsCStyleNotMathAnd) {
+  // Review finding (coverage gap 3): comparison ops left-associate
+  // at the comparison precedence level. `a < b < c` parses as
+  // `(a < b) < c`, NOT `(a < b) AND (b < c)`. The result of `a < b`
+  // is a 0/1 indicator; that's then compared against c.
+  //
+  // With a=0, b=1, c=2: (0 < 1) = 1, 1 < 2 = 1.
+  // With a=0, b=1, c=1: (0 < 1) = 1, 1 < 1 = 0.
+  // With a=1, b=0, c=2: (1 < 0) = 0, 0 < 2 = 1  (NOT math-AND, which
+  //                                              would be 1<0=F → 0).
+  // The third case is the clearest behavioural divergence from a
+  // math-user's chain interpretation; lock it in.
+  symbol_table syms;
+  auto e = parse_scalar("a < b < c", syms);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 0}, {"b", 1}, {"c", 2}}), 1.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 0}, {"b", 1}, {"c", 1}}), 0.0);
+  EXPECT_DOUBLE_EQ(eval_scalar(e, syms, {{"a", 1}, {"b", 0}, {"c", 2}}), 1.0)
+      << "Chained-comparison should be C-style (value-of-comparison "
+         "then compare), NOT math-style AND.";
+}
+
+TEST(ParserGrammar, T2sPlusScalarThrowsTypeMismatch) {
+  // Review finding (coverage gap 4): parallel to TensorPlusScalar.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("trace(A{rank=2, dim=3}) + 2", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, EmptyInputThrows) {
+  // Review finding (coverage gap 6): empty source must throw, not
+  // return some null variant.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("", syms); }, parse_error);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("   ", syms); }, parse_error);
+}
+
+TEST(ParserGrammar, BareOpenParenThrows) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse_scalar("(", syms); }, parse_error);
+}
+
+TEST(ParserGrammar, TensorFunctionOnScalarMentionsExpectedType) {
+  // Review finding (coverage gap 5): error message should be useful.
+  // The error needs to convey what failed; assert the call name
+  // and arg-position appear in what().
+  symbol_table syms;
+  try {
+    [[maybe_unused]] auto e = parse("trans(x)", syms);
+    FAIL() << "Expected type_mismatch_error to be thrown.";
+  } catch (type_mismatch_error const &e) {
+    std::string what = e.what();
+    EXPECT_NE(what.find("trans"), std::string::npos)
+        << "Error message should mention the function name. what() was:\n"
+        << what;
+    EXPECT_NE(what.find("argument"), std::string::npos)
+        << "Error message should mention 'argument'. what() was:\n"
+        << what;
+  }
+}
+
+TEST(ParserGrammar, InvOfScalarThrowsTypeMismatch) {
+  // Review finding (coverage gap 7): inv expects tensor; parallel to
+  // the trace test.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("inv(x)", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, TransOfScalarThrowsTypeMismatch) {
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("trans(x)", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, LeadingAndTrailingWhitespaceTensorDecl) {
+  // Whitespace handling around a sole tensor_decl.
+  symbol_table syms;
+  auto e = parse_tensor("   A{rank=2, dim=3}   ", syms);
+  EXPECT_EQ(e.get().rank(), 2u);
+  EXPECT_EQ(e.get().dim(), 3u);
+}
+
+// ─── Phase 2e: bracket-list indices + contraction functions ───────
+
+TEST(ParserGrammar, InnerProductBasicReturnsTensor) {
+  // inner_product(A, [3,4], B, [1,2]) — full contraction of the last
+  // two indices of A with the first two of B. With A rank-4 and B
+  // rank-2, the result is rank-(4+2-2-2)=2 tensor.
+  symbol_table syms;
+  auto result =
+      parse("inner_product(A{rank=4, dim=3}, [3, 4], B{rank=2, dim=3}, [1, 2])",
+            syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_expression>>(result));
+}
+
+TEST(ParserGrammar, DotProductReturnsT2s) {
+  // dot_product over matching indices yields a scalar (t2s).
+  symbol_table syms;
+  auto result = parse(
+      "dot_product(A{rank=2, dim=3}, [1, 2], B{rank=2, dim=3}, [1, 2])", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_to_scalar_expression>>(
+          result));
+}
+
+TEST(ParserGrammar, BracketListAcceptsSingleIndex) {
+  // [1] — a single-index bracket-list. Useful for first/last-axis
+  // contractions.
+  symbol_table syms;
+  auto result =
+      parse("dot_product(A{rank=1, dim=3}, [1], B{rank=1, dim=3}, [1])", syms);
+  EXPECT_TRUE(
+      std::holds_alternative<expression_holder<tensor_to_scalar_expression>>(
+          result));
+}
+
+TEST(ParserGrammar, BracketListEmptyThrows) {
+  // [] not allowed — contraction requires at least one index per side.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e = parse(
+            "inner_product(A{rank=2, dim=3}, [], B{rank=2, dim=3}, [1, 2])",
+            syms);
+      },
+      parse_error);
+}
+
+TEST(ParserGrammar, BracketListZeroIndexThrows) {
+  // Indices are 1-based; 0 is invalid.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e =
+            parse("inner_product(A{rank=2, dim=3}, [0, 1], B{rank=2, dim=3}, "
+                  "[1, 2])",
+                  syms);
+      },
+      lexical_error);
+}
+
+TEST(ParserGrammar, BracketListAsToplevelExpressionThrows) {
+  // A bare bracket-list at the top is not an expression.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("[1, 2, 3]", syms); }, parse_error);
+}
+
+TEST(ParserGrammar, BracketListPassedToNonContractionThrows) {
+  // sin doesn't take an index list — passing one is a type mismatch.
+  symbol_table syms;
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = parse("sin([1, 2])", syms); },
+      type_mismatch_error);
+}
+
+TEST(ParserGrammar, InnerProductWithExpressionWhereIndexExpectedThrows) {
+  // inner_product expects arg-positions 1 and 3 to be bracket-lists,
+  // not expressions. Passing an expression there is a type mismatch.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e =
+            parse("inner_product(A{rank=2, dim=3}, 1 + 2, B{rank=2, dim=3}, "
+                  "[1, 2])",
+                  syms);
+      },
+      type_mismatch_error);
+}
+
+// ─── Phase 2e review-pass additions ────────────────────────────────
+
+// Local tensor-data factory — TensorEvaluatorTest.h's `make_test_data`
+// lives in an anonymous namespace and we appear alphabetically before
+// it in main.cpp's include block, so we can't reuse the symbol.
+// Same shape; duplication is two lines.
+namespace parser_test_detail {
+template <std::size_t Dim, std::size_t Rank>
+inline auto make_tensor_data(std::initializer_list<double> values) {
+  auto ptr = std::make_shared<numsim::cas::tensor_data<double, Dim, Rank>>();
+  auto *raw = ptr->raw_data();
+  std::size_t i = 0;
+  for (auto v : values) {
+    raw[i++] = v;
+  }
+  return ptr;
+}
+} // namespace parser_test_detail
+
+TEST(ParserGrammar, DotProductEvaluatorRoundTrip) {
+  // Review finding (gap 1): pin the end-to-end value, not just the
+  // variant alternative. dot_product over matching indices computes
+  // sum_ij A_ij * A_ij for A = [[1, 2], [3, 4]]:
+  //   1*1 + 2*2 + 3*3 + 4*4 = 1 + 4 + 9 + 16 = 30.
+  //
+  // Catches any off-by-one in to_sequence (1-based → 0-based), any
+  // lhs/rhs swap in the dispatch lambda, and any index-list flow
+  // breakage between the action stack and the function call.
+  symbol_table syms;
+  auto expr = parse_t2s(
+      "dot_product(A{rank=2, dim=2}, [1, 2], A{rank=2, dim=2}, [1, 2])", syms);
+
+  // Recover the parser-declared tensor holder so we can bind data
+  // to the SAME holder the parsed expression references.
+  auto lookup = syms.get("A");
+  ASSERT_TRUE(lookup.has_value());
+  auto *A_ptr = std::get_if<expression_holder<tensor_expression>>(&*lookup);
+  ASSERT_NE(A_ptr, nullptr);
+
+  numsim::cas::tensor_to_scalar_evaluator<double> ev;
+  ev.set(*A_ptr,
+         parser_test_detail::make_tensor_data<2, 2>({1.0, 2.0, 3.0, 4.0}));
+  EXPECT_NEAR(ev.apply(expr), 30.0, 1e-12);
+}
+
+TEST(ParserGrammar, DotProductEvaluatorRoundTripAsymmetricMatrix) {
+  // Round-trip with an asymmetric matrix to confirm the index
+  // conversion doesn't accidentally transpose. For B = [[1, 2],
+  // [3, 4]] paired against C = [[5, 6], [7, 8]]:
+  //   dot_product(B, [1, 2], C, [1, 2]) = sum_ij B_ij C_ij
+  //   = 1*5 + 2*6 + 3*7 + 4*8 = 5 + 12 + 21 + 32 = 70.
+  symbol_table syms;
+  auto expr = parse_t2s(
+      "dot_product(B{rank=2, dim=2}, [1, 2], C{rank=2, dim=2}, [1, 2])", syms);
+  auto b_lookup = syms.get("B");
+  auto c_lookup = syms.get("C");
+  ASSERT_TRUE(b_lookup.has_value() && c_lookup.has_value());
+  auto *B_ptr = std::get_if<expression_holder<tensor_expression>>(&*b_lookup);
+  auto *C_ptr = std::get_if<expression_holder<tensor_expression>>(&*c_lookup);
+  ASSERT_NE(B_ptr, nullptr);
+  ASSERT_NE(C_ptr, nullptr);
+  numsim::cas::tensor_to_scalar_evaluator<double> ev;
+  ev.set(*B_ptr,
+         parser_test_detail::make_tensor_data<2, 2>({1.0, 2.0, 3.0, 4.0}));
+  ev.set(*C_ptr,
+         parser_test_detail::make_tensor_data<2, 2>({5.0, 6.0, 7.0, 8.0}));
+  EXPECT_NEAR(ev.apply(expr), 70.0, 1e-12);
+}
+
+TEST(ParserGrammar, BracketListTrailingCommaThrows) {
+  // Review finding (gap 2): `[1, 2,]` — trailing comma.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e = parse(
+            "dot_product(A{rank=2, dim=3}, [1, 2,], B{rank=2, dim=3}, [1, 2])",
+            syms);
+      },
+      parse_error);
+}
+
+TEST(ParserGrammar, BracketListMissingCommaThrows) {
+  // `[1 2]` — missing comma.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e = parse(
+            "dot_product(A{rank=2, dim=3}, [1 2], B{rank=2, dim=3}, [1, 2])",
+            syms);
+      },
+      parse_error);
+}
+
+TEST(ParserGrammar, BracketListDoubleCommaThrows) {
+  // `[1,,2]` — double comma.
+  symbol_table syms;
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto e = parse(
+            "dot_product(A{rank=2, dim=3}, [1,,2], B{rank=2, dim=3}, [1, 2])",
+            syms);
+      },
+      parse_error);
+}
+
+// ─── Phase 3a: integration tests ───────────────────────────────────
+//
+// End-to-end checks that parse-produced ASTs participate correctly in
+// the rest of the library: differentiation, evaluation, and
+// locale-independent number parsing. Each test parses a non-trivial
+// input, hands the result to an existing-library API, and asserts the
+// numeric or printed-form outcome. These are the first tests that
+// exercise the parser the way real callers will — grammar tests
+// confirm the parse succeeds; these confirm the AST is well-formed
+// enough for downstream visitors.
+
+TEST(ParserIntegration, PythagoreanDerivativeIsZero) {
+  // d/dx (sin(x)^2 + cos(x)^2) ≡ 0 for all x. Catches mistakes in the
+  // scalar function-call dispatch (sin/cos registry entries), `^` AST
+  // shape, and any construction-time simplification that would corrupt
+  // the chain rule downstream.
+  symbol_table syms;
+  auto e = parse_scalar("sin(x)^2 + cos(x)^2", syms);
+  auto x = syms.get_or_declare_scalar("x");
+  auto d = numsim::cas::diff(e, x);
+
+  numsim::cas::scalar_evaluator<double> ev;
+  for (double val : {0.0, 0.5, 1.0, 1.5, -0.7, 3.14159, 100.0}) {
+    ev.set(x, val);
+    EXPECT_NEAR(ev.apply(d), 0.0, 1e-12)
+        << "Pythagorean derivative should be 0 at x = " << val;
+  }
+}
+
+TEST(ParserIntegration, TraceGradientEqualsIdentity) {
+  // Two assertions woven into one test:
+  //
+  //  (a) The bare-`A` reference after `A{rank=2, dim=3}` resolves to
+  //      the SAME holder that lives inside the trace expression. The
+  //      diff result alone can't prove this — `diff(trace(A_x), A_y)`
+  //      would yield `identity_tensor` regardless of whether A_x and
+  //      A_y are literally the same holder, since the diff visitor
+  //      compares by value-equality on named tensors. The EXPECT_EQ
+  //      below is what actually pins phase 2d's lookup-first contract.
+  //  (b) d(trace(A))/dA = I (rank-2 identity tensor of matching dim).
+  //      Pins the (t2s, tensor) diff routing via tag_invoke.
+  symbol_table syms;
+  auto trace_expr = parse_t2s("trace(A{rank=2, dim=3})", syms);
+  auto A_bare = parse_tensor("A", syms);
+  auto A_lookup = syms.get("A");
+  ASSERT_TRUE(A_lookup.has_value());
+  auto *A_in_syms =
+      std::get_if<expression_holder<tensor_expression>>(&*A_lookup);
+  ASSERT_NE(A_in_syms, nullptr);
+  EXPECT_EQ(A_bare, *A_in_syms)
+      << "Bare `A` must resolve to the SAME holder as the declared tensor.";
+
+  auto d = diff(trace_expr, A_bare);
+  auto I = make_expression<identity_tensor>(std::size_t{3}, std::size_t{2});
+  EXPECT_SAME_PRINT(d, I);
+}
+
+TEST(ParserIntegration, MultiVariablePolynomialEvaluatesAtSampledPoints) {
+  // Parse `a*x^2 + b*x + c`, implicitly declaring four scalars in one
+  // go, then evaluate at sample (a, b, c, x). With (1, -3, 2):
+  //   polynomial = x^2 - 3x + 2 = (x-1)(x-2), roots at x=1, x=2.
+  //
+  // Verifies the parser composes literals + named scalars + mixed
+  // operators (* with both name-name and name-literal, then `+`)
+  // into an AST the scalar_evaluator can walk, AND that the
+  // symbol_table threads four implicit scalar declarations through
+  // one parse without cross-pollution.
+  symbol_table syms;
+  auto e = parse_scalar("a*x^2 + b*x + c", syms);
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(e, syms, {{"a", 1}, {"b", -3}, {"c", 2}, {"x", 1.0}}), 0.0);
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(e, syms, {{"a", 1}, {"b", -3}, {"c", 2}, {"x", 2.0}}), 0.0);
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(e, syms, {{"a", 1}, {"b", -3}, {"c", 2}, {"x", 0.0}}), 2.0);
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(e, syms, {{"a", 1}, {"b", -3}, {"c", 2}, {"x", 4.0}}), 6.0);
+  EXPECT_DOUBLE_EQ(
+      eval_scalar(e, syms, {{"a", 1}, {"b", -3}, {"c", 2}, {"x", -1.0}}), 6.0);
+}
+
+TEST(ParserIntegration, NumberLiteralIsLocaleIndependent) {
+  // Number-literal parsing uses std::from_chars, which ignores the
+  // global C locale. Set a comma-decimal locale, parse "1.5", and
+  // verify the value is 1.5 — proving we don't silently fall through
+  // to std::strtod / std::stod (both honor the global locale and
+  // would either misparse or throw in de_DE).
+  //
+  // CI runners may not have de_DE.UTF-8 installed; if no comma-decimal
+  // locale is available, skip rather than fail.
+  // Try a broad set of comma-decimal locales — most Linux/macOS CI
+  // images ship at least one of these, even if `de_DE` is missing.
+  // en_DK.utf8 is unusual because it's Danish English (so it's
+  // installed on hosts that don't have any continental European
+  // locales) but it still uses comma-decimal.
+  std::locale saved;
+  bool locale_set = false;
+  for (auto const *loc_name : {"de_DE.UTF-8", "de_DE.utf8", "de_DE", //
+                               "fr_FR.UTF-8", "fr_FR.utf8", "fr_FR", //
+                               "it_IT.UTF-8", "it_IT.utf8",          //
+                               "es_ES.UTF-8", "es_ES.utf8",          //
+                               "nl_NL.UTF-8", "nl_NL.utf8",          //
+                               "pt_PT.UTF-8", "pt_PT.utf8",          //
+                               "ru_RU.UTF-8", "ru_RU.utf8",          //
+                               "en_DK.UTF-8", "en_DK.utf8"}) {
+    try {
+      saved = std::locale::global(std::locale(loc_name));
+      locale_set = true;
+      break;
+    } catch (std::runtime_error const &) {
+      // try the next candidate name
+    }
+  }
+  if (!locale_set) {
+    GTEST_SKIP() << "no comma-decimal locale installed; skipping";
+  }
+
+  // RAII-restore the locale even if the EXPECT below throws.
+  struct LocaleRestorer {
+    std::locale saved;
+    ~LocaleRestorer() { std::locale::global(saved); }
+  } restorer{saved};
+
+  symbol_table syms;
+  EXPECT_DOUBLE_EQ(eval_scalar(parse_scalar("1.5", syms), syms), 1.5)
+      << "Parser must read '1.5' as 1.5 regardless of the global C "
+         "locale's decimal separator.";
+}
+
+// ─── Phase 3b: error-coverage tests ────────────────────────────────
+//
+// Phase 2 confirmed every error path raises *some* `parse_error`.
+// These tests tighten that: the right subclass fires, `position()`
+// points at the offending byte (verified inside multi-line input for
+// at least one path), `what()` mentions a relevant token, and the
+// subclass-specific accessors (`name()`, `expected_arity()`, …)
+// carry the values the throw site supplied. A regression that
+// broadened a throw to the base `parse_error` would still pass the
+// existing `EXPECT_THROW(..., parse_error)` checks; these don't.
+
+TEST(ParserErrorCoverage, BracketListZeroIndexFiresLexicalErrorWithPosition) {
+  symbol_table syms;
+  std::string src =
+      "inner_product(A{rank=2, dim=3}, [0, 1], B{rank=2, dim=3}, [1, 2])";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected lexical_error.";
+  } catch (lexical_error const &e) {
+    EXPECT_EQ(e.position(), src.find('0'))
+        << "Position should point at the offending '0'.";
+    EXPECT_NE(std::string(e.what()).find("1-based"), std::string::npos)
+        << "Message should mention the 1-based constraint. what():\n"
+        << e.what();
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, BracketListOverflowFiresLexicalErrorWithMessage) {
+  symbol_table syms;
+  std::string src =
+      "inner_product(A{rank=2, dim=3}, [99999999999999999999, 1], "
+      "B{rank=2, dim=3}, [1, 2])";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected lexical_error (overflow path).";
+  } catch (lexical_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("exceeds"), std::string::npos)
+        << "Overflow message should differ from the generic 'must be "
+           "positive 1-based' message. what():\n"
+        << e.what();
+  }
+}
+
+TEST(ParserErrorCoverage, ZeroRankTensorFiresSyntaxErrorAtDeclaration) {
+  symbol_table syms;
+  std::string src = "trace(A{rank=0, dim=3})";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected syntax_error.";
+  } catch (syntax_error const &e) {
+    // Action raises with the tensor_decl start position (the `A`).
+    EXPECT_EQ(e.position(), src.find('A'));
+    EXPECT_NE(std::string(e.what()).find("rank"), std::string::npos);
+    EXPECT_NE(std::string(e.what()).find(">= 1"), std::string::npos);
+  }
+}
+
+TEST(ParserErrorCoverage, ArityErrorCarriesFunctionNameAndCounts) {
+  symbol_table syms;
+  std::string src = "sin(x, y)";
+  try {
+    [[maybe_unused]] auto e = parse_scalar(src, syms);
+    FAIL() << "Expected arity_error.";
+  } catch (arity_error const &e) {
+    EXPECT_EQ(e.function(), "sin");
+    EXPECT_EQ(e.expected_arity(), 1u);
+    EXPECT_EQ(e.actual_arity(), 2u);
+    EXPECT_NE(std::string(e.what()).find("sin"), std::string::npos);
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, UnknownFunctionErrorCarriesName) {
+  symbol_table syms;
+  std::string src = "no_such_fn(x, y)";
+  try {
+    [[maybe_unused]] auto e = parse_scalar(src, syms);
+    FAIL() << "Expected unknown_function_error.";
+  } catch (unknown_function_error const &e) {
+    EXPECT_EQ(e.name(), "no_such_fn");
+    EXPECT_NE(std::string(e.what()).find("no_such_fn"), std::string::npos);
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, TypeMismatchMessageMentionsOperand) {
+  // `sin(A{...})` — sin's arg_kind is scalar, A is tensor. The
+  // function-call action's type-check should reject with the call
+  // name and argument index in the message so the user can locate
+  // the mistake.
+  symbol_table syms;
+  std::string src = "sin(A{rank=2, dim=3})";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected type_mismatch_error.";
+  } catch (type_mismatch_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("sin"), std::string::npos);
+    EXPECT_NE(std::string(e.what()).find("argument"), std::string::npos);
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, TypeCollisionScalarThenTensorInSameParse) {
+  // `x` is implicitly declared scalar by the first reference. The
+  // later `x{rank=2, dim=3}` tries to declare it as a tensor and
+  // hits symbol_table's collision check, which the parser re-throws
+  // as a type_collision_error with the call site's position.
+  symbol_table syms;
+  std::string src = "x + x{rank=2, dim=3}";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected type_collision_error.";
+  } catch (type_collision_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("x"), std::string::npos);
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, RedeclarationDifferentShapeInSameParse) {
+  // Two tensor decls in one expression with mismatched (rank, dim).
+  symbol_table syms;
+  std::string src = "trace(A{rank=2, dim=3}) + dot(A{rank=4, dim=3})";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected redeclaration_error.";
+  } catch (redeclaration_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("A"), std::string::npos);
+    EXPECT_TRUE(e.has_position());
+  }
+}
+
+TEST(ParserErrorCoverage, MultiLineInputPreservesLineAndColumn) {
+  // Multi-line input where the error fires on line 3 (the zero-rank
+  // tensor). Verifies the byte-offset → line:column translation in
+  // parse_error.cpp survives whitespace-padded multi-line input.
+  symbol_table syms;
+  std::string src = "1 +\n  2 *\n  trace(A{rank=0, dim=3})\n";
+  try {
+    [[maybe_unused]] auto e = parse(src, syms);
+    FAIL() << "Expected syntax_error.";
+  } catch (syntax_error const &e) {
+    EXPECT_EQ(e.line(), 3u) << "Error should land on line 3. what():\n"
+                            << e.what();
+    EXPECT_TRUE(e.has_position());
+    // Snippet should include line 3's text, not lines 1 or 2.
+    std::string what = e.what();
+    EXPECT_NE(what.find("trace(A{rank=0, dim=3})"), std::string::npos);
+    EXPECT_EQ(what.find("1 +"), std::string::npos)
+        << "Line 1 should not appear in the snippet. what():\n"
+        << what;
+  }
+}
+
+TEST(ParserErrorCoverage, PegtlTranslatedErrorPropagatesAsSyntaxError) {
+  // Regression test: parser.cpp's `translate_pegtl_error` used to
+  // return by value of base type `parse_error`, which sliced the
+  // `syntax_error` constructed inside it down to the base before the
+  // throw — so PEGTL-originated must-failures (missing close paren,
+  // unexpected EOF) arrived at the catch site as base `parse_error`
+  // instead of `syntax_error`. Now the function returns by `syntax_error`,
+  // preserving the type through the throw. Lock that in:
+  //
+  // `sin(x` triggers PEGTL's `must<function_call_close>` failure path,
+  // which goes through translate_pegtl_error. Must arrive as the
+  // narrow subclass.
+  symbol_table syms;
+  try {
+    [[maybe_unused]] auto e = parse_scalar("sin(x", syms);
+    FAIL() << "Expected syntax_error.";
+  } catch (syntax_error const &) {
+    SUCCEED();
+  } catch (parse_error const &e) {
+    FAIL() << "PEGTL-translated error was sliced to base parse_error. what():\n"
+           << e.what();
+  }
+}
+
+TEST(ParserErrorCoverage, UnknownSymbolErrorIsUnreachableFromParser) {
+  // Documentation test: the parser never raises unknown_symbol_error
+  // because every bare identifier in scalar position is implicitly
+  // declared by `get_or_declare_scalar`. The error class exists for
+  // potential future use (e.g. a strict mode that disables implicit
+  // declaration) and is exercised at the constructor level by
+  // ParseError.UnknownSymbolErrorCarriesName.
+  //
+  // This test pins the current behavior: a bare reference to a
+  // never-declared name in scalar position succeeds and implicitly
+  // declares the name as scalar.
+  symbol_table syms;
+  EXPECT_NO_THROW({
+    [[maybe_unused]] auto e = parse_scalar("never_seen_before + 1", syms);
+  });
+  EXPECT_TRUE(syms.has("never_seen_before"));
 }
 
 } // namespace numsim::cas::parser_test

--- a/tests/ParserTest.h
+++ b/tests/ParserTest.h
@@ -1,0 +1,211 @@
+#ifndef PARSERTEST_H
+#define PARSERTEST_H
+
+// Parser tests for issue #214 — the PEGTL string parser.
+//
+// File is always included in tests/main.cpp; body is gated on
+// NUMSIM_CAS_PARSER_ENABLED, defined only when the CMake option
+// NUMSIM_CAS_BUILD_PARSER=ON wires up the NumSim_CAS::Parser library
+// target and links it into the test binary. When the option is OFF
+// this file is a no-op.
+
+#ifdef NUMSIM_CAS_PARSER_ENABLED
+
+#include <gtest/gtest.h>
+
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <string>
+
+namespace numsim::cas::parser_test {
+
+// Bring the parser's public types into scope unqualified to keep test
+// bodies readable. Restricted to this anonymous-ish translation-unit
+// namespace; doesn't leak to other test files.
+using numsim::cas::parser::arity_error;
+using numsim::cas::parser::parse_error;
+using numsim::cas::parser::redeclaration_error;
+using numsim::cas::parser::symbol_table;
+using numsim::cas::parser::type_collision_error;
+using numsim::cas::parser::unknown_symbol_error;
+
+// ─── symbol_table: scalar declarations ─────────────────────────────
+
+TEST(SymbolTable, ImplicitScalarOnFirstUse) {
+  symbol_table st;
+  auto x = st.get_or_declare_scalar("x");
+  EXPECT_TRUE(x.is_valid());
+  EXPECT_TRUE(st.has("x"));
+}
+
+TEST(SymbolTable, RepeatedScalarLookupReturnsSameHolder) {
+  symbol_table st;
+  auto a = st.get_or_declare_scalar("alpha");
+  auto b = st.get_or_declare_scalar("alpha");
+  EXPECT_EQ(a, b)
+      << "Repeated lookups of an implicitly-declared scalar must return "
+         "the same expression_holder so structural equality across the "
+         "parse holds.";
+}
+
+TEST(SymbolTable, DifferentScalarsHaveDistinctHolders) {
+  symbol_table st;
+  auto x = st.get_or_declare_scalar("x");
+  auto y = st.get_or_declare_scalar("y");
+  EXPECT_NE(x, y);
+}
+
+// ─── symbol_table: tensor declarations ─────────────────────────────
+
+TEST(SymbolTable, TensorDeclaresWithRankAndDim) {
+  symbol_table st;
+  auto a = st.get_or_declare_tensor("A", /*rank=*/2, /*dim=*/3);
+  EXPECT_TRUE(a.is_valid());
+  EXPECT_EQ(a.get().rank(), 2u);
+  EXPECT_EQ(a.get().dim(), 3u);
+}
+
+TEST(SymbolTable, TensorIdenticalRedeclarationReturnsSameHolder) {
+  symbol_table st;
+  auto a1 = st.get_or_declare_tensor("A", 2, 3);
+  auto a2 = st.get_or_declare_tensor("A", 2, 3);
+  EXPECT_EQ(a1, a2);
+}
+
+TEST(SymbolTable, TensorRedeclarationWithDifferentRankThrows) {
+  symbol_table st;
+  st.get_or_declare_tensor("A", 2, 3);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = st.get_or_declare_tensor("A", 4, 3); },
+      redeclaration_error);
+}
+
+TEST(SymbolTable, TensorRedeclarationWithDifferentDimThrows) {
+  symbol_table st;
+  st.get_or_declare_tensor("A", 2, 3);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = st.get_or_declare_tensor("A", 2, 2); },
+      redeclaration_error);
+}
+
+// ─── symbol_table: cross-type collision ────────────────────────────
+
+TEST(SymbolTable, ScalarThenTensorThrowsCollision) {
+  symbol_table st;
+  st.get_or_declare_scalar("X");
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = st.get_or_declare_tensor("X", 2, 3); },
+      type_collision_error);
+}
+
+TEST(SymbolTable, TensorThenScalarThrowsCollision) {
+  symbol_table st;
+  st.get_or_declare_tensor("X", 2, 3);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = st.get_or_declare_scalar("X"); },
+      type_collision_error);
+}
+
+// ─── symbol_table: read-only inspection ────────────────────────────
+
+TEST(SymbolTable, TensorShapeReturnsRankAndDim) {
+  symbol_table st;
+  st.get_or_declare_tensor("A", 4, 3);
+  auto shape = st.tensor_shape("A");
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(shape->first, 4u);
+  EXPECT_EQ(shape->second, 3u);
+}
+
+TEST(SymbolTable, TensorShapeOfScalarReturnsNullopt) {
+  symbol_table st;
+  st.get_or_declare_scalar("x");
+  EXPECT_FALSE(st.tensor_shape("x").has_value());
+}
+
+TEST(SymbolTable, TensorShapeOfUnknownReturnsNullopt) {
+  symbol_table st;
+  EXPECT_FALSE(st.tensor_shape("never_declared").has_value());
+}
+
+TEST(SymbolTable, HasReportsBothScalarAndTensor) {
+  symbol_table st;
+  st.get_or_declare_scalar("x");
+  st.get_or_declare_tensor("A", 2, 3);
+  EXPECT_TRUE(st.has("x"));
+  EXPECT_TRUE(st.has("A"));
+  EXPECT_FALSE(st.has("y"));
+}
+
+// ─── parse_error: snippet rendering ────────────────────────────────
+
+TEST(ParseError, NoSourceGivesBareMessage) {
+  parse_error e("something went wrong", 0, std::string_view{});
+  std::string what = e.what();
+  EXPECT_EQ(what, "parse error: something went wrong");
+  EXPECT_FALSE(e.has_position());
+}
+
+TEST(ParseError, SingleLineSourceRendersSnippetWithCaret) {
+  std::string src = "sin(x + 2";
+  parse_error e("expected ')'", /*pos=*/src.size(), src);
+  std::string what = e.what();
+  // Header reports line=1, col=10 (one past the last char).
+  EXPECT_NE(what.find("at 1:10:"), std::string::npos)
+      << "Header missing line:col. what() was:\n"
+      << what;
+  // Snippet must include the offending line and a caret at col 10.
+  EXPECT_NE(what.find("sin(x + 2"), std::string::npos);
+  EXPECT_NE(what.find("\n           ^"), std::string::npos)
+      << "Caret should be at column 10 (9 spaces + ^). what() was:\n"
+      << what;
+  EXPECT_TRUE(e.has_position());
+  EXPECT_EQ(e.line(), 1u);
+  EXPECT_EQ(e.column(), 10u);
+}
+
+TEST(ParseError, MultiLineSourceCaretAlignsWithCorrectLine) {
+  std::string src = "line one\nline two has the error here\nline three";
+  // Point at 'e' in "error" — column 18 of line 2.
+  // ("line two has the " is 17 chars; 'e' is at column 18, 1-based.)
+  auto pos = src.find("error");
+  ASSERT_NE(pos, std::string::npos);
+  parse_error e("unexpected 'error'", pos, src);
+  EXPECT_EQ(e.line(), 2u);
+  EXPECT_EQ(e.column(), 18u);
+  std::string what = e.what();
+  // Snippet must be the *second* line, not the first.
+  EXPECT_NE(what.find("line two has the error here"), std::string::npos);
+  EXPECT_EQ(what.find("line one"), std::string::npos)
+      << "First line should not appear in the snippet. what() was:\n"
+      << what;
+  // Caret should be at column 18 (17 spaces + ^).
+  EXPECT_NE(what.find("\n  " + std::string(17, ' ') + '^'), std::string::npos)
+      << "Caret column mismatch. what() was:\n"
+      << what;
+}
+
+// ─── parse_error: subclass extra fields ────────────────────────────
+
+TEST(ParseError, UnknownSymbolErrorCarriesName) {
+  unknown_symbol_error e("foo", 0, std::string_view{});
+  EXPECT_EQ(e.name(), "foo");
+  EXPECT_NE(std::string(e.what()).find("foo"), std::string::npos);
+}
+
+TEST(ParseError, ArityErrorCarriesCounts) {
+  arity_error e("sin", /*expected=*/1, /*actual=*/2, 0, std::string_view{});
+  EXPECT_EQ(e.function(), "sin");
+  EXPECT_EQ(e.expected_arity(), 1u);
+  EXPECT_EQ(e.actual_arity(), 2u);
+  EXPECT_NE(std::string(e.what()).find("sin"), std::string::npos);
+  EXPECT_NE(std::string(e.what()).find("1"), std::string::npos);
+  EXPECT_NE(std::string(e.what()).find("2"), std::string::npos);
+}
+
+} // namespace numsim::cas::parser_test
+
+#endif // NUMSIM_CAS_PARSER_ENABLED
+
+#endif // PARSERTEST_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,5 +1,6 @@
 #include "CoreBugFixTest.h"
 #include "LimitVisitorTest.h"
+#include "ParserTest.h"
 #include "ScalarAssumptionTest.h"
 #include "ScalarComparisonTest.h"
 #include "ScalarDifferentiationTest.h"


### PR DESCRIPTION
First slice of the PEGTL-based string parser ([#214](https://github.com/NumSim-Stack/numsim-cas/issues/214)). Ships the non-grammar plumbing so phase 2 can land the grammar in isolation.

## What's in

**CMake option** `NUMSIM_CAS_BUILD_PARSER` (default OFF). With the flag OFF the main library globs exclude `src/numsim_cas/parser/` and `include/numsim_cas/parser/` entirely — zero parser code compiled. Baseline test count (1736) unchanged.

**`include/numsim_cas/parser/parse_error.h`**
- `parse_error` base + 8 specialised subclasses: `lexical_error`, `syntax_error`, `unknown_symbol_error`, `unknown_function_error`, `arity_error`, `type_mismatch_error`, `redeclaration_error`, `type_collision_error`.
- Position-aware constructor: rendered `what()` includes a snippet-with-caret pointing at the offending byte.
- No-source overload (empty `string_view`) gracefully degrades to `"parse error: <body>"` — used by `symbol_table` which has no source context. Phase 2 parser actions will catch and re-throw with position.

**`include/numsim_cas/parser/symbol_table.h`**
- On-the-fly typed registry. Scalars implicit on first bare use; tensors explicit via `get_or_declare_tensor(name, rank, dim)`.
- Identical redeclarations return the same holder.
- `redeclaration_error` on rank/dim mismatch.
- `type_collision_error` on scalar↔tensor cross-use (both orders).
- Thread-safety and persistence-on-failure semantics documented in the class doxygen.

**`src/numsim_cas/parser/{parse_error,symbol_table}.cpp`** — implementations.

**Conditional library target** `NumSim_CAS_Parser` (alias `NumSim_CAS::Parser`) when the flag is ON, with full warnings matrix matching the main lib (`-Wall -Wextra -Wpedantic` on GCC/Clang, `/W4` on MSVC). Sanitiser flags propagate. Header install path `numsim_cas/parser/*.h` only when both the main install and the parser flag are on.

**`tests/ParserTest.h`** — 18 tests across two suites:

- `SymbolTable` (13): implicit scalar declaration, repeated-lookup identity, distinct holders, tensor declaration with rank+dim, identical redecl returns same holder, rank mismatch / dim mismatch throws, both cross-type collision orderings, `tensor_shape` / `has` inspection.
- `ParseError` (5): empty-source gives bare message, single-line source renders snippet+caret at correct column, multi-line source caret lands on the right line, subclass fields (`name`, `function`, `arity`) carry through.

File body gated on `NUMSIM_CAS_PARSER_ENABLED`, defined when the parser library is linked. Tests are a no-op when the flag is OFF.

## What's NOT in (phase 2)

- The PEGTL grammar + actions
- `parser.cpp` top-level `parse()` and `parse_scalar/tensor/t2s` wrappers
- FetchContent for `taocpp/PEGTL` (only added when phase 2 needs it)

## Verification

- `cmake -DNUMSIM_CAS_BUILD_PARSER=OFF` (default): **1736 tests pass**, no parser TUs compiled.
- `cmake -DNUMSIM_CAS_BUILD_PARSER=ON`: **1754 tests pass** (+18 parser).
- `clang-format-18 --Werror` clean on every new file.

Plan: `.claude/plans/starry-tinkering-mitten.md` (in the working tree).