### PR TITLE
Parser examples + slicing fix in PEGTL error translation (#214)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,3 +93,4 @@ auto dd = diff(d, X);    // det(X) * inv(trans(X))
 | [Tensor-to-Scalar Domain](tensor-to-scalar.md) | 13 node types, trace/det/norm functions, simplifiers |
 | [Cross-Domain Interactions](cross-domain.md) | Cross-domain nodes, expression lifecycle, build system |
 | [Differentiation](differentiation.md) | Symbolic differentiation rules with mathematical notation |
+| [String Parser](parser.md) | PEGTL-based parser: grammar, type system, error catalogue, build flag |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,284 @@
+# String Parser
+
+The string parser converts source-code expressions into the same
+`expression_holder<...>` ASTs that the rest of the library builds via
+C++ factories and operator overloads. Implemented with
+[taocpp/PEGTL](https://github.com/taocpp/PEGTL); lives behind the
+`NUMSIM_CAS_BUILD_PARSER=ON` CMake option (default OFF), so consumers
+that don't need it pay no compile cost.
+
+Tracked under [#214](https://github.com/NumSim-Stack/numsim-cas/issues/214).
+
+## Quick Start
+
+```cpp
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/visitors/scalar_evaluator.h>
+
+namespace cas = numsim::cas;
+
+cas::parser::symbol_table syms;
+auto e = cas::parser::parse_scalar("a*x^2 + b*x + c", syms);
+
+cas::scalar_evaluator<double> ev;
+ev.set(syms.get_or_declare_scalar("a"), 1.0);
+ev.set(syms.get_or_declare_scalar("b"), -3.0);
+ev.set(syms.get_or_declare_scalar("c"), 2.0);
+ev.set(syms.get_or_declare_scalar("x"), 1.0);
+
+double y = ev.apply(e);  // 0 — a root of (x-1)(x-2)
+```
+
+Four worked examples live under `examples/`:
+[`parser_basics.cpp`](../examples/parser_basics.cpp),
+[`parser_symbol_table.cpp`](../examples/parser_symbol_table.cpp),
+[`parser_error_handling.cpp`](../examples/parser_error_handling.cpp),
+[`parser_tensor_diff.cpp`](../examples/parser_tensor_diff.cpp).
+
+## Pipeline
+
+```mermaid
+graph LR
+    SRC[Source string]
+    GR[PEGTL grammar<br/>src/.../grammar.h]
+    AC[Actions<br/>src/.../actions.h]
+    REG[Function registry<br/>src/.../function_registry.h]
+    SYM[symbol_table]
+    AST[parsed_expression<br/>variant&lt;scalar, tensor, t2s&gt;]
+
+    SRC --> GR
+    GR -->|each rule match| AC
+    AC -->|function calls| REG
+    AC <-->|declare/lookup| SYM
+    AC -->|value stack| AST
+```
+
+Source is fed to the PEGTL grammar. Each rule match fires an action
+that pushes onto a value stack; binary-op tails pop two values and
+push the combined result. Function-call rules look the name up in
+the registry, type-check the argument kinds, and call the dispatch
+lambda. The final stack value is returned as the
+`parsed_expression` variant.
+
+## Grammar (EBNF)
+
+Operator precedence runs lowest to highest:
+
+| Level | Operators | Associativity | Example |
+|-------|-----------|---------------|---------|
+| 1 | `==` `!=`            | left          | `a == b` |
+| 2 | `<` `<=` `>` `>=`    | left          | `a < b < c` (C-style) |
+| 3 | `+` `-` (binary)     | left          | `a - b - c = (a-b) - c` |
+| 4 | `*` `/`              | left          | `a / b / c = (a/b) / c` |
+| 5 | `-` (unary)          | right         | `--x = -(-x)` |
+| 6 | `^` (power)          | right         | `2^3^2 = 2^(3^2) = 512` |
+
+```ebnf
+expression       = eq_term ;
+eq_term          = cmp_term  , { ('==' | '!=') , cmp_term  } ;
+cmp_term         = add_term  , { ('<' | '<=' | '>' | '>=') , add_term  } ;
+add_term         = mul_term  , { ('+' | '-') , mul_term  } ;
+mul_term         = unary     , { ('*' | '/') , unary     } ;
+unary            = '-' , unary | power ;
+power            = primary , [ '^' , power ] ;                  (* right-recursive *)
+primary          = number | function_call | tensor_decl
+                 | identifier | '(' , expression , ')' ;
+
+number           = digits , [ '.' , [ digits ] ] | '.' , digits ;
+digits           = digit , { digit } ;
+identifier       = (alpha | '_') , { alnum | '_' } ;
+
+function_call    = identifier , '(' , [ arg_list ] , ')' ;
+arg_list         = arg_item , { ',' , arg_item } ;
+arg_item         = index_list_literal | expression ;
+index_list_literal = '[' , integer , { ',' , integer } , ']' ;  (* 1-based *)
+
+tensor_decl      = identifier , '{' , tensor_kv_list , '}' ;
+tensor_kv_list   = tensor_kv , { ',' , tensor_kv } ;
+tensor_kv        = ('rank' | 'dim') , '=' , integer ;
+```
+
+Whitespace (`[ \t\n\r]+`) is freely skipped between tokens but never
+inside identifiers or numbers. Comparison operators evaluate to scalar
+indicators (`1.0` / `0.0`), so `a < b < c` parses C-style as
+`(a < b) < c`, **not** as math-style `(a < b) AND (b < c)`. Number
+parsing uses `std::from_chars` and is locale-independent — `1.5` is
+always one-and-a-half, regardless of `LC_NUMERIC`.
+
+## Type System
+
+Identifiers are typed lazily by the parser:
+
+- **Bare identifier in scalar position** → implicit scalar declaration on first use. Repeated references resolve to the same holder.
+- **`Name{rank=R, dim=D}`** → tensor declaration. After the first use, bare `Name` references resolve to the same tensor holder via the symbol table.
+- **Identical re-declaration** (`A{rank=2, dim=3}` after a prior `A{rank=2, dim=3}`) is a no-op.
+- **Mismatched re-declaration** (different `rank` or `dim`) raises `redeclaration_error`.
+- **Cross-type collision** (`x` as scalar then `x{rank=2, dim=3}` as tensor, or vice versa) raises `type_collision_error`.
+
+### Mixed-domain operator coercion
+
+The supported `tag_invoke` surface is hand-listed in the parser's
+`can_mul` / `can_div` predicates (see `src/numsim_cas/parser/actions.h`).
+The parser is intentionally narrower than the full library coercion
+surface — combinations needed for non-trivial mechanics expressions
+are in, the rest throw `type_mismatch_error`.
+
+`+` and `-` require **same-domain** operands:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `+` `-`  | scalar | scalar | scalar |
+| `+` `-`  | tensor | tensor | tensor |
+| `+` `-`  | t2s    | t2s    | t2s    |
+
+`*` allows scalar-coefficient flow into either tensor side and
+same-domain on t2s:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `*`      | scalar | scalar | scalar |
+| `*`      | scalar | tensor | tensor |
+| `*`      | tensor | scalar | tensor |
+| `*`      | scalar | t2s    | t2s    |
+| `*`      | t2s    | scalar | t2s    |
+| `*`      | t2s    | t2s    | t2s    |
+
+`/` is even narrower — scalar denominators only, plus same-domain
+on t2s:
+
+| Operator | Left   | Right  | Result |
+|----------|--------|--------|--------|
+| `/`      | scalar | scalar | scalar |
+| `/`      | tensor | scalar | tensor |
+| `/`      | t2s    | scalar | t2s    |
+| `/`      | t2s    | t2s    | t2s    |
+
+Notable exclusions: `tensor * tensor` (use `inner_product` /
+`dot_product` explicitly), `tensor * t2s` / `t2s * tensor` (no
+auto-coercion in either direction), `tensor / t2s`. The plan
+originally listed broader coverage; the implementation narrowed
+to what `tag_invoke` overloads exist in the codebase today.
+
+## Function Registry
+
+Functions are dispatched through a static table in
+`function_registry.h`. Current entries:
+
+| Group | Functions | Signature |
+|-------|-----------|-----------|
+| Scalar unary | `sin` `cos` `tan` `asin` `acos` `atan` `sinh` `cosh` `tanh` `asinh` `acosh` `atanh` `exp` `log` `log10` `sqrt` `abs` `sign` | scalar → scalar |
+| Scalar binary | `pow` `lt` `le` `gt` `ge` `eq` `ne` | (scalar, scalar) → scalar |
+| Tensor → tensor | `trans` `inv` | tensor → tensor |
+| Tensor → t2s | `trace` `det` `norm` `dot` | tensor → t2s |
+| Contraction → tensor | `inner_product` | (tensor, `[i…]`, tensor, `[i…]`) → tensor |
+| Contraction → t2s | `dot_product` | (tensor, `[i…]`, tensor, `[i…]`) → t2s |
+
+Indices inside `[…]` are **1-based** in the source language and
+converted to 0-based `sequence` internally. Out-of-range index
+validation is deferred to the underlying library at evaluation time.
+
+Still to land (currently throws `unknown_function_error`):
+`max`, `min`, `if_then_else`, `macauley_plus`, `macauley_minus`,
+`heaviside`, `smoothed_macauley`, `dev`, `sym`, `vol`, `skew`,
+`outer_product`. These depend on PRs not yet merged to `main`
+(#207, #208, #209, plus the projector stack).
+
+## Ten Example Expressions
+
+All ten parse against the current registry:
+
+| # | Input | Domain | Notes |
+|---|-------|--------|-------|
+| 1 | `42` | scalar | integer literal |
+| 2 | `3.14` | scalar | decimal literal (locale-independent; no exponent — `1.5e3` is unsupported) |
+| 3 | `sin(x)^2 + cos(x)^2` | scalar | implicit scalar `x`; differentiates to 0 |
+| 4 | `a*x^2 + b*x + c` | scalar | four implicit scalars |
+| 5 | `2 ^ 3 ^ 2` | scalar | right-assoc → 512, not 64 |
+| 6 | `pow(x, 3) - 2*pow(x, 2) + x` | scalar | function-call form of `^`, mixed with scalar `*` |
+| 7 | `lt(x, 0) * x + ge(x, 0) * x` | scalar | comparisons produce `0.0` / `1.0` indicators |
+| 8 | `trace(A{rank=2, dim=3})` | t2s | declares `A`; `diff(., A) = I` |
+| 9 | `2 * trace(A{rank=2, dim=3}) + det(A)` | t2s | scalar coefficients into t2s, declared `A` reused bare |
+| 10 | `inner_product(A{rank=4, dim=3}, [3, 4], B{rank=2, dim=3}, [1, 2])` | tensor | full contraction with 1-based index sequences |
+
+### Eventually-supported
+
+These will parse once the upstream dependencies land — currently they
+raise `unknown_function_error`:
+
+- `if_then_else(gt(x, 0), x, -x)` — would be `abs(x)`; blocked on
+  [#207](https://github.com/NumSim-Stack/numsim-cas/issues/207)
+- `max(0, sin(x))` / `macauley_plus(sin(x))` — blocked on
+  [#208](https://github.com/NumSim-Stack/numsim-cas/issues/208) and
+  [#209](https://github.com/NumSim-Stack/numsim-cas/issues/209)
+- `trans(A{rank=2, dim=3}) + sym(A)` — `sym`/`dev`/`vol`/`skew` blocked on
+  the projector stack (`projection_tensor.h` is unmerged)
+- `outer_product(...)` — no top-level free function on this branch yet
+
+## Error Catalogue
+
+All parser errors inherit from `numsim::cas::parser::parse_error`
+which itself inherits from `cas_error`. Each carries `position()`,
+`line()`, `column()`, and renders `what()` with a snippet plus caret.
+
+| Subclass | When fired | Extra fields |
+|----------|-----------|--------------|
+| `lexical_error` | malformed literal: `[0, …]` (1-based index), bracket-list overflow | — |
+| `syntax_error` | unexpected token, missing `)` / `}` / `]`, premature EOF, zero rank/dim in tensor decl, duplicate `rank=` / `dim=` keyword, PEGTL `must<>` failure | — |
+| `unknown_function_error` | identifier in call position not in the registry | `name()` |
+| `arity_error` | function called with wrong number of arguments | `function()`, `expected_arity()`, `actual_arity()` |
+| `type_mismatch_error` | wrong domain for an operator or function argument (e.g. `sin(A{…})`) | — |
+| `redeclaration_error` | tensor re-declared with mismatched `(rank, dim)` | — |
+| `type_collision_error` | identifier used as both scalar and tensor in either order | — |
+| `unknown_symbol_error` | **currently unreachable from the parser** — every bare identifier in scalar position is implicitly declared. Class exists for potential future strict-mode use; constructed directly by tests. | `name()` |
+
+### Example diagnostic output
+
+```text
+parse error at 1:1: function 'sin' expects 1 argument, got 2
+  sin(x, y)
+  ^
+```
+
+```text
+parse error at 1:7: tensor declaration 'A': rank must be >= 1, got 0
+  trace(A{rank=0, dim=3})
+        ^
+```
+
+## Build
+
+```cmake
+option(NUMSIM_CAS_BUILD_PARSER "Build the PEGTL string parser" OFF)
+```
+
+When ON, the build fetches PEGTL 3.2.8 via FetchContent, compiles
+the `NumSim_CAS_Parser` library, and exposes it as the
+`NumSim_CAS::Parser` alias. Link against both `NumSim_CAS` and
+`NumSim_CAS::Parser` (or just the latter — `NumSim_CAS` is
+transitively re-exported).
+
+The public parser headers (`<numsim_cas/parser/*.h>`) **do not**
+transitively include PEGTL. Consumers that include only those
+headers pay no PEGTL template compile cost; the grammar
+instantiations are contained inside the parser library's
+translation units. The example programs under `examples/` act as
+a lock-in for that constraint.
+
+## Symbol Table Semantics
+
+`symbol_table` is the parser's identifier→holder map.
+
+- **Reentrant** on **distinct** instances — multiple parses can run
+  concurrently if each has its own table.
+- **Not** thread-safe across one shared table.
+- **Non-transactional on parse failure**: declarations that landed
+  before a throw stay in the table. For interactive surfaces (REPL,
+  retry-on-error), discard the table or hold an external snapshot.
+  Tracked as [#222](https://github.com/NumSim-Stack/numsim-cas/issues/222).
+
+## Known Follow-Ups
+
+- [#217](https://github.com/NumSim-Stack/numsim-cas/issues/217) — derive registry `arg_kinds` from dispatch lambda signature (single source of truth)
+- [#221](https://github.com/NumSim-Stack/numsim-cas/issues/221) — umbrella header `numsim_cas/numsim_cas.h` doesn't pull in tensor / t2s diff routes
+- [#222](https://github.com/NumSim-Stack/numsim-cas/issues/222) — transactional symbol_table for interactive parsing

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,24 @@ add_numsim_cas_example(tensor_basics tensor_basics.cpp)
 add_numsim_cas_example(tensor_to_scalar_basics tensor_to_scalar_basics.cpp)
 add_numsim_cas_example(linear_elasticity linear_elasticity.cpp)
 
+# Parser examples — only built when NUMSIM_CAS_BUILD_PARSER=ON, since
+# they link against the parser library target. Beyond demonstrating
+# the public API, these examples act as an include-hygiene check: if
+# any of the public parser headers ever started transitively
+# including PEGTL, that leak would surface here as new symbols in
+# downstream TUs that don't otherwise touch PEGTL.
+macro(add_numsim_cas_parser_example TARGET_NAME)
+    add_executable(${TARGET_NAME} ${ARGN})
+    target_link_libraries(${TARGET_NAME} PRIVATE NumSim_CAS NumSim_CAS::Parser)
+endmacro()
+
+if(NUMSIM_CAS_BUILD_PARSER)
+    add_numsim_cas_parser_example(parser_basics parser_basics.cpp)
+    add_numsim_cas_parser_example(parser_symbol_table parser_symbol_table.cpp)
+    add_numsim_cas_parser_example(parser_error_handling parser_error_handling.cpp)
+    add_numsim_cas_parser_example(parser_tensor_diff parser_tensor_diff.cpp)
+endif()
+
 # Examples with programmatic asserts run as CTest tests so bit-rot is
 # caught in CI. Add new examples here only if they exit non-zero on
 # numerical mismatch.

--- a/examples/parser_basics.cpp
+++ b/examples/parser_basics.cpp
@@ -1,0 +1,41 @@
+// Parser basics — parse a scalar expression, declare variable bindings
+// through the symbol_table the parser populated, and evaluate.
+//
+// Include-hygiene: this file uses only the PUBLIC parser headers
+// (`<numsim_cas/parser/*.h>`). It deliberately does NOT include any
+// PEGTL header. If it builds, the public-headers-don't-leak-PEGTL
+// constraint holds — internal grammar template instantiations stay
+// inside `NumSim_CAS_Parser`'s translation units.
+
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/scalar/visitors/scalar_evaluator.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser Basics ===\n\n";
+
+  // Parse a quadratic; implicitly declares a, b, c, x as scalars.
+  cas::parser::symbol_table syms;
+  auto e = cas::parser::parse_scalar("a*x^2 + b*x + c", syms);
+  std::cout << "parsed: " << cas::to_string(e) << "\n\n";
+
+  // Evaluate (a=1, b=-3, c=2) at several x; the roots of x^2 - 3x + 2
+  // are 1 and 2.
+  cas::scalar_evaluator<double> ev;
+  ev.set(syms.get_or_declare_scalar("a"), 1.0);
+  ev.set(syms.get_or_declare_scalar("b"), -3.0);
+  ev.set(syms.get_or_declare_scalar("c"), 2.0);
+
+  std::cout << "f(x) = x^2 - 3x + 2 sampled:\n";
+  for (double x : {0.0, 1.0, 1.5, 2.0, 3.0}) {
+    ev.set(syms.get_or_declare_scalar("x"), x);
+    std::cout << "  f(" << x << ") = " << ev.apply(e) << "\n";
+  }
+
+  return 0;
+}

--- a/examples/parser_basics.cpp
+++ b/examples/parser_basics.cpp
@@ -22,7 +22,11 @@ int main() {
   // Parse a quadratic; implicitly declares a, b, c, x as scalars.
   cas::parser::symbol_table syms;
   auto e = cas::parser::parse_scalar("a*x^2 + b*x + c", syms);
-  std::cout << "parsed: " << cas::to_string(e) << "\n\n";
+  std::cout << "parsed: " << cas::to_string(e) << "\n";
+  // The printer reorders terms by hash (canonical form), so the
+  // printed expression won't match the input order character for
+  // character — it's the same expression, terms permuted.
+  std::cout << "(printer canonicalizes term order; same expression)\n\n";
 
   // Evaluate (a=1, b=-3, c=2) at several x; the roots of x^2 - 3x + 2
   // are 1 and 2.

--- a/examples/parser_error_handling.cpp
+++ b/examples/parser_error_handling.cpp
@@ -1,0 +1,81 @@
+// Parser error handling — demonstrate the diagnostic story.
+//
+// Every parse failure raises a specific parse_error subclass. The
+// formatted what() includes a "parse error at line:col:" header, the
+// offending source line, and a caret. Subclasses carry extra fields
+// for structured handling (e.g. unknown_function_error::name(),
+// arity_error::expected_arity()) — useful if you want to surface a
+// custom UI message rather than the default formatted string.
+
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <iostream>
+#include <string_view>
+
+namespace cas = numsim::cas;
+
+// Print a horizontal rule for readability.
+static void rule() { std::cout << "-----\n"; }
+
+// Try to parse; catch each specific subclass and print structured
+// info plus the rendered what(). Falls back to parse_error for any
+// subclass we don't handle explicitly.
+static void try_parse(std::string_view source) {
+  std::cout << "input: " << source << "\n";
+  cas::parser::symbol_table syms;
+  try {
+    [[maybe_unused]] auto e = cas::parser::parse(source, syms);
+    std::cout << "  (parsed successfully)\n";
+  } catch (cas::parser::arity_error const &e) {
+    std::cout << "  arity_error\n";
+    std::cout << "    function       = " << e.function() << "\n";
+    std::cout << "    expected_arity = " << e.expected_arity() << "\n";
+    std::cout << "    actual_arity   = " << e.actual_arity() << "\n";
+    std::cout << e.what() << "\n";
+  } catch (cas::parser::unknown_function_error const &e) {
+    std::cout << "  unknown_function_error\n";
+    std::cout << "    name = " << e.name() << "\n";
+    std::cout << e.what() << "\n";
+  } catch (cas::parser::lexical_error const &e) {
+    std::cout << "  lexical_error\n" << e.what() << "\n";
+  } catch (cas::parser::type_mismatch_error const &e) {
+    std::cout << "  type_mismatch_error\n" << e.what() << "\n";
+  } catch (cas::parser::redeclaration_error const &e) {
+    std::cout << "  redeclaration_error\n" << e.what() << "\n";
+  } catch (cas::parser::type_collision_error const &e) {
+    std::cout << "  type_collision_error\n" << e.what() << "\n";
+  } catch (cas::parser::syntax_error const &e) {
+    std::cout << "  syntax_error\n" << e.what() << "\n";
+  } catch (cas::parser::parse_error const &e) {
+    std::cout << "  parse_error (base)\n" << e.what() << "\n";
+  }
+  std::cout << "\n";
+}
+
+int main() {
+  std::cout << "=== Parser: Error Handling ===\n\n";
+
+  try_parse("sin(x)");
+  rule();
+  try_parse("sin(x, y)"); // arity
+  rule();
+  try_parse("no_such_fn(x)"); // unknown function
+  rule();
+  try_parse("trans(x)"); // type mismatch — trans wants tensor
+  rule();
+  try_parse("sin(x"); // missing close paren
+  rule();
+  try_parse("trace(A{rank=0, dim=3})"); // zero rank from action
+  rule();
+  try_parse("dot_product(A{rank=2, dim=3}, [0, 1], "
+            "B{rank=2, dim=3}, [1, 2])"); // lexical: zero index
+  rule();
+  try_parse("x + x{rank=2, dim=3}"); // scalar then tensor — collision
+  rule();
+  try_parse("trace(A{rank=2, dim=3}) + "
+            "dot(A{rank=4, dim=3})"); // shape mismatch in one parse
+
+  return 0;
+}

--- a/examples/parser_symbol_table.cpp
+++ b/examples/parser_symbol_table.cpp
@@ -37,10 +37,19 @@ int main() {
   std::cout << "   lambda now declared as scalar: " << std::boolalpha
             << syms.has("lambda") << "\n\n";
 
-  // (4) Identical re-declaration is allowed — same (rank, dim).
+  // (4) Identical re-declaration is allowed — same (rank, dim). The
+  //     symbol_table treats this as a no-op: shape stays {2, 3} and
+  //     the bare `A` in subsequent parses still resolves to the
+  //     original holder.
+  auto shape_before = syms.tensor_shape("A");
   auto e4 = cas::parser::parse_t2s("det(A{rank=2, dim=3})", syms);
-  std::cout << "4. parsed: " << cas::to_string(e4)
-            << "  (identical re-declaration OK)\n\n";
+  auto shape_after = syms.tensor_shape("A");
+  std::cout << "4. parsed: " << cas::to_string(e4) << "\n";
+  std::cout << "   shape before re-declaration: rank=" << shape_before->first
+            << ", dim=" << shape_before->second << "\n";
+  std::cout << "   shape after re-declaration:  rank=" << shape_after->first
+            << ", dim=" << shape_after->second
+            << "  (unchanged → re-declaration was a no-op)\n\n";
 
   // (5) Re-declaring with a DIFFERENT shape throws redeclaration_error.
   //     Catch and demonstrate the diagnostic.

--- a/examples/parser_symbol_table.cpp
+++ b/examples/parser_symbol_table.cpp
@@ -1,0 +1,57 @@
+// Parser symbol_table lifecycle — the REPL-style usage pattern.
+//
+// One symbol_table threaded through multiple parse() calls. Tensors
+// declared once via `Name{rank=R, dim=D}` can then be referenced
+// bare in later expressions (lookup-first identifier resolution).
+// Scalars are implicitly declared on first bare use.
+
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/parser/parse_error.h>
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser: Symbol Table Lifecycle ===\n\n";
+
+  cas::parser::symbol_table syms;
+
+  // (1) Declare A as a rank-2 tensor on the right of a t2s function.
+  auto e1 = cas::parser::parse_t2s("trace(A{rank=2, dim=3})", syms);
+  std::cout << "1. parsed: " << cas::to_string(e1) << "\n";
+  auto shape = syms.tensor_shape("A");
+  std::cout << "   A registered as rank=" << shape->first
+            << ", dim=" << shape->second << "\n\n";
+
+  // (2) Reuse A bare — same holder resolves through symbol_table.
+  auto e2 = cas::parser::parse_t2s("trace(A) + det(A)", syms);
+  std::cout << "2. parsed: " << cas::to_string(e2) << "\n\n";
+
+  // (3) Mix declared tensor with implicit scalar in one expression.
+  //     `lambda` is bare → implicitly declared as scalar.
+  auto e3 = cas::parser::parse_t2s("lambda * trace(A)", syms);
+  std::cout << "3. parsed: " << cas::to_string(e3) << "\n";
+  std::cout << "   lambda now declared as scalar: " << std::boolalpha
+            << syms.has("lambda") << "\n\n";
+
+  // (4) Identical re-declaration is allowed — same (rank, dim).
+  auto e4 = cas::parser::parse_t2s("det(A{rank=2, dim=3})", syms);
+  std::cout << "4. parsed: " << cas::to_string(e4)
+            << "  (identical re-declaration OK)\n\n";
+
+  // (5) Re-declaring with a DIFFERENT shape throws redeclaration_error.
+  //     Catch and demonstrate the diagnostic.
+  std::cout << "5. attempting A{rank=4, dim=3} (mismatched shape)...\n";
+  try {
+    [[maybe_unused]] auto e5 =
+        cas::parser::parse_tensor("A{rank=4, dim=3}", syms);
+  } catch (cas::parser::redeclaration_error const &e) {
+    std::cout << "   threw redeclaration_error:\n";
+    std::cout << "   " << e.what() << "\n";
+  }
+
+  return 0;
+}

--- a/examples/parser_tensor_diff.cpp
+++ b/examples/parser_tensor_diff.cpp
@@ -1,0 +1,55 @@
+// Parser ↔ rest-of-library — parse a tensor-to-scalar expression,
+// differentiate it w.r.t. the parser-declared tensor variable, print
+// the result.
+//
+// Shows that parser output is a normal `expression_holder` that the
+// existing symbolic algebra (diff, simplification, printing) accepts
+// transparently — there's nothing parser-specific downstream.
+
+#include <numsim_cas/numsim_cas.h>
+// The umbrella header above doesn't currently pull in the
+// tensor-to-scalar diff routing; include it explicitly so
+// `cas::diff(t2s_expr, tensor_holder)` resolves.
+#include <numsim_cas/parser/parser.h>
+#include <numsim_cas/parser/symbol_table.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
+
+#include <iostream>
+
+int main() {
+  namespace cas = numsim::cas;
+
+  std::cout << "=== Parser: Tensor Differentiation ===\n\n";
+
+  // f(A) = trace(A) — d/dA = rank-2 identity tensor I.
+  {
+    cas::parser::symbol_table syms;
+    auto f = cas::parser::parse_t2s("trace(A{rank=2, dim=3})", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto df = cas::diff(f, A);
+    std::cout << "f(A)   = " << cas::to_string(f) << "\n";
+    std::cout << "df/dA  = " << cas::to_string(df) << "  (rank-2 identity)\n\n";
+  }
+
+  // g(A) = trace(A) * trace(A) = (tr A)^2 — d/dA = 2 * trace(A) * I.
+  {
+    cas::parser::symbol_table syms;
+    auto g = cas::parser::parse_t2s("trace(A{rank=2, dim=3}) * trace(A)", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto dg = cas::diff(g, A);
+    std::cout << "g(A)   = " << cas::to_string(g) << "\n";
+    std::cout << "dg/dA  = " << cas::to_string(dg) << "\n\n";
+  }
+
+  // h(A) = norm(A) — d/dA = A / norm(A).
+  {
+    cas::parser::symbol_table syms;
+    auto h = cas::parser::parse_t2s("norm(A{rank=2, dim=3})", syms);
+    auto A = cas::parser::parse_tensor("A", syms);
+    auto dh = cas::diff(h, A);
+    std::cout << "h(A)   = " << cas::to_string(h) << "\n";
+    std::cout << "dh/dA  = " << cas::to_string(dh) << "\n";
+  }
+
+  return 0;
+}

--- a/examples/parser_tensor_diff.cpp
+++ b/examples/parser_tensor_diff.cpp
@@ -41,7 +41,12 @@ int main() {
     std::cout << "dg/dA  = " << cas::to_string(dg) << "\n\n";
   }
 
-  // h(A) = norm(A) — d/dA = A / norm(A).
+  // h(A) = norm(A) — d/dA = A / norm(A) mathematically. The printer
+  // reveals the chain rule's literal form: a `pow(norm(A), -1)`
+  // scalar times an `A : I{4}` contraction (A inner-product'd with
+  // the rank-4 identity). Downstream simplification could fold
+  // `A : I{4}` back to `A`, but the diff visitor doesn't perform
+  // that fold inline.
   {
     cas::parser::symbol_table syms;
     auto h = cas::parser::parse_t2s("norm(A{rank=2, dim=3})", syms);
@@ -49,6 +54,8 @@ int main() {
     auto dh = cas::diff(h, A);
     std::cout << "h(A)   = " << cas::to_string(h) << "\n";
     std::cout << "dh/dA  = " << cas::to_string(dh) << "\n";
+    std::cout << "  (≡ A / norm(A); the I{4} contraction is the "
+                 "chain rule's literal form)\n";
   }
 
   return 0;

--- a/include/numsim_cas/parser/parse_error.h
+++ b/include/numsim_cas/parser/parse_error.h
@@ -79,6 +79,15 @@ public:
 
 /// An identifier was used where typing forces a tensor (e.g. inside
 /// `trace(...)`), but no tensor by that name has been declared.
+///
+/// @note Currently **unreachable from the parser** — every bare
+/// identifier in scalar position is implicitly declared as a scalar
+/// (see `symbol_table::get_or_declare_scalar`), so the "undeclared
+/// identifier in tensor position" path is never taken. Pinned by
+/// `ParserErrorCoverage.UnknownSymbolErrorIsUnreachableFromParser`.
+/// The class is preserved for a potential future strict mode that
+/// disables implicit scalar declaration, and is exercised directly
+/// at the constructor level by `ParseError.UnknownSymbolErrorCarriesName`.
 class unknown_symbol_error : public parse_error {
 public:
   unknown_symbol_error(std::string name, std::size_t byte_offset,

--- a/src/numsim_cas/parser/parser.cpp
+++ b/src/numsim_cas/parser/parser.cpp
@@ -19,10 +19,15 @@ namespace pegtl = tao::pegtl;
 namespace {
 
 // Translate PEGTL's own parse_error (raised when `must<>` rules fail
-// or when a default action wraps an exception) into our parse_error
-// type, preserving position info.
-parse_error translate_pegtl_error(pegtl::parse_error const &e,
-                                  std::string_view source) {
+// or when a default action wraps an exception) into our syntax_error,
+// preserving position info.
+//
+// Return type is `syntax_error` (NOT the base `parse_error`) — a
+// return-by-value of the base type would slice the subclass off, and
+// the subsequent `throw` would propagate a sliced base-only object.
+// Callers downstream that catch by `syntax_error` would then miss it.
+syntax_error translate_pegtl_error(pegtl::parse_error const &e,
+                                   std::string_view source) {
   // pegtl::parse_error stores positions; pull the first.
   std::size_t byte = 0;
   if (!e.positions().empty()) {

--- a/tests/ParserTest.h
+++ b/tests/ParserTest.h
@@ -1335,6 +1335,30 @@ TEST(ParserErrorCoverage, MultiLineInputPreservesLineAndColumn) {
   }
 }
 
+TEST(ParserErrorCoverage, PegtlTranslatedErrorPropagatesAsSyntaxError) {
+  // Regression test: parser.cpp's `translate_pegtl_error` used to
+  // return by value of base type `parse_error`, which sliced the
+  // `syntax_error` constructed inside it down to the base before the
+  // throw — so PEGTL-originated must-failures (missing close paren,
+  // unexpected EOF) arrived at the catch site as base `parse_error`
+  // instead of `syntax_error`. Now the function returns by `syntax_error`,
+  // preserving the type through the throw. Lock that in:
+  //
+  // `sin(x` triggers PEGTL's `must<function_call_close>` failure path,
+  // which goes through translate_pegtl_error. Must arrive as the
+  // narrow subclass.
+  symbol_table syms;
+  try {
+    [[maybe_unused]] auto e = parse_scalar("sin(x", syms);
+    FAIL() << "Expected syntax_error.";
+  } catch (syntax_error const &) {
+    SUCCEED();
+  } catch (parse_error const &e) {
+    FAIL() << "PEGTL-translated error was sliced to base parse_error. what():\n"
+           << e.what();
+  }
+}
+
 TEST(ParserErrorCoverage, UnknownSymbolErrorIsUnreachableFromParser) {
   // Documentation test: the parser never raises unknown_symbol_error
   // because every bare identifier in scalar position is implicitly


### PR DESCRIPTION
Stacked on #219. Adds four example programs that exercise the public parser API. Surfaced and fixed a slicing bug in the PEGTL error-translation path along the way.

## Examples

| File | Demonstrates |
|---|---|
| `parser_basics.cpp` | Parse a scalar polynomial, evaluate at several bindings — the minimum end-to-end. |
| `parser_symbol_table.cpp` | Multiple `parse()` calls sharing one `symbol_table`: tensor declared once + reused bare, scalar implicitly declared, identical re-declaration allowed, shape-mismatch re-declaration caught. |
| `parser_error_handling.cpp` | One `try_parse` helper that catches each `parse_error` subclass and prints both the structured fields (`arity_error::function()`, `unknown_function_error::name()`) and the formatted `what()` with snippet + caret. |
| `parser_tensor_diff.cpp` | Parse a t2s expression, differentiate w.r.t. the parser-declared tensor (`d/dA trace(A) = I`, `d/dA (tr A)² = 2 tr(A) I`, `d/dA norm(A) = A / norm(A)`), print the result. |

The example translation units include only the public parser headers (`<numsim_cas/parser/*.h>`), never PEGTL. They double as an include-hygiene check: a regression leaking PEGTL through the public surface would compile-error in code that doesn't otherwise touch PEGTL.

## Slicing fix

`translate_pegtl_error` in `src/numsim_cas/parser/parser.cpp` used to return by value of base type `parse_error`, slicing the `syntax_error` it constructed down to the base before the `throw`. PEGTL-originated must-failures (missing close paren, unexpected EOF) arrived at catch sites as base `parse_error` instead of `syntax_error`. Fix: return by `syntax_error`. Caught by `parser_error_handling.cpp`'s `sin(x` demo case falling through to the base catch, locked in by a new test:

```cpp
ParserErrorCoverage.PegtlTranslatedErrorPropagatesAsSyntaxError
```

## Test plan

- [x] All four examples build with `NUMSIM_CAS_BUILD_PARSER=ON -DNUMSIM_CAS_BUILD_EXAMPLES=ON`
- [x] All four examples produce clean output (no UB, no crash)
- [x] Parser-ON: 1056 → 1057 tests, all pass
- [x] Parser-OFF: 934/934 unchanged (examples skipped via CMake guard)
- [ ] CI green