### PR TITLE
Add tensor/t2s diff routes to umbrella header (closes #221)

### DIFF
--- a/include/numsim_cas/numsim_cas.h
+++ b/include/numsim_cas/numsim_cas.h
@@ -35,6 +35,13 @@
 #include <numsim_cas/scalar/visitors/scalar_evaluator.h>
 #include <numsim_cas/scalar/visitors/scalar_printer.h>
 
+// Diff routing for tensor and tensor-to-scalar (#221). Without these,
+// callers who include only the umbrella get `no matching tag_invoke
+// overload` errors for `diff(tensor, tensor)` and any t2s diff form,
+// even though the visitors are otherwise pulled in.
+#include <numsim_cas/tensor/tensor_diff.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
+
 #include <numsim_cas/scalar/scalar_latex_io.h>
 #include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/levi_civita_tensor.h>

--- a/include/numsim_cas/numsim_cas.h
+++ b/include/numsim_cas/numsim_cas.h
@@ -35,10 +35,6 @@
 #include <numsim_cas/scalar/visitors/scalar_evaluator.h>
 #include <numsim_cas/scalar/visitors/scalar_printer.h>
 
-// Diff routing for tensor and tensor-to-scalar (#221). Without these,
-// callers who include only the umbrella get `no matching tag_invoke
-// overload` errors for `diff(tensor, tensor)` and any t2s diff form,
-// even though the visitors are otherwise pulled in.
 #include <numsim_cas/tensor/tensor_diff.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
 


### PR DESCRIPTION
## Summary

The umbrella header \`<numsim_cas/numsim_cas.h>\` was missing two includes that left common diff-call paths unresolved for consumers who only pulled in the umbrella:

- \`<numsim_cas/tensor/tensor_diff.h>\` — provides \`tag_invoke(diff_fn, tensor, tensor)\`
- \`<numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>\` — provides \`tag_invoke(diff_fn, t2s, tensor)\` and \`(t2s, t2s)\`

Without these, callers who include only the umbrella got \`no matching tag_invoke overload\` errors for \`diff(tensor, tensor)\` / any t2s diff form. The \`examples/parser_tensor_diff.cpp\` example documented the workaround inline:

\`\`\`cpp
// The umbrella header above doesn't currently pull in the
// tensor-to-scalar diff routing; include it explicitly so
// \`cas::diff(t2s_expr, tensor_holder)\` resolves.
#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_diff.h>
\`\`\`

This PR removes the need for that workaround. Two-line include addition.

## Test plan

- [x] 1157/1157 tests pass with the umbrella self-sufficient
- [x] \`examples/parser_tensor_diff.cpp\` builds without the explicit workaround include (could be cleaned up in a follow-up)
- [ ] CI green

Closes #221.