### PR TITLE
Canonicalise scalar constants across all construction paths (closes #184)

### DIFF
--- a/include/numsim_cas/basic_functions.h
+++ b/include/numsim_cas/basic_functions.h
@@ -79,13 +79,47 @@ template <typename... Args> auto make_scalar_variable(Args &&...args) {
   return std::make_tuple(make_expression<scalar>(std::forward<Args>(args))...);
 }
 
-template <typename... Args> auto make_scalar_constant(Args &&...args) {
+} // namespace numsim::cas
+
+// scalar_make_constant supplies the arithmetic→canonical-form
+// `tag_invoke(make_constant_fn, type_identity<scalar_expression>, T)`
+// dispatch used by `make_scalar_constant` for arithmetic args (#184
+// canonical-form fix). Included AFTER `make_expression` is declared
+// (it depends on that), but BEFORE the `make_scalar_constant`
+// overloads that depend on it.
+#include "scalar/scalar_make_constant.h"
+
+namespace numsim::cas {
+
+namespace detail {
+// Single-value factory shared by the 1-arg and N-arg `make_scalar_constant`
+// overloads. Arithmetic types route through the canonicalisation in
+// `scalar_make_constant.h`'s `tag_invoke(make_constant_fn, …)` — same path
+// used by `int * holder` operators — so `make_scalar_constant(int)` and
+// `int * holder`-style construction produce structurally identical nodes
+// (#184). Non-arithmetic types (e.g. `scalar_number`) fall through to
+// direct `scalar_constant` construction unchanged.
+template <typename T> auto make_one_scalar_constant(T &&v) {
+  if constexpr (std::is_arithmetic_v<std::remove_cvref_t<T>>) {
+    return tag_invoke(make_constant_fn{},
+                      std::type_identity<scalar_expression>{},
+                      std::forward<T>(v));
+  } else {
+    return make_expression<scalar_constant>(std::forward<T>(v));
+  }
+}
+} // namespace detail
+
+template <typename A, typename B, typename... Rest>
+auto make_scalar_constant(A &&a, B &&b, Rest &&...rest) {
   return std::make_tuple(
-      make_expression<scalar_constant>(std::forward<Args>(args))...);
+      detail::make_one_scalar_constant(std::forward<A>(a)),
+      detail::make_one_scalar_constant(std::forward<B>(b)),
+      detail::make_one_scalar_constant(std::forward<Rest>(rest))...);
 }
 
 template <typename Args> auto make_scalar_constant(Args &&args) {
-  return make_expression<scalar_constant>(std::forward<Args>(args));
+  return detail::make_one_scalar_constant(std::forward<Args>(args));
 }
 
 template <typename Expr>

--- a/include/numsim_cas/scalar/scalar_domain_traits.h
+++ b/include/numsim_cas/scalar/scalar_domain_traits.h
@@ -44,7 +44,14 @@ template <> struct domain_traits<scalar_expression> {
   }
 
   static expr_holder_t make_constant(scalar_number const &value) {
-    return make_expression<scalar_constant>(value);
+    // Route through the canonical-form dispatch (#184). Centralises
+    // 0 → scalar_zero singleton, 1 → scalar_one singleton,
+    // -1 → -scalar_one, negative → -scalar_constant(|v|), positive →
+    // scalar_constant(v). Keeps simplifier-built coefficients
+    // structurally identical to constants built via the public
+    // make_scalar_constant / `int * holder` paths.
+    return detail::tag_invoke(detail::make_constant_fn{},
+                              std::type_identity<scalar_expression>{}, value);
   }
 };
 

--- a/include/numsim_cas/scalar/scalar_make_constant.h
+++ b/include/numsim_cas/scalar/scalar_make_constant.h
@@ -2,10 +2,33 @@
 #define SCALAR_MAKE_CONSTANT_H
 
 #include <numsim_cas/core/make_constant.h>
+#include <numsim_cas/core/scalar_number.h>
 #include <numsim_cas/scalar/scalar_expression.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 
 namespace numsim::cas::detail {
+
+// scalar_number → canonical scalar_expression holder. Shared by the
+// simplifier coefficient-collapse paths (via `scalar_traits::make_constant`)
+// AND by the arithmetic-literal overload below, so both routes produce
+// structurally identical nodes for the same value (#184). Without this
+// the simplifier would build raw `scalar_constant{1}` for sums collapsing
+// to one while the public API returned the `scalar_one` singleton.
+inline expression_holder<scalar_expression>
+tag_invoke(make_constant_fn, std::type_identity<scalar_expression>,
+           scalar_number const &v) {
+  if (v == scalar_number{0})
+    return get_scalar_zero();
+  if (v == scalar_number{1})
+    return get_scalar_one();
+  if (v == scalar_number{-1})
+    return -get_scalar_one();
+  if (numeric_less(v, scalar_number{0})) {
+    return -make_expression<scalar_constant>(-v);
+  }
+  return make_expression<scalar_constant>(v);
+}
+
 // arithmetic -> scalar_constant
 template <class T>
 requires std::is_arithmetic_v<std::remove_cvref_t<T>>

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_domain_traits.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_domain_traits.h
@@ -49,8 +49,11 @@ template <> struct domain_traits<tensor_to_scalar_expression> {
   }
 
   static expr_holder_t make_constant(scalar_number const &value) {
+    // Wrap the canonical scalar form (#184) — keeps t2s-coefficient
+    // shapes identical to user-built ones for -1/0/1/negative cases.
     return make_expression<tensor_to_scalar_scalar_wrapper>(
-        make_expression<scalar_constant>(value));
+        detail::tag_invoke(detail::make_constant_fn{},
+                           std::type_identity<scalar_expression>{}, value));
   }
 };
 

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -843,6 +843,76 @@ TEST(CoreBugFix, ScalarHyperbolicDerivativesMatchClosedForm) {
   EXPECT_NEAR(ev.apply(d_tanh), 1.0 / (std::cosh(0.5) * std::cosh(0.5)), 1e-12);
 }
 
+// ---------------------------------------------------------------------------
+// #184: canonical form of constant×expr must NOT depend on construction path.
+// `int * x` and `make_scalar_constant(int) * x` should produce expressions
+// that compare equal under `==` and merge in the n_ary_tree symbol_map.
+// ---------------------------------------------------------------------------
+
+TEST(CoreBugFix, Issue184_IntPathAndConstantPathMatch_Negative) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  // Lifted directly from the issue's repro.
+  auto v1 = -2 * x + y;                       // int * holder route
+  auto v2 = make_scalar_constant(-2) * x + y; // explicit-constant route
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(CoreBugFix, Issue184_IntPathAndConstantPathMatch_AcrossValues) {
+  auto [x] = make_scalar_variable("x");
+  // Probe a spread of values: small + large, both signs. Skip 0 and 1
+  // — those go to scalar_zero / scalar_one singletons and have their
+  // own equality lock-ins below.
+  for (int v : {-1, -2, -7, -100, 2, 3, 17, 1000}) {
+    auto lhs = v * x;
+    auto rhs = make_scalar_constant(v) * x;
+    EXPECT_EQ(lhs, rhs) << "Construction-path mismatch at value v = " << v
+                        << "; lhs = " << to_string(lhs)
+                        << "; rhs = " << to_string(rhs);
+  }
+}
+
+TEST(CoreBugFix, Issue184_MakeScalarConstantZeroIsSingleton) {
+  // make_scalar_constant(0) currently builds scalar_constant{0} as a
+  // distinct node; the int(0) path returns the scalar_zero singleton.
+  // Canonicalise both to the singleton.
+  EXPECT_EQ(make_scalar_constant(0), get_scalar_zero());
+}
+
+TEST(CoreBugFix, Issue184_MakeScalarConstantOneIsSingleton) {
+  EXPECT_EQ(make_scalar_constant(1), get_scalar_one());
+}
+
+TEST(CoreBugFix, Issue184_MakeScalarConstantNegOneMatchesNegSingleton) {
+  EXPECT_EQ(make_scalar_constant(-1), -get_scalar_one());
+}
+
+TEST(CoreBugFix, Issue184_MakeScalarConstantNegativeMatchesNegated) {
+  // make_scalar_constant(-2) must equal -make_scalar_constant(2)
+  // regardless of which node shape is chosen as canonical — what
+  // matters is that the two construction paths converge.
+  EXPECT_EQ(make_scalar_constant(-2), -make_scalar_constant(2));
+}
+
+TEST(CoreBugFix, Issue184_MixedPathCoefficientsMergeInNAryTree) {
+  // 2*x + make_scalar_constant(2)*x should collapse to 4*x via the
+  // n_ary_tree symbol_map merge — proving the two construction paths
+  // produce the same key in the underlying map. Pre-fix this stored
+  // two separate entries and failed to fold.
+  auto [x] = make_scalar_variable("x");
+  auto e = 2 * x + make_scalar_constant(2) * x;
+  EXPECT_EQ(e, 4 * x);
+}
+
+TEST(CoreBugFix, Issue184_DoublePathAndConstantPathMatch) {
+  // Same canonical-form rule must apply to floating-point literals.
+  auto [x] = make_scalar_variable("x");
+  for (double v : {-1.5, 0.25, -7.3, 100.0}) {
+    auto lhs = v * x;
+    auto rhs = make_scalar_constant(v) * x;
+    EXPECT_EQ(lhs, rhs) << "Construction-path mismatch at value v = " << v;
+  }
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H


### PR DESCRIPTION
## Summary

Closes #184. \`int * x\` and \`make_scalar_constant(int) * x\` were producing structurally distinct nodes for the same mathematical value, so \`expression_holder::operator==\` returned false:

\`\`\`cpp
auto v1 = -2 * x + y;                       // y-2*x
auto v2 = make_scalar_constant(-2) * x + y; // -2*x+y
v1 == v2 ? false   // wrong
\`\`\`

Three sites built \`scalar_constant{value}\` directly, bypassing the canonical-form rules ("0 → \`scalar_zero\` singleton", "1 → \`scalar_one\`", "-1 → \`-scalar_one\`", "negative v → \`-scalar_constant(|v|)\`") that \`tag_invoke(make_constant_fn, scalar_expression, T)\` applies for arithmetic types — and the canonical-form dispatch itself only had an arithmetic-type overload, missing the \`scalar_number\` case the simplifier uses internally.

## Fix

1. **Add \`scalar_number\` overload** of \`tag_invoke(make_constant_fn, scalar_expression, ...)\` in \`scalar_make_constant.h\` — implements the same singleton + negation-pulling canonicalisation as the arithmetic overload. Centralises the rule.

2. **Route \`scalar_traits::make_constant\`** through the dispatch (was: direct \`make_expression<scalar_constant>\`). Effect: every simplifier site that collapses a coefficient to 1 now produces the \`scalar_one\` singleton.

3. **Route \`tensor_to_scalar_traits::make_constant\`** symmetrically.

4. **Update \`make_scalar_constant\` in basic_functions.h** — single-arg + multi-arg variants both delegate to a new \`detail::make_one_scalar_constant\` helper that picks the canonical path for arithmetic args and falls through to direct construction for \`scalar_number\`.

## Tests added (\`CoreBugFix.Issue184_*\`)

- Repro from the issue body (negative int) parity check
- Cross-value parity across {-1, -2, -7, -100, 2, 3, 17, 1000}
- Singleton equality for 0, 1, -1
- \`make_scalar_constant(-2) == -make_scalar_constant(2)\`
- N-ary tree merge: \`2*x + make_scalar_constant(2)*x == 4*x\`
- Double-precision path parity

## Existing test regressions surfaced + fixed automatically

The canonicalisation alone resolved these (no manual test updates required) — they were workarounds for the old behavior:

- **\`CoreBugFix.NArySubAddDispatchScalar\`**: \`(2+x) - (1+x)\` now collapses to the \`scalar_one\` singleton (was \`scalar_constant{1}\`).
- **\`TensorToScalarDivOperatorTest.DivByPowFlattensExponent\`** (×3 instantiations): pow-of-pow merge now builds the canonical \`-scalar_constant(2)\` form (was raw \`scalar_constant{-2}\`).

## Test plan

- [x] All 1165 tests pass locally
- [x] No regressions in the existing suite
- [ ] CI green

Closes #184.