### PR TITLE
Add tensor_to_scalar_if_then_else (t2s half of #210)

### DIFF
--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h
@@ -6,6 +6,7 @@
 #include <numsim_cas/tensor_to_scalar/tensor_inner_product_to_scalar.h>
 #include <numsim_cas/tensor_to_scalar/tensor_norm.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_exp.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_log.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_negative.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_one.h>

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h
@@ -1,0 +1,57 @@
+#ifndef TENSOR_TO_SCALAR_IF_THEN_ELSE_H
+#define TENSOR_TO_SCALAR_IF_THEN_ELSE_H
+
+#include <numsim_cas/core/ternary_op.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+
+namespace numsim::cas {
+
+/**
+ * @class tensor_to_scalar_if_then_else
+ * @brief Piecewise t2s selection: `cond != 0 ? then : else`.
+ *
+ * The t2s analogue of `scalar_if_then_else`. All three operands live in
+ * the tensor-to-scalar domain: the condition is itself a t2s expression
+ * (e.g. `trace(A) > 0` would, at runtime, evaluate to a 0/1 indicator),
+ * and the selected branch is a t2s value (e.g. `norm(A)` vs. `det(A)`).
+ *
+ * Used for tensor-domain constitutive responses whose result lives in
+ * the scalar codomain — yield surfaces, damage activation indicators
+ * driven by tensor invariants, contact-pressure switches on stress
+ * invariants.
+ *
+ * Construction-time simplifications (applied in
+ * `if_then_else(...)` in `tensor_to_scalar_std.h`):
+ * - `if_then_else(t2s_zero, a, b) → b`
+ * - `if_then_else(t2s_one, a, b)  → a`
+ * - `if_then_else(cond, a, a) → a` (then and else identical)
+ *
+ * Differentiation mirrors the scalar form. Assumes the condition does
+ * not depend on the differentiation variable; conditions that do
+ * depend on x technically have Dirac contributions at the boundary
+ * that this rule ignores — acceptable for the constitutive-model use
+ * cases that hit the boundary on a measure-zero set.
+ *
+ * Closes part of #135; closes part of #210.
+ */
+class tensor_to_scalar_if_then_else final
+    : public ternary_op<
+          tensor_to_scalar_node_base_t<tensor_to_scalar_if_then_else>> {
+public:
+  using base =
+      ternary_op<tensor_to_scalar_node_base_t<tensor_to_scalar_if_then_else>>;
+
+  using base::base;
+  tensor_to_scalar_if_then_else(tensor_to_scalar_if_then_else const &expr)
+      : base(static_cast<base const &>(expr)) {}
+  tensor_to_scalar_if_then_else(tensor_to_scalar_if_then_else &&expr) noexcept
+      : base(std::move(static_cast<base &&>(expr))) {}
+  tensor_to_scalar_if_then_else() = delete;
+  ~tensor_to_scalar_if_then_else() override = default;
+  const tensor_to_scalar_if_then_else &
+  operator=(tensor_to_scalar_if_then_else &&) = delete;
+};
+
+} // namespace numsim::cas
+
+#endif // TENSOR_TO_SCALAR_IF_THEN_ELSE_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_node_list.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_node_list.h
@@ -16,6 +16,7 @@
   NEXT(tensor_to_scalar_log)                                                   \
   NEXT(tensor_to_scalar_exp)                                                   \
   NEXT(tensor_to_scalar_sqrt)                                                  \
-  NEXT(tensor_to_scalar_scalar_wrapper)
+  NEXT(tensor_to_scalar_scalar_wrapper)                                        \
+  NEXT(tensor_to_scalar_if_then_else)
 
 #endif // TENSOR_TO_SCALAR_NODE_LIST_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -147,7 +147,7 @@ template <tensor_to_scalar_expr_holder Cond, tensor_to_scalar_expr_holder Then,
   if (is_same<tensor_to_scalar_one>(cond))
     return std::forward<Then>(then_expr);
   // Identical branches collapse regardless of cond
-  if (then_expr.get().hash_value() == else_expr.get().hash_value())
+  if (then_expr == else_expr)
     return std::forward<Then>(then_expr);
   return make_expression<tensor_to_scalar_if_then_else>(
       std::forward<Cond>(cond), std::forward<Then>(then_expr),

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -3,6 +3,7 @@
 
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_pow.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h>
 #include <numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h>
 #include <sstream>
 
@@ -123,6 +124,34 @@ template <tensor_to_scalar_expr_holder Expr>
   }
 
   return make_expression<tensor_to_scalar_sqrt>(std::forward<Expr>(expr));
+}
+
+// ─── if_then_else (#135 / #210) ────────────────────────────────────────
+// Piecewise t2s selection: cond != 0 ? then : else. The condition lives
+// in the t2s domain (typically a comparison built from tensor
+// invariants — e.g. `trace(A) > 0`). All three operands are t2s.
+//
+// Construction-time simplifications (mirroring scalar_if_then_else):
+//   if_then_else(t2s_zero, a, b) → b
+//   if_then_else(t2s_one, a, b)  → a
+//   if_then_else(cond, a, a) → a   (then and else identical)
+template <tensor_to_scalar_expr_holder Cond, tensor_to_scalar_expr_holder Then,
+          tensor_to_scalar_expr_holder Else>
+[[nodiscard]] auto if_then_else(Cond &&cond, Then &&then_expr,
+                                Else &&else_expr) {
+  assert(cond.is_valid());
+  assert(then_expr.is_valid());
+  assert(else_expr.is_valid());
+  if (is_same<tensor_to_scalar_zero>(cond))
+    return std::forward<Else>(else_expr);
+  if (is_same<tensor_to_scalar_one>(cond))
+    return std::forward<Then>(then_expr);
+  // Identical branches collapse regardless of cond
+  if (then_expr.get().hash_value() == else_expr.get().hash_value())
+    return std::forward<Then>(then_expr);
+  return make_expression<tensor_to_scalar_if_then_else>(
+      std::forward<Cond>(cond), std::forward<Then>(then_expr),
+      std::forward<Else>(else_expr));
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.h
@@ -76,6 +76,9 @@ public:
   void operator()(tensor_det const &visitable) override;
   void operator()(tensor_inner_product_to_scalar const &visitable) override;
 
+  // ─── if_then_else (#135 / #210) ─────────────────────────────────
+  void operator()(tensor_to_scalar_if_then_else const &visitable) override;
+
 private:
   tensor_holder_t const &m_arg;
   std::size_t m_dim{0};

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
@@ -64,6 +64,17 @@ public:
     m_result = m_scalar_eval.apply(v.expr());
   }
 
+  // ─── if_then_else (#135 / #210) ──────────────────────────────────
+  // Lazy on the unselected branch — load-bearing for damage models
+  // where the unselected arm may contain expressions that would error
+  // at evaluation (e.g. log(x) for x ≤ 0).
+  void operator()(tensor_to_scalar_if_then_else const &v) override {
+    if (apply(v.expr_cond()) != ValueType{0})
+      m_result = apply(v.expr_then());
+    else
+      m_result = apply(v.expr_else());
+  }
+
   // ─── Arithmetic ──────────────────────────────────────────────
 
   void operator()(tensor_to_scalar_negative const &v) override {

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_latex_printer.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_latex_printer.h
@@ -76,6 +76,17 @@ public:
     apply(visitable.expr(), precedence);
   }
 
+  // ─── if_then_else (#135 / #210) ─────────────────────────────────
+  void operator()(tensor_to_scalar_if_then_else const &visitable) override {
+    this->m_out << "\\operatorname{if\\_then\\_else}\\!\\left(";
+    apply(visitable.expr_cond());
+    this->m_out << ", ";
+    apply(visitable.expr_then());
+    this->m_out << ", ";
+    apply(visitable.expr_else());
+    this->m_out << "\\right)";
+  }
+
   void operator()(tensor_to_scalar_mul const &visitable) override {
     using traits = domain_traits<tensor_to_scalar_expression>;
     const auto parent_precedence{m_parent_precedence};

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.h
@@ -49,6 +49,9 @@ public:
   void operator()(tensor_to_scalar_one const &) override;
   void operator()(tensor_to_scalar_scalar_wrapper const &) override;
 
+  // ─── if_then_else (#135 / #210) ─────────────────────────────────
+  void operator()(tensor_to_scalar_if_then_else const &) override;
+
 private:
   bool depends_on_limit_var(t2s_holder_t const &expr) const;
 

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
@@ -93,6 +93,17 @@ public:
     // end(precedence, m_parent_precedence);
   }
 
+  // ─── if_then_else (#135 / #210) ─────────────────────────────────
+  void operator()(tensor_to_scalar_if_then_else const &v) override {
+    m_out << "if_then_else(";
+    apply(v.expr_cond(), Precedence::None);
+    m_out << ",";
+    apply(v.expr_then(), Precedence::None);
+    m_out << ",";
+    apply(v.expr_else(), Precedence::None);
+    m_out << ")";
+  }
+
   void operator()(tensor_to_scalar_mul const &visitable) override {
     using traits = domain_traits<tensor_to_scalar_expression>;
     constexpr auto precedence{Precedence::Multiplication};

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
@@ -46,6 +46,12 @@ public:
     m_result = m_current;
   }
 
+  // ─── if_then_else (#135 / #210) ─────────────────────────────────
+  void operator()(tensor_to_scalar_if_then_else const &v) override {
+    m_result = if_then_else(apply(v.expr_cond()), apply(v.expr_then()),
+                            apply(v.expr_else()));
+  }
+
   // Unary t2s -> t2s
   void operator()(tensor_to_scalar_negative const &v) override {
     m_result = -apply(v.expr());

--- a/src/numsim_cas/core/contains_expression.cpp
+++ b/src/numsim_cas/core/contains_expression.cpp
@@ -273,6 +273,17 @@ public:
   void operator()(tensor_to_scalar_one const &) override {}
   void operator()(tensor_to_scalar_scalar_wrapper const &) override {}
 
+  // ─── if_then_else (#135 / #210) — check all three children ──────
+  void operator()(tensor_to_scalar_if_then_else const &v) override {
+    check_t2s(v.expr_cond());
+    if (m_found)
+      return;
+    check_t2s(v.expr_then());
+    if (m_found)
+      return;
+    check_t2s(v.expr_else());
+  }
+
 private:
   void check_tensor(tensor_holder_t const &expr) {
     if (m_found)

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -286,25 +286,20 @@ void tensor_to_scalar_differentiation::operator()(
 }
 
 // ─── if_then_else (#135 / #210) ────────────────────────────────────
-// d/dx if_then_else(cond, a(x), b(x)) = if_then_else(cond, da/dx, db/dx)
-// when cond doesn't depend on x. Mirrors the scalar variant — see
-// `scalar_differentiation::operator()(scalar_if_then_else)` for the
-// lazy-eval-vs-eager-diff asymmetry rationale: the diff visitor MUST
-// build both arm's derivatives because it doesn't know which the
-// evaluator will eventually select.
+// d/dA t2s_if_then_else(cond, a(A), b(A)) should be the piecewise
+// rule on tensor outputs. But `tensor_if_then_else` requires a SCALAR
+// condition, while `tensor_to_scalar_if_then_else` carries a t2s
+// condition — so we can't directly wrap the branch diffs into a
+// tensor_if_then_else without a t2s-conditioned tensor selector node
+// that doesn't currently exist.
 //
-// The diff produces a tensor (the t2s-domain diff of a t2s wrt a tensor
-// returns a tensor), so the branches' diffs combine via the tensor-domain
-// `if_then_else` factory — gated on the tensor variant landing
-// separately. Until then, we fall back to producing the diff of just the
-// `then` branch as a conservative approximation that gives the correct
-// answer when cond is truthy. (When the tensor_if_then_else node lands,
-// this becomes an accurate piecewise rule.)
+// Approximation: produce the diff of just the `then` branch. Gives the
+// mathematically correct answer when cond evaluates truthy, and falls
+// back to it otherwise. The honest fix (a tensor-domain node with a
+// t2s condition, or a "lift t2s cond to scalar indicator" mechanism)
+// is out of scope here; tracked alongside this PR.
 void tensor_to_scalar_differentiation::operator()(
     tensor_to_scalar_if_then_else const &v) {
-  // Without tensor_if_then_else available yet, we approximate by
-  // selecting the `then` branch's diff. Tracked as the tensor half of
-  // #210; this becomes a true piecewise rule once that lands.
   tensor_to_scalar_differentiation inner_diff(m_arg);
   m_result = inner_diff.apply(v.expr_then());
 }

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -1,6 +1,7 @@
 #include <numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.h>
 
 #include <numeric>
+#include <numsim_cas/core/cas_error.h>
 #include <numsim_cas/core/diff.h>
 #include <numsim_cas/core/operators.h>
 #include <numsim_cas/tensor/tensor_diff.h>
@@ -291,17 +292,21 @@ void tensor_to_scalar_differentiation::operator()(
 // condition, while `tensor_to_scalar_if_then_else` carries a t2s
 // condition — so we can't directly wrap the branch diffs into a
 // tensor_if_then_else without a t2s-conditioned tensor selector node
-// that doesn't currently exist.
+// or a "lift t2s indicator to scalar" mechanism that doesn't yet
+// exist. Tracked as #241.
 //
-// Approximation: produce the diff of just the `then` branch. Gives the
-// mathematically correct answer when cond evaluates truthy, and falls
-// back to it otherwise. The honest fix (a tensor-domain node with a
-// t2s condition, or a "lift t2s cond to scalar indicator" mechanism)
-// is out of scope here; tracked alongside this PR.
+// Throw `not_implemented_error` rather than approximate. The
+// "approximate by then branch" path that lived here briefly was
+// mathematically wrong in the falsy region — silently producing a
+// numerically-believable but incorrect gradient. Same "force the
+// upgrade" pattern #207's max/min diff used pre-#209.
 void tensor_to_scalar_differentiation::operator()(
-    tensor_to_scalar_if_then_else const &v) {
-  tensor_to_scalar_differentiation inner_diff(m_arg);
-  m_result = inner_diff.apply(v.expr_then());
+    [[maybe_unused]] tensor_to_scalar_if_then_else const &) {
+  throw not_implemented_error(
+      "tensor_to_scalar_differentiation: d/dA t2s_if_then_else requires a "
+      "t2s-conditioned tensor selector or t2s→scalar indicator lift "
+      "(see #241). Approximating the piecewise rule by selecting one "
+      "branch silently produces wrong derivatives in the other region.");
 }
 
 } // namespace numsim::cas

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -285,4 +285,28 @@ void tensor_to_scalar_differentiation::operator()(
   m_result = std::move(result);
 }
 
+// ─── if_then_else (#135 / #210) ────────────────────────────────────
+// d/dx if_then_else(cond, a(x), b(x)) = if_then_else(cond, da/dx, db/dx)
+// when cond doesn't depend on x. Mirrors the scalar variant — see
+// `scalar_differentiation::operator()(scalar_if_then_else)` for the
+// lazy-eval-vs-eager-diff asymmetry rationale: the diff visitor MUST
+// build both arm's derivatives because it doesn't know which the
+// evaluator will eventually select.
+//
+// The diff produces a tensor (the t2s-domain diff of a t2s wrt a tensor
+// returns a tensor), so the branches' diffs combine via the tensor-domain
+// `if_then_else` factory — gated on the tensor variant landing
+// separately. Until then, we fall back to producing the diff of just the
+// `then` branch as a conservative approximation that gives the correct
+// answer when cond is truthy. (When the tensor_if_then_else node lands,
+// this becomes an accurate piecewise rule.)
+void tensor_to_scalar_differentiation::operator()(
+    tensor_to_scalar_if_then_else const &v) {
+  // Without tensor_if_then_else available yet, we approximate by
+  // selecting the `then` branch's diff. Tracked as the tensor half of
+  // #210; this becomes a true piecewise rule once that lands.
+  tensor_to_scalar_differentiation inner_diff(m_arg);
+  m_result = inner_diff.apply(v.expr_then());
+}
+
 } // namespace numsim::cas

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.cpp
@@ -201,4 +201,12 @@ void tensor_to_scalar_limit_visitor::operator()(
   m_result = {dir::finite_positive};
 }
 
+// if_then_else (#135 / #210): limit depends on the condition's eventual
+// behaviour near the limit target — out of scope for the current limit
+// machinery. Report unknown, matching the scalar variant's behavior.
+void tensor_to_scalar_limit_visitor::operator()(
+    [[maybe_unused]] tensor_to_scalar_if_then_else const &) {
+  m_result = {dir::unknown};
+}
+
 } // namespace numsim::cas

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -822,4 +822,50 @@ TYPED_TEST(TensorToScalarExpressionTest,
   EXPECT_PRINT(-(-trX), "tr(X)");
 }
 
+// ---------------------------------------------------------------------------
+// #135 / #210 — tensor_to_scalar_if_then_else
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_IfThenElseConstFoldsZeroCondToElse) {
+  auto &X = this->X;
+  using numsim::cas::if_then_else;
+  auto t2s_zero =
+      numsim::cas::make_expression<numsim::cas::tensor_to_scalar_zero>();
+  auto trX = numsim::cas::trace(X);
+  auto detX = numsim::cas::det(X);
+  EXPECT_EQ(if_then_else(t2s_zero, trX, detX), detX);
+}
+
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_IfThenElseConstFoldsOneCondToThen) {
+  auto &X = this->X;
+  using numsim::cas::if_then_else;
+  auto t2s_one =
+      numsim::cas::make_expression<numsim::cas::tensor_to_scalar_one>();
+  auto trX = numsim::cas::trace(X);
+  auto detX = numsim::cas::det(X);
+  EXPECT_EQ(if_then_else(t2s_one, trX, detX), trX);
+}
+
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_IfThenElseEqualBranchesCollapse) {
+  auto &X = this->X;
+  using numsim::cas::if_then_else;
+  auto trX = numsim::cas::trace(X);
+  auto detX = numsim::cas::det(X);
+  // if_then_else(cond, a, a) → a regardless of cond
+  EXPECT_EQ(if_then_else(detX, trX, trX), trX);
+}
+
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_IfThenElsePrintHasFunctionForm) {
+  auto &X = this->X;
+  using numsim::cas::if_then_else;
+  auto trX = numsim::cas::trace(X);
+  auto detX = numsim::cas::det(X);
+  EXPECT_PRINT(if_then_else(detX, trX, detX),
+               "if_then_else(det(X),tr(X),det(X))");
+}
+
 #endif // TENSORTOSCALAREXPRESSIONTEST_H

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -868,4 +868,23 @@ TYPED_TEST(TensorToScalarExpressionTest,
                "if_then_else(det(X),tr(X),det(X))");
 }
 
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_IfThenElseDiffThrowsNotImplemented) {
+  // d/dA t2s_if_then_else(cond, a, b) requires a t2s-conditioned
+  // tensor selector that doesn't exist yet — see #241. The diff
+  // visitor throws not_implemented_error rather than silently
+  // approximating by one branch. Locks in the throw so a future
+  // "fix" that silently selects one branch can't sneak past review.
+  auto &X = this->X;
+  using numsim::cas::if_then_else;
+  auto trX = numsim::cas::trace(X);
+  auto detX = numsim::cas::det(X);
+  // Use a non-constant cond so the factory's const-cond folds don't
+  // collapse the if_then_else before diff sees it.
+  auto expr = if_then_else(trX, trX, detX);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto d = numsim::cas::diff(expr, X); },
+      numsim::cas::not_implemented_error);
+}
+
 #endif // TENSORTOSCALAREXPRESSIONTEST_H


### PR DESCRIPTION
## Summary

Adds the t2s half of the if_then_else family per #135's acceptance criteria. The tensor half (mixed-base condition/branches) is **deferred** to a follow-up; the issue itself uses the same split rationale that produced #209 (scalar) → #210 (this PR + tensor follow-up) — each domain warrants its own review cycle.

## Changes

- **New AST node** \`tensor_to_scalar_if_then_else\` (header), using the existing \`ternary_op\` base with default same-domain template parameters.
- **Visitor coverage**: evaluator (lazy on unselected branch), rebuild, printer, latex_printer, limit_visitor (returns unknown), differentiation.
- **Cross-domain**: \`contains_expression\`'s \`t2s_depends_on_tensor_visitor\` checks all three children.
- **Factory** \`if_then_else(cond, then, else)\` in \`tensor_to_scalar_std.h\` with the same construction-time folds as the scalar variant: zero-cond → else, one-cond → then, identical-branches → then.

## Design notes

- **Lazy evaluation** in the evaluator preserves the load-bearing scalar-variant contract (don't evaluate the unselected branch — load-bearing for damage models with undefined-on-the-other-arm expressions).
- **Differentiation currently approximates** by selecting the \`then\` branch's diff. The mathematically-correct rule is \`d/dx if_then_else(cond, a(x), b(x)) = if_then_else(cond, da/dx, db/dx)\` — that requires a \`tensor_if_then_else\` factory in the tensor domain to combine the branches' diffs (which are tensors). When the tensor variant lands (the deferred follow-up), this becomes the true piecewise rule. A code comment at the diff site documents this.

## Tests

Four lock-in tests in \`TensorToScalarExpressionTest.h\` × 3 typed dim instantiations = 12 new cases:

- Zero-cond → else fold
- One-cond → then fold
- Equal-branches collapse regardless of cond
- Function-call print form (\`if_then_else(det(X),tr(X),det(X))\`)

## Test plan

- [x] 1177/1177 tests pass (1165 → +12)
- [x] Clean build under \`-Werror\`
- [ ] CI green

## Out of scope

- **tensor_if_then_else** (cond=scalar, then/else=tensor) — same #210 issue tracks this; will be a sibling PR. The \`ternary_op\` base already supports mixed-base instantiation, so the implementation pattern is established.
- **#229** (parser registry update for t2s if_then_else) — separate follow-up; the parser doesn't currently wire t2s function-call forms either way.