### PR TITLE
Use expression_holder::operator== in scalar if_then_else fold

### DIFF
--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -640,7 +640,7 @@ template <scalar_expr_holder Cond, scalar_expr_holder Then,
     return (*cval == scalar_number{0}) ? std::forward<Else>(else_expr)
                                        : std::forward<Then>(then_expr);
   // Identical branches collapse regardless of cond
-  if (then_expr.get().hash_value() == else_expr.get().hash_value())
+  if (then_expr == else_expr)
     return std::forward<Then>(then_expr);
   return make_expression<scalar_if_then_else>(std::forward<Cond>(cond),
                                               std::forward<Then>(then_expr),


### PR DESCRIPTION
Drive-by tightening surfaced during review of #239: the identical-branches fold in \`scalar_std.h::if_then_else\` was comparing hashes directly:

\`\`\`cpp
if (then_expr.get().hash_value() == else_expr.get().hash_value())
\`\`\`

Equivalent in behavior to \`then_expr == else_expr\` (the holder's \`operator==\` ultimately delegates to hash comparison), but the operator form is the canonical way to compare holders in this codebase and reads more directly.

Same one-line fix applied separately in the t2s and tensor \`if_then_else\` factories on PRs #238 and #239; this PR completes the trio for the scalar variant (which is already on main).

## Test plan

- [x] 1165/1165 tests pass
- [ ] CI green