### PR TITLE
Add lazy-eval lock-in tests for tensor + t2s if_then_else (#242)

### DIFF
--- a/tests/TensorEvaluatorTest.h
+++ b/tests/TensorEvaluatorTest.h
@@ -991,6 +991,37 @@ TEST(TensorProjAlgebra, ProjectorHashSameForIdenticalSpaces) {
   EXPECT_EQ(p1.get().hash_value(), p2.get().hash_value());
 }
 
+// ─── if_then_else lazy-evaluation lock-in (#242) ─────────────────
+// Mirror of the scalar IfThenElseEvaluatorLazyOnUnselectedBranch test.
+// The unselected branch references an unbound tensor symbol — eager
+// evaluation would throw evaluation_error trying to look it up.
+// Lazy evaluation skips it entirely.
+TEST(TensorEval, IfThenElseLazyOnUnselectedBranch) {
+  tensor_evaluator<double> ev;
+  auto x = make_expression<scalar>("x");
+  auto A = make_expression<tensor>("A", 2, 2); // deliberately UNBOUND
+  auto _zero = make_expression<scalar_constant>(0.0);
+  auto Z = make_expression<tensor_zero>(std::size_t{2}, std::size_t{2});
+
+  // cond = ge(x, 0). At x=1 → cond truthy → then = Z is selected.
+  // The else branch is inv(A) — accessing the unbound A would throw.
+  ev.set_scalar(x, 1.0);
+  auto expr_then_safe = if_then_else(ge(x, _zero), Z, inv(A));
+  auto result = ev.apply(expr_then_safe);
+  ASSERT_NE(result, nullptr);
+  auto expected = make_tmech<2, 2>({0.0, 0.0, 0.0, 0.0});
+  EXPECT_TRUE(tmech::almost_equal(as_tmech<2, 2>(*result), expected, tol));
+
+  // cond = ge(x, 0). At x=-1 → cond falsy → else = Z is selected.
+  // The then branch is inv(A) — same unbound-symbol trap, on the
+  // other arm.
+  ev.set_scalar(x, -1.0);
+  auto expr_else_safe = if_then_else(ge(x, _zero), inv(A), Z);
+  auto result2 = ev.apply(expr_else_safe);
+  ASSERT_NE(result2, nullptr);
+  EXPECT_TRUE(tmech::almost_equal(as_tmech<2, 2>(*result2), expected, tol));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSOREVALUATORTEST_H

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -258,6 +258,35 @@ TEST(T2sEval, EvaluationErrorIsCatchableAsRuntimeError) {
   EXPECT_THROW(ev.apply(trace(A)), std::runtime_error);
 }
 
+// ─── if_then_else lazy-evaluation lock-in (#242) ─────────────────
+// Mirror of TensorEval.IfThenElseLazyOnUnselectedBranch and the
+// scalar IfThenElseEvaluatorLazyOnUnselectedBranch. The unselected
+// branch contains trace(A) where A is deliberately unbound — eager
+// evaluation would throw evaluation_error. Lazy evaluation skips it.
+TEST(T2sEval, IfThenElseLazyOnUnselectedBranch) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto x = make_expression<scalar>("x");
+  auto A = make_expression<tensor>("A", 2, 2); // deliberately UNBOUND
+  // Wrap the scalar so the cond is a t2s expression (matches the
+  // tensor_to_scalar_if_then_else node's cond type). A wrapped variable
+  // also escapes the construction-time `if cond is constant` fold in
+  // tensor_to_scalar_std.h's factory.
+  auto cond = make_expression<tensor_to_scalar_scalar_wrapper>(x);
+  auto safe = make_expression<tensor_to_scalar_scalar_wrapper>(
+      make_expression<scalar_constant>(42.0));
+  auto unsafe = trace(A);
+
+  // cond truthy (x=1) → then = safe.
+  ev.set_scalar(x, 1.0);
+  auto expr_then_safe = if_then_else(cond, safe, unsafe);
+  EXPECT_NEAR(ev.apply(expr_then_safe), 42.0, t2s_tol);
+
+  // cond falsy (x=0) → else = safe.
+  ev.set_scalar(x, 0.0);
+  auto expr_else_safe = if_then_else(cond, unsafe, safe);
+  EXPECT_NEAR(ev.apply(expr_else_safe), 42.0, t2s_tol);
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORTOSCALAREVALUATORTEST_H


### PR DESCRIPTION
Closes #242.

## Summary
- Adds `TensorEval.IfThenElseLazyOnUnselectedBranch` and `T2sEval.IfThenElseLazyOnUnselectedBranch`, mirroring the existing scalar variant.
- Each test uses an unbound tensor symbol on the unselected branch — eager evaluation would throw `evaluation_error`, lazy evaluation skips it. Both branch-arm positions are exercised.

## Why now
The laziness contract is load-bearing for damage / contact models where the unselected arm may contain expressions that error at evaluation. Scalar had a test, the two newer variants didn't.

## Sanity check
Temporarily replaced both evaluator impls with eager versions (apply both branches unconditionally before the cond check) — confirmed both tests fail. Restored, both pass. Full suite: 1203/1203 (was 1201, +2).

## Stack
- Stacked on `210-tensor-half` (#239) because it needs `tensor_if_then_else` to exist. Will retarget to `main` before merge per the stacked-PR cascade rule.