### PR TITLE
Add principal invariants (I1, I2, I3) for rank-2 tensors (#226 part 1)

### DIFF
--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h
@@ -22,6 +22,28 @@ norm(expression_holder<tensor_expression> const &expr);
 [[nodiscard]] expression_holder<tensor_to_scalar_expression>
 det(expression_holder<tensor_expression> const &expr);
 
+// Principal invariants of a rank-2 tensor A — the coefficients of A's
+// characteristic polynomial det(A - λI). These are the three scalars
+// that characterise A up to similarity:
+//
+//   I1(A) = tr(A)
+//   I2(A) = (tr(A)^2 - tr(A^2)) / 2
+//   I3(A) = det(A)
+//
+// Implemented as compositions of existing primitives (trace, det, the
+// tensor-tensor product). The eigenvalue / eigenvector half of #226
+// needs new AST nodes — these are the cheap deliverable.
+//
+// Rank-2 enforced via the underlying trace/det rank-2 asserts.
+[[nodiscard]] expression_holder<tensor_to_scalar_expression>
+first_invariant(expression_holder<tensor_expression> const &expr);
+
+[[nodiscard]] expression_holder<tensor_to_scalar_expression>
+second_invariant(expression_holder<tensor_expression> const &expr);
+
+[[nodiscard]] expression_holder<tensor_to_scalar_expression>
+third_invariant(expression_holder<tensor_expression> const &expr);
+
 } // namespace numsim::cas
 
 #endif // TENSOR_TO_SCALAR_FUNCTIONS_H

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -5,6 +5,7 @@
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/scalar/scalar_std.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
+#include <numsim_cas/tensor/tensor_operators.h>
 
 #include <cassert>
 #include <ranges>
@@ -145,6 +146,34 @@ det(expression_holder<tensor_expression> const &expr) {
   }
 
   return make_expression<tensor_det>(expr);
+}
+
+// ─── Principal invariants (#226 cheap deliverable) ─────────────────────
+// I1(A) = tr(A); I2(A) = (tr(A)^2 - tr(A^2)) / 2; I3(A) = det(A).
+// Compositions of existing primitives — no new AST nodes.
+
+expression_holder<tensor_to_scalar_expression>
+first_invariant(expression_holder<tensor_expression> const &expr) {
+  return trace(expr);
+}
+
+expression_holder<tensor_to_scalar_expression>
+second_invariant(expression_holder<tensor_expression> const &expr) {
+  // For a rank-2 tensor A: I2 = (tr(A)^2 - tr(A·A)) / 2.
+  // The A*A product uses the existing single-contraction tensor-tensor
+  // mul_fn (rank 2*2 = 2). Zero-short-circuits and trace simplifiers
+  // fire through the composition automatically.
+  auto tr_A = trace(expr);
+  auto tr_AA = trace(expr * expr);
+  // (tr_A * tr_A - tr_AA) / 2. Use a scalar_constant(2) wrapped as t2s.
+  auto two = make_expression<tensor_to_scalar_scalar_wrapper>(
+      make_expression<scalar_constant>(2));
+  return (tr_A * tr_A - tr_AA) / two;
+}
+
+expression_holder<tensor_to_scalar_expression>
+third_invariant(expression_holder<tensor_expression> const &expr) {
+  return det(expr);
 }
 
 } // namespace numsim::cas

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -231,6 +231,107 @@ TEST(T2sEval, EvalScalarTimesTrace) {
   EXPECT_NEAR(ev.apply(expr), 15.0, t2s_tol);
 }
 
+// ─── Principal invariants (#226) ──────────────────────────────────────
+
+TEST(T2sEval, FirstInvariantEqualsTrace) {
+  // I1(A) = tr(A). Aliases trace; this lock-in catches any future
+  // accidental divergence (e.g. someone makes I1 mean something else).
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 1.0, 0.0,
+                                   1.0, 3.0, 1.0,
+                                   0.0, 1.0, 5.0}));
+  // clang-format on
+  EXPECT_NEAR(ev.apply(first_invariant(A)), ev.apply(trace(A)), t2s_tol);
+  EXPECT_NEAR(ev.apply(first_invariant(A)), 10.0, t2s_tol);
+}
+
+TEST(T2sEval, ThirdInvariantEqualsDet) {
+  // I3(A) = det(A).
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 1.0, 0.0,
+                                   1.0, 3.0, 1.0,
+                                   0.0, 1.0, 2.0}));
+  // clang-format on
+  auto tmech_A =
+      make_tmech<3, 2>({2.0, 1.0, 0.0, 1.0, 3.0, 1.0, 0.0, 1.0, 2.0});
+  EXPECT_NEAR(ev.apply(third_invariant(A)), ev.apply(det(A)), t2s_tol);
+  EXPECT_NEAR(ev.apply(third_invariant(A)), tmech::det(tmech_A), t2s_tol);
+}
+
+TEST(T2sEval, SecondInvariantMatchesFormula) {
+  // I2(A) = (tr(A)^2 - tr(A·A)) / 2. Verify against the explicit
+  // formula computed independently and against a hand-checked value.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // Diagonal A=diag(2,3,5): A^2=diag(4,9,25), tr=10, tr(A^2)=38,
+  // I2 = (100 - 38)/2 = 31.
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 0.0, 0.0,
+                                   0.0, 3.0, 0.0,
+                                   0.0, 0.0, 5.0}));
+  // clang-format on
+  EXPECT_NEAR(ev.apply(second_invariant(A)), 31.0, t2s_tol);
+}
+
+TEST(T2sEval, SecondInvariantSymmetricMatrix) {
+  // Symmetric (non-diagonal) case: A = [[2,1,0],[1,3,1],[0,1,2]].
+  // A^2 = [[5,5,1],[5,11,5],[1,5,5]]; tr(A^2)=21; tr(A)=7; tr(A)^2=49;
+  // I2 = (49 - 21)/2 = 14.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 1.0, 0.0,
+                                   1.0, 3.0, 1.0,
+                                   0.0, 1.0, 2.0}));
+  // clang-format on
+  EXPECT_NEAR(ev.apply(second_invariant(A)), 14.0, t2s_tol);
+}
+
+TEST(T2sEval, SecondInvariantNonSymmetric) {
+  // tr(A^2) for non-symmetric A is A_ij A_ji, NOT A:A — exercises the
+  // tensor-tensor product path (rather than the squared Frobenius norm
+  // shortcut for symmetric A).
+  // A = [[1,2],[3,4]]; A^2 = [[7,10],[15,22]]; tr=29; tr(A)=5; tr(A)^2=25;
+  // I2 = (25 - 29)/2 = -2.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  ev.set(A, make_test_data<2, 2>({1.0, 2.0, 3.0, 4.0}));
+  EXPECT_NEAR(ev.apply(second_invariant(A)), -2.0, t2s_tol);
+}
+
+TEST(T2sEval, InvariantsCharacteristicPolynomial) {
+  // For a rank-2 tensor A, the characteristic polynomial is
+  //   det(A - λ I) = -λ^3 + I1·λ^2 - I2·λ + I3   (dim=3 sign convention)
+  // At λ=1 this reads -1 + I1 - I2 + I3 = det(A - I).
+  // Use it as a structural lock-in: invariants reconstruct the
+  // characteristic polynomial.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({4.0, 1.0, 0.0,
+                                   1.0, 2.0, 1.0,
+                                   0.0, 1.0, 3.0}));
+  // clang-format on
+  auto I = make_expression<identity_tensor>(std::size_t{3}, std::size_t{2});
+  auto det_A_minus_I = det(A - I);
+
+  auto i1 = first_invariant(A);
+  auto i2 = second_invariant(A);
+  auto i3 = third_invariant(A);
+
+  // Reconstructed value of det(A - I) via the characteristic polynomial
+  // evaluated at λ = 1: -1 + I1 - I2 + I3.
+  auto neg_one = make_expression<tensor_to_scalar_scalar_wrapper>(
+      make_expression<scalar_constant>(-1));
+  auto reconstructed = neg_one + i1 - i2 + i3;
+
+  EXPECT_NEAR(ev.apply(det_A_minus_I), ev.apply(reconstructed), 1e-10);
+}
+
 // ─── Error tests ──────────────────────────────────────────────────────
 
 TEST(T2sEval, EvalMissingTensorSymbol) {


### PR DESCRIPTION
First slice of #226 — the cheap deliverable that doesn't need new AST nodes. The eigenvalue / eigenvector half stays open as the larger remaining work on that issue.

## Summary
Three principal invariants of a rank-2 tensor `A`, defined as the coefficients of `A`'s characteristic polynomial `det(A - λI)`:

- `first_invariant(A)`  = `tr(A)`
- `second_invariant(A)` = `(tr(A)² − tr(A·A)) / 2`
- `third_invariant(A)`  = `det(A)`

Pure compositions of existing primitives (`trace`, `det`, the tensor-tensor product). No new AST nodes; existing zero/identity short-circuits in trace/det fire transparently.

For symmetric A, `tr(A²)` reduces to `||A||_F²` (the Frobenius squared norm). The implementation doesn't specialise — the existing simplifier infrastructure can pick that up later if it matters.

## Tests
6 lock-ins in `tests/TensorToScalarEvaluatorTest.h`:
- `I1 == trace`, `I3 == det` aliases (3x3)
- I2 on diagonal `diag(2,3,5)` → analytic 31
- I2 on symmetric tridiagonal → analytic 14
- I2 on non-symmetric `[[1,2],[3,4]]` → analytic −2 (exercises the A·A path where `tr(A²) ≠ A:A`)
- **Characteristic-polynomial reconstruction**: `−1 + I1 − I2 + I3 == det(A − I)`, verified by evaluating both sides independently. This is the strongest correctness check — it confirms the invariants ARE the polynomial coefficients.

Suite: 1171/1171 pass (1165 + 6 new).

## Out of scope (rest of #226)
- `eigenvalues(A)` / `eigenvectors(A)` returning `std::array<expression_holder<...>, Dim>` — needs new AST nodes (`tensor_to_scalar_eigenvalue` carrying A + index) and evaluator integration with tmech's eigen routines.
- Chain rule for eigenvalues via Magnus / Neudecker (`d/dA λᵢ = nᵢ ⊗ nᵢ`).
- Polar decomposition `F = RU` via eigendecomposition of `F^T F`.