### PR TITLE
Support rank-4 inv with annotation-driven dispatch (#248)

### DIFF
--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -409,14 +409,27 @@ template <tensor_expr_holder Expr>
   if (is_same<tensor_zero>(expr))
     throw invalid_expression_error("inv: operand is the zero tensor "
                                    "(singular)");
-  // Rank gate: only rank-2 inverses are supported. tmech::inv expects
-  // rank-2; higher-rank inversion has no canonical definition in this
-  // codebase (the rank-4 minor identity is a special case handled above).
-  // Reject at construction so downstream evaluation cannot produce
-  // NaN/Inf or a confusing tmech runtime error. Closes #192.
-  if (expr.get().rank() != 2)
+  // Rank gate (#248): rank-2 is unconditionally supported; rank-4 is
+  // supported with two evaluator routes selected by the operand's space
+  // annotation:
+  //
+  //   * Minor / MinorMajor → tmech::inv<sequence<1,2>, sequence<3,4>>
+  //       The minor-symmetric inverse — the dominant case in continuum
+  //       mechanics (algorithmic-tangent rule C_ijkl = ∂a_ij/∂b_kl):
+  //         (A^{-1})_ijmn · A_mnkl = 1/2 (I_ik I_jl + I_il I_jk)
+  //
+  //   * any other / unannotated → tmech::invf (fully anisotropic):
+  //         (A^{-1})_ijmn · A_mnkl = I_ij · I_kl
+  //
+  // The dispatch lives in the evaluator (operator()(tensor_inv) inspects
+  // the operand's space). The factory just gates rank; the AST node
+  // remains a single tensor_inv either way.
+  //
+  // Other ranks (3, 5, ...) keep the rejection — they have no canonical
+  // inverse routine. Supersedes #192's rank-2-only gate.
+  if (expr.get().rank() != 2 && expr.get().rank() != 4)
     throw invalid_expression_error(
-        "inv: only rank-2 tensors are supported (got rank " +
+        "inv: only rank-2 and rank-4 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
   // inv(α·A) = inv(A) / α. The scalar pulls out of the inverse as its
   // reciprocal. Recurse so e.g. inv(α·inv(A)) folds via tensor_inv → A,

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -418,7 +418,8 @@ template <tensor_expr_holder Expr>
   //       mechanics (algorithmic-tangent rule C_ijkl = ∂a_ij/∂b_kl):
   //         (A^{-1})_ijmn · A_mnkl = 1/2 (I_ik I_jl + I_il I_jk)
   //
-  //   * any other / unannotated → tmech::invf (fully anisotropic):
+  //   * Any other annotation (Skew, Sym_r, Anti_r, ...) OR no annotation
+  //     → tmech::invf (fully anisotropic):
   //         (A^{-1})_ijmn · A_mnkl = I_ij · I_kl
   //
   // The dispatch lives in the evaluator (operator()(tensor_inv) inspects
@@ -440,12 +441,16 @@ template <tensor_expr_holder Expr>
     auto const &sm = expr.template get<tensor_scalar_mul>();
     return inv(sm.expr_rhs()) / sm.expr_lhs();
   }
-  // A skew-symmetric matrix in odd dimensions is singular (det = 0) by the
-  // determinant theorem det(-A^T) = (-1)^n det(A). contains_skew_factor also
-  // catches expressions that aren't themselves skew but contain a skew factor
-  // (e.g. B * skew(A)) — still singular. The rank check above already
-  // filtered non-rank-2 inputs, so this guard only covers the rank-2 case.
-  if (expr.get().dim() % 2 != 0 && contains_skew_factor(expr)) {
+  // A skew-symmetric matrix in odd dimensions is singular (det = 0) by
+  // the determinant theorem det(-A^T) = (-1)^n det(A). The theorem is
+  // RANK-2 SPECIFIC — for rank-4 a "skew" annotation doesn't carry the
+  // same algebraic consequence (rank-4 skew has different geometry and
+  // the 9x9 unfolding's determinant isn't related to (-1)^n det(A)).
+  // Restrict the guard to rank-2 so rank-4 skew passes through to the
+  // invf evaluator branch. contains_skew_factor catches both direct
+  // skew tensors and products like B * skew(A).
+  if (expr.get().rank() == 2 && expr.get().dim() % 2 != 0 &&
+      contains_skew_factor(expr)) {
     throw invalid_expression_error(
         "inv: operand contains a skew-symmetric factor in odd dimensions "
         "(singular)");

--- a/include/numsim_cas/tensor/visitors/tensor_evaluator.h
+++ b/include/numsim_cas/tensor/visitors/tensor_evaluator.h
@@ -266,6 +266,20 @@ public:
   }
 
   void operator()(tensor_inv const &v) override {
+    // Rank-2: tmech::inv. Rank-4 with Minor/MinorMajor annotation:
+    // tmech::inv (minor-symmetric default convention). Rank-4 with any
+    // other annotation (or no annotation): tmech::invf (fully
+    // anisotropic). See the factory in tensor_functions.h for the
+    // policy rationale (#248).
+    if (v.rank() == 4) {
+      auto const &sp = v.expr().get().space();
+      bool minor_sym = sp && (std::holds_alternative<Minor>(sp->perm) ||
+                              std::holds_alternative<MinorMajor>(sp->perm));
+      if (!minor_sym) {
+        eval_unary_tmech<tmech_ops::invf>(v);
+        return;
+      }
+    }
     eval_unary_tmech<tmech_ops::inv>(v);
   }
 

--- a/include/numsim_cas/tensor/wrappers/tensor_inv.h
+++ b/include/numsim_cas/tensor/wrappers/tensor_inv.h
@@ -13,15 +13,35 @@ public:
   explicit tensor_inv(
       Expr &&_expr) // NOLINT(bugprone-forwarding-reference-overload)
       : base(std::forward<Expr>(_expr), _expr.get().dim(), _expr.get().rank()) {
-    // inv preserves Symmetric, Volumetric, and Skew spaces.
-    // Deviatoric/Harmonic are NOT preserved (tr(A^{-1}) ≠ 0 in general),
-    // but the Symmetric perm is still valid — downgrade to Symmetric.
     if (auto const &sp = this->expr().get().space()) {
-      if (std::holds_alternative<DeviatoricTag>(sp->trace) ||
-          std::holds_alternative<HarmonicTag>(sp->trace))
-        this->set_space({Symmetric{}, AnyTraceTag{}});
-      else
-        this->set_space(*sp);
+      const auto r = this->rank();
+      if (r == 2) {
+        // Rank-2: tmech::inv preserves Symmetric, Volumetric, and Skew
+        // perms. Deviatoric / Harmonic trace tags are NOT preserved
+        // (tr(A^{-1}) != 0 in general) — downgrade to AnyTraceTag while
+        // keeping the perm.
+        if (std::holds_alternative<DeviatoricTag>(sp->trace) ||
+            std::holds_alternative<HarmonicTag>(sp->trace))
+          this->set_space({Symmetric{}, AnyTraceTag{}});
+        else
+          this->set_space(*sp);
+      } else if (r == 4) {
+        // Rank-4 (#248): only Minor / MinorMajor perms survive. Those
+        // route to tmech::inv (Voigt-symmetric path), which DOES
+        // preserve the Voigt symmetry — so the inverse is also
+        // minor- (resp. minor-and-major-)symmetric. Any other perm
+        // (Skew, Sym_r, Anti_r, Harm_r, Young, General) routes to
+        // tmech::invf (fully anisotropic) — those algebraic properties
+        // are NOT preserved by the full 9×9 matrix inverse, so the
+        // result is general anisotropic. Leave the annotation cleared
+        // in that case rather than incorrectly preserving it.
+        if (std::holds_alternative<Minor>(sp->perm) ||
+            std::holds_alternative<MinorMajor>(sp->perm))
+          this->set_space(*sp);
+        // else: space left unset on the result (general anisotropic).
+      }
+      // Other ranks: inv() factory rejects them; this branch
+      // shouldn't be reached.
     }
   }
 };

--- a/tests/TensorDifferentiationTest.h
+++ b/tests/TensorDifferentiationTest.h
@@ -565,6 +565,25 @@ TEST_F(TensorDifferentiationTest, AuditTensorToScalarWithTensorMulCovered) {
       << "Second-order differentiation produced invalid result";
 }
 
+// #248: rank-4 inv() construction is now supported, but differentiation
+// of a rank-4 inv is NOT yet wired. The visitor throws
+// not_implemented_error with a clear message. Lock that contract in so
+// users hit a definite error rather than getting silent garbage if they
+// try to compose `diff(inv(rank4), ...)`.
+TEST(TensorDiffRank4InvNotImplemented, ThrowsWithClearMessage) {
+  auto C = make_expression<tensor>("C", 3, 4);
+  assume_minor_major(C);
+  auto X = make_expression<tensor>("X", 3, 2);
+  auto invC = inv(C);
+  try {
+    [[maybe_unused]] auto r = diff(invC, X);
+    FAIL() << "Expected diff(inv(rank-4), ...) to throw not_implemented_error";
+  } catch (not_implemented_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("rank"), std::string::npos)
+        << "error message should mention rank; got: " << e.what();
+  }
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORDIFFERENTIATIONTEST_H

--- a/tests/TensorEvaluatorTest.h
+++ b/tests/TensorEvaluatorTest.h
@@ -548,6 +548,18 @@ TEST(TensorEval, Rank4InvDispatchDiffersByAnnotation) {
     ASSERT_NE(result, nullptr);
     EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 4>(*result), invf_data, 1e-10));
   }
+  // Explicitly-non-Minor/MinorMajor annotation (Skew) also routes to
+  // invf — exercises the "any other annotation" branch of the dispatch.
+  {
+    tensor_evaluator<double> ev;
+    auto C = make_expression<tensor>("C", 3, 4);
+    assume_skew(C);
+    ev.set(C, std::static_pointer_cast<tensor_data_base<double>>(C_data));
+    auto result = ev.apply(inv(C));
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 4>(*result), invf_data, 1e-10))
+        << "Skew-annotated rank-4 should still route to invf";
+  }
 }
 
 // --- Compound expression tests ---

--- a/tests/TensorEvaluatorTest.h
+++ b/tests/TensorEvaluatorTest.h
@@ -438,6 +438,118 @@ TEST(TensorEval, EvalInverse3x3) {
   EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 2>(*result), expected, tol));
 }
 
+// ─── Rank-4 inv dispatch (#248) ────────────────────────────────────────
+// The evaluator picks tmech::inv (minor-symmetric) for Minor/MinorMajor-
+// annotated rank-4 operands and tmech::invf (fully anisotropic)
+// otherwise. Verify both branches numerically against tmech directly.
+
+TEST(TensorEval, EvalInverseRank4MinorMajor) {
+  // Annotated minor-major: routes to tmech::inv. Construct a positive-
+  // definite isotropic stiffness as 2μ·I_sym + λ·I⊗I — minor-symmetric
+  // by construction. Bind it via a fixture-sized random PD rank-4.
+  tensor_evaluator<double> ev;
+  auto C = make_expression<tensor>("C", 3, 4);
+  assume_minor_major(C);
+
+  // Build a numerically PD rank-4 by hand: C = 2μ I_sym + λ I⊗I.
+  // For an isotropic linear-elastic stiffness in dim=3, this gives a
+  // matrix that's invertible in both conventions.
+  tmech::tensor<double, 3, 2> I2;
+  for (std::size_t i = 0; i < 3; ++i)
+    for (std::size_t j = 0; j < 3; ++j)
+      I2(i, j) = (i == j) ? 1.0 : 0.0;
+  double const mu = 1.0, lam = 2.0;
+  auto C_tmech = tmech::eval(2.0 * mu * tmech::otimesu(I2, I2) +
+                             lam * tmech::otimes(I2, I2));
+
+  auto C_data = std::make_shared<tensor_data<double, 3, 4>>();
+  C_data->data() = C_tmech;
+  ev.set(C, std::static_pointer_cast<tensor_data_base<double>>(C_data));
+
+  auto result = ev.apply(inv(C));
+  ASSERT_NE(result, nullptr);
+  // Expected: tmech::inv (minor-symmetric default convention).
+  auto expected = tmech::eval(tmech::inv(C_tmech));
+  EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 4>(*result), expected, 1e-10));
+}
+
+TEST(TensorEval, EvalInverseRank4UnannotatedRoutesToInvf) {
+  // No annotation → tmech::invf (fully anisotropic). Same numerical
+  // tensor as above, but without the assume_minor_major call. The two
+  // results should differ in general (different conventions), so the
+  // assertion is "matches tmech::invf, NOT tmech::inv".
+  tensor_evaluator<double> ev;
+  auto C = make_expression<tensor>("C", 3, 4);
+  // NO annotation — the evaluator must route to invf.
+
+  tmech::tensor<double, 3, 2> I2;
+  for (std::size_t i = 0; i < 3; ++i)
+    for (std::size_t j = 0; j < 3; ++j)
+      I2(i, j) = (i == j) ? 1.0 : 0.0;
+  double const mu = 1.0, lam = 2.0;
+  auto C_tmech = tmech::eval(2.0 * mu * tmech::otimesu(I2, I2) +
+                             lam * tmech::otimes(I2, I2));
+
+  auto C_data = std::make_shared<tensor_data<double, 3, 4>>();
+  C_data->data() = C_tmech;
+  ev.set(C, std::static_pointer_cast<tensor_data_base<double>>(C_data));
+
+  auto result = ev.apply(inv(C));
+  ASSERT_NE(result, nullptr);
+  // Expected: tmech::invf (fully anisotropic).
+  auto expected_invf = tmech::eval(tmech::invf(C_tmech));
+  EXPECT_TRUE(
+      tmech::almost_equal(as_tmech<3, 4>(*result), expected_invf, 1e-10))
+      << "unannotated rank-4 inv must route to tmech::invf";
+}
+
+TEST(TensorEval, Rank4InvDispatchDiffersByAnnotation) {
+  // Cross-check: for the SAME numerical input, the annotated and
+  // unannotated paths give different results (different conventions).
+  // This is the strongest evidence that the dispatch is wired correctly
+  // and not silently collapsing to one routine.
+  tmech::tensor<double, 3, 2> I2;
+  for (std::size_t i = 0; i < 3; ++i)
+    for (std::size_t j = 0; j < 3; ++j)
+      I2(i, j) = (i == j) ? 1.0 : 0.0;
+  // Pick a tensor that's NOT minor-symmetric so the two inverses
+  // genuinely disagree (a fully symmetric tensor would give the same
+  // result either way and the test wouldn't be discriminating).
+  // An outer product I2 ⊗ I2 is symmetric, so use a non-trivial mix.
+  auto C_tmech =
+      tmech::eval(2.0 * tmech::otimes(I2, I2) + 1.0 * tmech::otimesu(I2, I2));
+
+  auto inv_data = tmech::eval(tmech::inv(C_tmech));
+  auto invf_data = tmech::eval(tmech::invf(C_tmech));
+  // Sanity: confirm the test premise — the two tmech routines disagree
+  // on this input.
+  EXPECT_FALSE(tmech::almost_equal(inv_data, invf_data, 1e-10))
+      << "Test setup assumes tmech::inv != tmech::invf on this input";
+
+  auto C_data = std::make_shared<tensor_data<double, 3, 4>>();
+  C_data->data() = C_tmech;
+
+  // Annotated path.
+  {
+    tensor_evaluator<double> ev;
+    auto C = make_expression<tensor>("C", 3, 4);
+    assume_minor_major(C);
+    ev.set(C, std::static_pointer_cast<tensor_data_base<double>>(C_data));
+    auto result = ev.apply(inv(C));
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 4>(*result), inv_data, 1e-10));
+  }
+  // Unannotated path.
+  {
+    tensor_evaluator<double> ev;
+    auto C = make_expression<tensor>("C", 3, 4);
+    ev.set(C, std::static_pointer_cast<tensor_data_base<double>>(C_data));
+    auto result = ev.apply(inv(C));
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(tmech::almost_equal(as_tmech<3, 4>(*result), invf_data, 1e-10));
+  }
+}
+
 // --- Compound expression tests ---
 //
 // tmech binary operators (+, -, scalar*) are not found via ADL inside

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -759,6 +759,35 @@ TYPED_TEST(TensorExpressionTest, InvRank4InvInvCollapsesAtAnyRank) {
   EXPECT_EQ(r, A);
 }
 
+TYPED_TEST(TensorExpressionTest, InvRank4ScalarPullOutPreserved) {
+  // inv(α·A) = inv(A) / α — the existing #71 fold runs at any rank
+  // (placed after the rank gate, before tensor_inv construction). For
+  // rank-4 the recursion calls inv() on the unwrapped tensor, which
+  // routes through the new rank-4 path — exercises that the existing
+  // fold composes with the rank-4 dispatch.
+  auto &A = this->A;
+  numsim::cas::assume_minor_major(A);
+  auto two = numsim::cas::make_scalar_constant(2);
+  auto r = numsim::cas::inv(two * A);
+  // Expected structural form: a t2s-scalar-mul wrapping inv(A) by the
+  // reciprocal scalar. Don't assert exact node type — the existing
+  // tensor_with_scalar simplifier may pack it as a tensor_scalar_mul.
+  // What we DO assert: the result is well-formed and rank-4.
+  EXPECT_EQ(r.get().rank(), 4u);
+  EXPECT_EQ(r.get().dim(), TestFixture::Dim);
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4SkewAnnotationStillBuilds) {
+  // Skew rank-4 (rare but legal under the existing annotation surface):
+  // the dispatch sends anything other than Minor/MinorMajor to invf.
+  // Construction-time sanity — just verify the node builds.
+  auto &A = this->A;
+  numsim::cas::assume_skew(A);
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::tensor_inv>(r));
+  EXPECT_EQ(r.get().rank(), 4u);
+}
+
 TYPED_TEST(TensorExpressionTest, InvRank3SymbolStillThrows) {
   // Odd ranks (3, 5, ...) have no canonical inverse routine in tmech;
   // they still get rejected at construction.

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -720,14 +720,53 @@ TYPED_TEST(TensorExpressionTest, InvZeroFromScalarMulThrows) {
       numsim::cas::invalid_expression_error);
 }
 
-TYPED_TEST(TensorExpressionTest, InvRank4SymbolThrows) {
-  // #192: rank > 2 inversion has no canonical definition (the rank-4
-  // minor identity is an explicit special case handled separately).
-  // Reject rank-4 (and higher) symbols at construction.
+TYPED_TEST(TensorExpressionTest, InvRank4SymbolBuilds) {
+  // #248: rank-4 inversion is now supported. The factory accepts any
+  // annotation (or none) at rank-4; the evaluator picks the correct
+  // tmech routine — tmech::inv (minor-symmetric) for Minor/MinorMajor,
+  // tmech::invf (fully anisotropic) otherwise. Construction-time guards
+  // here verify only that the AST node is well-formed.
   auto &A = this->A; // rank-4 fixture variable
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::tensor_inv>(r));
+  EXPECT_EQ(r.get().rank(), 4u);
+  EXPECT_EQ(r.get().dim(), TestFixture::Dim);
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4WithMinorAnnotation) {
+  // Annotated rank-4 also builds (evaluator will route to tmech::inv).
+  auto &A = this->A;
+  numsim::cas::assume_minor(A);
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::tensor_inv>(r));
+  // Space annotation propagates through inv (existing behavior).
+  EXPECT_TRUE(numsim::cas::is_minor(r));
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4WithMinorMajorAnnotation) {
+  auto &A = this->A;
+  numsim::cas::assume_minor_major(A);
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_same<numsim::cas::tensor_inv>(r));
+  EXPECT_TRUE(numsim::cas::is_minor_major(r));
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4InvInvCollapsesAtAnyRank) {
+  // inv(inv(A)) → A — the existing fold runs before the rank gate, so
+  // it works for rank-4 too.
+  auto &A = this->A;
+  auto r = numsim::cas::inv(numsim::cas::inv(A));
+  EXPECT_EQ(r, A);
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank3SymbolStillThrows) {
+  // Odd ranks (3, 5, ...) have no canonical inverse routine in tmech;
+  // they still get rejected at construction.
+  auto A3 = numsim::cas::make_expression<numsim::cas::tensor>(
+      "A3", static_cast<std::size_t>(TestFixture::Dim), std::size_t{3});
   try {
-    [[maybe_unused]] auto r = numsim::cas::inv(A);
-    FAIL() << "Expected inv(rank-4 symbol) to throw";
+    [[maybe_unused]] auto r = numsim::cas::inv(A3);
+    FAIL() << "Expected inv(rank-3 symbol) to throw";
   } catch (numsim::cas::invalid_expression_error const &e) {
     EXPECT_NE(std::string(e.what()).find("rank"), std::string::npos)
         << "error message should mention rank; got: " << e.what();

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -788,6 +788,40 @@ TYPED_TEST(TensorExpressionTest, InvRank4SkewAnnotationStillBuilds) {
   EXPECT_EQ(r.get().rank(), 4u);
 }
 
+TYPED_TEST(TensorExpressionTest, InvRank4SkewLosesAnnotation) {
+  // Annotation propagation through tensor_inv at rank-4: Skew does NOT
+  // survive (tmech::invf doesn't preserve skew structure at rank-4 —
+  // the 9x9 unfolding's inverse has different algebraic content). The
+  // result's space should be cleared rather than incorrectly preserving
+  // Skew, which would mislead downstream simplifiers.
+  auto &A = this->A;
+  numsim::cas::assume_skew(A);
+  ASSERT_TRUE(numsim::cas::is_skew(A));
+  auto r = numsim::cas::inv(A);
+  EXPECT_FALSE(numsim::cas::is_skew(r))
+      << "inv of rank-4 skew should NOT inherit the Skew annotation";
+  EXPECT_FALSE(r.get().space().has_value())
+      << "result should have no space annotation (general anisotropic)";
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4MinorPreservesAnnotation) {
+  // Annotation propagation at rank-4 + Minor: tmech::inv (Voigt path)
+  // preserves the minor symmetry, so the result IS still Minor.
+  auto &A = this->A;
+  numsim::cas::assume_minor(A);
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_minor(r));
+}
+
+TYPED_TEST(TensorExpressionTest, InvRank4MinorMajorPreservesAnnotation) {
+  // Same for MinorMajor — both symmetries are preserved through the
+  // Voigt inverse.
+  auto &A = this->A;
+  numsim::cas::assume_minor_major(A);
+  auto r = numsim::cas::inv(A);
+  EXPECT_TRUE(numsim::cas::is_minor_major(r));
+}
+
 TYPED_TEST(TensorExpressionTest, InvRank3SymbolStillThrows) {
   // Odd ranks (3, 5, ...) have no canonical inverse routine in tmech;
   // they still get rejected at construction.


### PR DESCRIPTION
Closes #248.

## Summary
Relaxes the rank-2-only gate in `inv()` (#192) to support rank-4 with structural dispatch driven by the operand's existing tensor_space annotation. No new accessor on `tensor_inv` — the convention is already encoded in the Minor/MinorMajor tags from the existing annotation surface.

## Dispatch table

| Rank | Annotation | tmech routine |
|---|---|---|
| 2 | any | `tmech::inv` (rank-2 closed form) |
| 4 | Minor or MinorMajor | `tmech::inv<sequence<1,2>, sequence<3,4>>` (minor-sym, the algorithmic-tangent case) |
| 4 | anything else / none | `tmech::invf` (fully anisotropic) |
| 3, 5, ... | n/a | rejected at construction (no tmech routine) |

The two rank-4 paths apply to disjoint input classes — a minor-symmetric tensor's 9x9 unfolding has rank <= 6 (so `invf` is degenerate), and a fully-anisotropic tensor lacks the Voigt symmetry `inv` requires. The annotation gating makes the user's mathematical choice explicit.

## Tests

Construction (TensorExpressionTest.h):
- Replaces the old `InvRank4SymbolThrows` (#192 lock-in for the policy this PR supersedes).
- `InvRank4SymbolBuilds`, `InvRank4WithMinorAnnotation`, `InvRank4WithMinorMajorAnnotation`, `InvRank4InvInvCollapsesAtAnyRank`, `InvRank3SymbolStillThrows`.

Evaluator (TensorEvaluatorTest.h):
- `EvalInverseRank4MinorMajor` — annotated rank-4, result matches `tmech::inv(C)` componentwise.
- `EvalInverseRank4UnannotatedRoutesToInvf` — same numeric input, no annotation; result matches `tmech::invf(C)`.
- `Rank4InvDispatchDiffersByAnnotation` — strongest correctness check: same input through both annotation paths produces different (routine-specific) results, confirming the dispatch is genuinely routing rather than silently collapsing.

Suite: **1180/1180 pass** (was 1165 + new tests, minus the old throws-lock-in).

## tmech version note

Rank-4 inv requires tmech with the post-Sep-2025 `inverse_wrapper` rewrite (master). Pre-rewrite installs (e.g. older `/usr/local/include/tmech`) produce NaN through the Voigt-rank-4 path because the inner LU is unpivoted and the older code had a bug in the conversion routine — verified by direct reproduction. The current `CMakeLists.txt` uses `find_package(tmech QUIET)` and falls back to `FetchContent` (master) if not found.

If CI or local builds have a stale system tmech, build with:

```
cmake -B build -DCMAKE_DISABLE_FIND_PACKAGE_tmech=TRUE ...
```

This forces the FetchContent path. The current PR doesn't change CMakeLists.txt — if maintainers prefer pinning to a known-good tmech tag instead of `master`, that's a small follow-up.

## Out of scope
- New `inv_contraction_pair()` accessor on `tensor_inv` (the design comment on the issue suggested this but it's not needed — the existing space annotation IS the convention).
- Algebra-rule folds (`inv(orthogonal) -> trans(orthogonal)`, etc.) — those belong to #246.
- Construction-time rank-4 singularity detection beyond the existing `tensor_zero` check.

## Related
- Supersedes #192's rank-2-only policy.
- numsim-codegen #43 (downstream tracking) can close — the algorithmic-tangent pass now has a CAS-level `inv()` that handles rank-4.
- Cross-ref #246 — when algebra-rule propagation lands, `inv(PD)` → PD will propagate the annotation through.
