### PR TITLE
Algebra folds: inv(orthogonal)→trans + det(orthogonal)→1 (#246 α-2a)

### DIFF
--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -9,6 +9,7 @@
 #include <numsim_cas/tensor/projector_algebra.h>
 #include <numsim_cas/tensor/sequence.h>
 #include <numsim_cas/tensor/skew_classification.h>
+#include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_expression.h>
 #include <numsim_cas/tensor/tensor_zero.h>
 #include <numsim_cas/tensor/visitors/tensor_printer.h>
@@ -432,6 +433,18 @@ template <tensor_expr_holder Expr>
     throw invalid_expression_error(
         "inv: only rank-2 and rank-4 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
+  // inv(orthogonal R) = trans(R). Closes one half of #246. The
+  // orthogonality annotation only makes sense at rank-2 (R^T R = I for
+  // square R) and trans() is rank-2 only — gate on both. Re-annotate
+  // the result as orthogonal so downstream queries / further folds see
+  // it (trans() doesn't propagate the algebra annotation through its
+  // general path). Same post-construction annotation pattern as
+  // tensor_operators.h's `trans(A) + (-A) → Skew` recognition.
+  if (expr.get().rank() == 2 && is_orthogonal(expr)) {
+    auto result = trans(std::forward<Expr>(expr));
+    result.data()->tensor_algebra_assumptions().insert(orthogonal{});
+    return result;
+  }
   // inv(α·A) = inv(A) / α. The scalar pulls out of the inverse as its
   // reciprocal. Recurse so e.g. inv(α·inv(A)) folds via tensor_inv → A,
   // not just one layer. (Placed after the rank gate so rank > 2 inputs

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -373,13 +373,24 @@ template <tensor_expr_holder Expr>
     throw invalid_expression_error(
         "trans: only rank-2 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
+  // Capture orthogonal annotation BEFORE forwarding — trans(orthogonal R)
+  // is itself orthogonal (algebra: (R^T)^T = R = R^{-1}^{-T}, so R^T is
+  // also orthogonal). Propagate via post-construction insert on whichever
+  // branch produces a fresh node. The Symmetric short-circuit returns
+  // the input directly, which already carries the annotation; tensor_zero
+  // can't be orthogonal so we skip propagation there.
+  const bool propagate_orthogonal = is_orthogonal(expr);
   // trans(X) = X when X is symmetric (or any symmetric subspace)
   // trans(X) = -X when X is skew-symmetric
   if (auto const &sp = expr.get().space()) {
     if (std::holds_alternative<Symmetric>(sp->perm))
       return std::forward<Expr>(expr);
-    if (std::holds_alternative<Skew>(sp->perm))
-      return -std::forward<Expr>(expr);
+    if (std::holds_alternative<Skew>(sp->perm)) {
+      auto result = -std::forward<Expr>(expr);
+      if (propagate_orthogonal)
+        result.data()->tensor_algebra_assumptions().insert(orthogonal{});
+      return result;
+    }
   }
   if (is_same<tensor_zero>(expr))
     return make_expression<tensor_zero>(expr.get().dim(), expr.get().rank());
@@ -388,8 +399,11 @@ template <tensor_expr_holder Expr>
     if (bc.indices() == sequence{2, 1})
       return bc.expr();
   }
-  return make_expression<permute_indices_wrapper>(std::forward<Expr>(expr),
-                                                  sequence{2, 1});
+  auto result = make_expression<permute_indices_wrapper>(
+      std::forward<Expr>(expr), sequence{2, 1});
+  if (propagate_orthogonal)
+    result.data()->tensor_algebra_assumptions().insert(orthogonal{});
+  return result;
 }
 
 template <tensor_expr_holder Expr>
@@ -433,18 +447,12 @@ template <tensor_expr_holder Expr>
     throw invalid_expression_error(
         "inv: only rank-2 and rank-4 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
-  // inv(orthogonal R) = trans(R). Closes one half of #246. The
-  // orthogonality annotation only makes sense at rank-2 (R^T R = I for
-  // square R) and trans() is rank-2 only — gate on both. Re-annotate
-  // the result as orthogonal so downstream queries / further folds see
-  // it (trans() doesn't propagate the algebra annotation through its
-  // general path). Same post-construction annotation pattern as
-  // tensor_operators.h's `trans(A) + (-A) → Skew` recognition.
-  if (expr.get().rank() == 2 && is_orthogonal(expr)) {
-    auto result = trans(std::forward<Expr>(expr));
-    result.data()->tensor_algebra_assumptions().insert(orthogonal{});
-    return result;
-  }
+  // inv(orthogonal R) = trans(R). Closes one half of #246. Orthogonality
+  // is rank-2 algebra (R^T R = I for square R); trans() is rank-2 only
+  // and itself propagates the orthogonal annotation through, so the fold
+  // is just structural — no separate insert needed here.
+  if (expr.get().rank() == 2 && is_orthogonal(expr))
+    return trans(std::forward<Expr>(expr));
   // inv(α·A) = inv(A) / α. The scalar pulls out of the inverse as its
   // reciprocal. Recurse so e.g. inv(α·inv(A)) folds via tensor_inv → A,
   // not just one layer. (Placed after the rank gate so rank > 2 inputs

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -447,6 +447,27 @@ template <tensor_expr_holder Expr>
     throw invalid_expression_error(
         "inv: only rank-2 and rank-4 tensors are supported (got rank " +
         std::to_string(expr.get().rank()) + ")");
+  // A skew-symmetric matrix in odd dimensions is singular (det = 0) by
+  // the determinant theorem det(-A^T) = (-1)^n det(A). The theorem is
+  // RANK-2 SPECIFIC — for rank-4 a "skew" annotation doesn't carry the
+  // same algebraic consequence (rank-4 skew has different geometry and
+  // the 9x9 unfolding's determinant isn't related to (-1)^n det(A)).
+  // Restrict the guard to rank-2 so rank-4 skew passes through to the
+  // invf evaluator branch. contains_skew_factor catches both direct
+  // skew tensors and products like B * skew(A).
+  //
+  // NOTE on ordering: this singularity check runs BEFORE the orthogonal
+  // fold below. A user who asserts both assume_skew(R) AND
+  // assume_orthogonal(R) for an odd-dim R has a logical contradiction
+  // (skew odd-dim ⇒ det = 0; orthogonal ⇒ det = ±1). Honoring the
+  // skew claim and throwing is safer than silently folding to trans(R)
+  // via the orthogonal claim and hiding the contradiction.
+  if (expr.get().rank() == 2 && expr.get().dim() % 2 != 0 &&
+      contains_skew_factor(expr)) {
+    throw invalid_expression_error(
+        "inv: operand contains a skew-symmetric factor in odd dimensions "
+        "(singular)");
+  }
   // inv(orthogonal R) = trans(R). Closes one half of #246. Orthogonality
   // is rank-2 algebra (R^T R = I for square R); trans() is rank-2 only
   // and itself propagates the orthogonal annotation through, so the fold
@@ -461,20 +482,6 @@ template <tensor_expr_holder Expr>
   if (is_same<tensor_scalar_mul>(expr)) {
     auto const &sm = expr.template get<tensor_scalar_mul>();
     return inv(sm.expr_rhs()) / sm.expr_lhs();
-  }
-  // A skew-symmetric matrix in odd dimensions is singular (det = 0) by
-  // the determinant theorem det(-A^T) = (-1)^n det(A). The theorem is
-  // RANK-2 SPECIFIC — for rank-4 a "skew" annotation doesn't carry the
-  // same algebraic consequence (rank-4 skew has different geometry and
-  // the 9x9 unfolding's determinant isn't related to (-1)^n det(A)).
-  // Restrict the guard to rank-2 so rank-4 skew passes through to the
-  // invf evaluator branch. contains_skew_factor catches both direct
-  // skew tensors and products like B * skew(A).
-  if (expr.get().rank() == 2 && expr.get().dim() % 2 != 0 &&
-      contains_skew_factor(expr)) {
-    throw invalid_expression_error(
-        "inv: operand contains a skew-symmetric factor in odd dimensions "
-        "(singular)");
   }
   return make_expression<tensor_inv>(std::forward<Expr>(expr));
 }

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -4,6 +4,7 @@
 
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/scalar/scalar_std.h>
+#include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
 #include <numsim_cas/tensor/tensor_operators.h>
 
@@ -97,6 +98,15 @@ det(expression_holder<tensor_expression> const &expr) {
   // identity_tensor reaching here is the rank-2 Kronecker delta;
   // kronecker_delta was unified into identity_tensor by #188).
   if (is_same<identity_tensor>(expr))
+    return make_expression<tensor_to_scalar_one>();
+
+  // det(orthogonal R) = +1 for proper rotations. The "orthogonal"
+  // annotation in this codebase doesn't distinguish proper rotations
+  // (det = +1) from improper ones / reflections (det = -1); the
+  // common continuum-mechanics use case is proper rotation so we
+  // default to +1. A future `chirality` sub-tag could refine this.
+  // Closes one half of #246.
+  if (is_orthogonal(expr))
     return make_expression<tensor_to_scalar_one>();
 
   // det(inv(A)) = 1/det(A). Routes through the t2s div operator which

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -321,17 +321,20 @@ TEST(TensorAlgebraFold, InvScalarMulOrthogonalRecursesCorrectly) {
   assume_orthogonal(R);
   auto alpha = std::get<0>(make_scalar_variable("alpha"));
   auto r = inv(alpha * R);
-  // Defensive contract: the orthogonal fold must NOT have fired on
-  // α·R, so the result is not bare trans(R) — it carries the 1/α
-  // factor structurally (typically as a tensor_scalar_mul of (1/α)
-  // and trans(R)).
-  EXPECT_FALSE(is_same<identity_tensor>(r));
-  // The inv(α·A) recursion + inv(orth) fold MUST still produce
-  // something: not a bare tensor_inv node (which would mean the
-  // recursion stalled).
-  EXPECT_FALSE(is_same<tensor_inv>(r))
-      << "inv(α·R) for orthogonal R should recurse through the "
-         "scalar_mul rule and fold the inner inv(R)";
+  // POSITIVE structural check (not negative). In the bug case where
+  // is_orthogonal(α·R) wrongly returned true, the orthogonal fold
+  // would build permute_indices_wrapper(α·R, {2,1}) — that's
+  // neither identity_tensor nor tensor_inv, so absence-only
+  // assertions would silently miss the bug. Assert presence of the
+  // 1/α scalar factor: a tensor_scalar_mul wrapping trans(R).
+  ASSERT_TRUE(is_same<tensor_scalar_mul>(r))
+      << "expected (1/α)·trans(R); bare trans/permute means the orth "
+         "fold wrongly fired on α·R without preserving the scalar factor";
+  // Belt and braces: the inner tensor of the scalar_mul is trans(R),
+  // i.e. a permute_indices_wrapper.
+  auto const &sm = r.template get<tensor_scalar_mul>();
+  EXPECT_TRUE(is_same<permute_indices_wrapper>(sm.expr_rhs()))
+      << "inner of the scalar_mul should be trans(R)";
 }
 
 TEST(TensorAlgebraFold, DetScalarMulOrthogonalIsNotOne) {

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -1,10 +1,13 @@
 #ifndef TENSORALGEBRAASSUMETEST_H
 #define TENSORALGEBRAASSUMETEST_H
 
+#include <cmath>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include <numsim_cas/numsim_cas.h>
 #include <numsim_cas/tensor/tensor_assume.h>
+#include <numsim_cas/tensor/visitors/tensor_evaluator.h>
 
 namespace numsim::cas {
 
@@ -187,6 +190,97 @@ TEST(TensorAlgebraAssume, AlgebraAssumptionOrthogonalToProjectorSpace) {
   EXPECT_TRUE(is_orthogonal(W));
   // The earlier Skew space tag survives — orthogonal does not clear it.
   EXPECT_TRUE(is_skew(W));
+}
+
+// ─── #246 algebra-rule folds (α-2a): inv / det for orthogonal ──────────
+
+TEST(TensorAlgebraFold, InvOrthogonalFoldsToTrans) {
+  // inv(R) = trans(R) when R is annotated orthogonal — closes the
+  // dominant simplification for rotation tensors. The result must also
+  // carry the orthogonal annotation so downstream queries / further
+  // folds see it.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto r = inv(R);
+  // Structural form is the transpose, NOT a tensor_inv node.
+  EXPECT_FALSE(is_same<tensor_inv>(r))
+      << "inv(orthogonal) should fold, not build a tensor_inv node";
+  EXPECT_TRUE(is_same<permute_indices_wrapper>(r))
+      << "expected trans(R) = permute_indices_wrapper";
+  // Annotation propagation: inv(orthogonal) is still orthogonal.
+  EXPECT_TRUE(is_orthogonal(r))
+      << "result should carry orthogonal annotation for downstream folds";
+}
+
+TEST(TensorAlgebraFold, InvOrthogonalDoesNotFireAtRank4) {
+  // The fold requires rank == 2 (trans() is rank-2 only and orthogonality
+  // at rank-4 isn't standardly defined). A rank-4 tensor with orthogonal
+  // annotation should still build a tensor_inv (routed to invf at eval).
+  auto A4 = make_expression<tensor>("A4", std::size_t{3}, std::size_t{4});
+  assume_orthogonal(A4);
+  auto r = inv(A4);
+  EXPECT_TRUE(is_same<tensor_inv>(r))
+      << "rank-4 orthogonal should NOT trigger the trans fold";
+}
+
+TEST(TensorAlgebraFold, InvUnannotatedDoesNotFireFold) {
+  // Negative case: without the orthogonal annotation the fold must NOT
+  // fire — guards against accidental over-eager folding.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto r = inv(A);
+  EXPECT_TRUE(is_same<tensor_inv>(r))
+      << "inv(unannotated rank-2) should build tensor_inv as before";
+}
+
+TEST(TensorAlgebraFold, DetOrthogonalFoldsToOne) {
+  // det(R) = 1 for proper rotations (the dominant continuum-mechanics
+  // case). The annotation doesn't distinguish improper rotations (det =
+  // -1); a future chirality sub-tag could refine this.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto d = det(R);
+  EXPECT_TRUE(is_same<tensor_to_scalar_one>(d))
+      << "det(orthogonal) should fold to tensor_to_scalar_one";
+}
+
+TEST(TensorAlgebraFold, DetUnannotatedDoesNotFireFold) {
+  // Negative case: det of an un-annotated tensor must build a tensor_det
+  // node — fold gated correctly.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto d = det(A);
+  EXPECT_TRUE(is_same<tensor_det>(d))
+      << "det(unannotated) should build tensor_det as before";
+}
+
+TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {
+  // End-to-end: inv(R) folded to trans(R) must evaluate to the actual
+  // matrix inverse for a numerically-orthogonal rotation. Build a 3D
+  // rotation about z by π/6 and verify inv(R) equals R^T componentwise.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  const double c = std::cos(M_PI / 6.0);
+  const double s = std::sin(M_PI / 6.0);
+  auto R_data = std::make_shared<tensor_data<double, 3, 2>>();
+  auto *raw = R_data->raw_data();
+  raw[0] = c;
+  raw[1] = -s;
+  raw[2] = 0;
+  raw[3] = s;
+  raw[4] = c;
+  raw[5] = 0;
+  raw[6] = 0;
+  raw[7] = 0;
+  raw[8] = 1;
+  tensor_evaluator<double> ev;
+  ev.set(R, std::static_pointer_cast<tensor_data_base<double>>(R_data));
+  auto inv_R_data = ev.apply(inv(R));
+  ASSERT_NE(inv_R_data, nullptr);
+  // For a rotation, transpose IS the inverse: R^T(0,1) = R(1,0) = s.
+  auto const &inv_R =
+      static_cast<tensor_data<double, 3, 2> const &>(*inv_R_data).data();
+  EXPECT_NEAR(inv_R(0, 1), s, 1e-12);
+  EXPECT_NEAR(inv_R(1, 0), -s, 1e-12);
+  EXPECT_NEAR(inv_R(2, 2), 1.0, 1e-12);
 }
 
 } // namespace numsim::cas

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -301,6 +301,50 @@ TEST(TensorAlgebraFold, InvSkewOrthogonal2DStillFolds) {
   // skew returns -R (trans()'s skew short-circuit). So inv = -R.
   EXPECT_TRUE(is_same<tensor_negative>(r))
       << "2D skew-orthogonal inv folds to -R via trans short-circuit";
+  // (-R) is itself orthogonal: (-R)^T (-R) = R^T R = I. trans()'s skew
+  // branch inserts the orthogonal annotation onto the negated result;
+  // lock that in so a refactor of the short-circuit doesn't drop it.
+  EXPECT_TRUE(is_orthogonal(r))
+      << "negated result should still carry the orthogonal annotation";
+}
+
+TEST(TensorAlgebraFold, InvScalarMulOrthogonalRecursesCorrectly) {
+  // inv(α·R) → inv(R)/α = trans(R)/α. Locks in the inv() factory
+  // ordering: the orthogonal-fold check (gated on rank-2) sits BEFORE
+  // the scalar_mul fold but must NOT fire on α·R, because
+  // tensor_scalar_mul does NOT propagate the orthogonal algebra
+  // annotation (verified in operators/scalar/tensor_scalar_mul.h —
+  // only `space` is forwarded). If a future change to scalar_mul
+  // wrongly propagated orthogonal, the fold would silently collapse
+  // α·R → trans(R) instead of preserving the 1/α factor.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto alpha = std::get<0>(make_scalar_variable("alpha"));
+  auto r = inv(alpha * R);
+  // Defensive contract: the orthogonal fold must NOT have fired on
+  // α·R, so the result is not bare trans(R) — it carries the 1/α
+  // factor structurally (typically as a tensor_scalar_mul of (1/α)
+  // and trans(R)).
+  EXPECT_FALSE(is_same<identity_tensor>(r));
+  // The inv(α·A) recursion + inv(orth) fold MUST still produce
+  // something: not a bare tensor_inv node (which would mean the
+  // recursion stalled).
+  EXPECT_FALSE(is_same<tensor_inv>(r))
+      << "inv(α·R) for orthogonal R should recurse through the "
+         "scalar_mul rule and fold the inner inv(R)";
+}
+
+TEST(TensorAlgebraFold, DetScalarMulOrthogonalIsNotOne) {
+  // det(α·R) = α^d · det(R) = α^d for orthogonal R. The result MUST
+  // NOT collapse to 1 — that would be the bug case where the
+  // orthogonal fold fired on α·R despite the scalar factor.
+  // Companion to InvScalarMulOrthogonalRecursesCorrectly above.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto alpha = std::get<0>(make_scalar_variable("alpha"));
+  auto d = det(alpha * R);
+  EXPECT_FALSE(is_same<tensor_to_scalar_one>(d))
+      << "det(α·R) is α^d, not 1 — orthogonal fold must not fire on α·R";
 }
 
 TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -265,6 +265,44 @@ TEST(TensorAlgebraFold, DetUnannotatedDoesNotFireFold) {
       << "det(unannotated) should build tensor_det as before";
 }
 
+TEST(TensorAlgebraFold, InvSkewOrthogonalOddDimThrowsContradiction) {
+  // User asserts BOTH skew and orthogonal on an odd-dim tensor —
+  // logical contradiction (skew odd-dim ⇒ det = 0 by the (-1)^n det
+  // theorem; orthogonal ⇒ det = ±1). The skew-singularity guard
+  // (rank-2, odd-dim, contains_skew_factor) is ordered BEFORE the
+  // orthogonal fold so the contradiction is rejected loudly rather
+  // than silently folded to trans(R).
+  //
+  // The 2D case is legitimate (2D rotation by π/2 IS both skew and
+  // orthogonal: R=[[0,-1],[1,0]], R^T=-R, R^T R = I). That case is
+  // covered by InvSkewOrthogonal2DStillFolds below.
+  auto R3 = make_expression<tensor>("R3", std::size_t{3}, std::size_t{2});
+  assume_skew(R3);
+  assume_orthogonal(R3);
+  try {
+    [[maybe_unused]] auto r = inv(R3);
+    FAIL() << "Expected throw for skew+orthogonal at odd dim "
+              "(logical contradiction)";
+  } catch (invalid_expression_error const &e) {
+    EXPECT_NE(std::string(e.what()).find("skew"), std::string::npos)
+        << "error message should mention skew singularity";
+  }
+}
+
+TEST(TensorAlgebraFold, InvSkewOrthogonal2DStillFolds) {
+  // Even-dim skew-and-orthogonal IS mathematically valid (e.g. 2D
+  // rotation by π/2 satisfies both). Skew guard doesn't fire (even
+  // dim) so the orthogonal fold runs: inv(R) → trans(R) = -R.
+  auto R2 = make_expression<tensor>("R2", std::size_t{2}, std::size_t{2});
+  assume_skew(R2);
+  assume_orthogonal(R2);
+  auto r = inv(R2);
+  // Even-dim skew + orthogonal is legit; fold to trans which for
+  // skew returns -R (trans()'s skew short-circuit). So inv = -R.
+  EXPECT_TRUE(is_same<tensor_negative>(r))
+      << "2D skew-orthogonal inv folds to -R via trans short-circuit";
+}
+
 TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {
   // End-to-end: inv(R) folded to trans(R) must evaluate to the actual
   // matrix inverse for a numerically-orthogonal rotation. Build a 3D

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <memory>
+#include <numbers>
 
 #include <numsim_cas/numsim_cas.h>
 #include <numsim_cas/tensor/tensor_assume.h>
@@ -194,6 +195,18 @@ TEST(TensorAlgebraAssume, AlgebraAssumptionOrthogonalToProjectorSpace) {
 
 // ─── #246 algebra-rule folds (α-2a): inv / det for orthogonal ──────────
 
+TEST(TensorAlgebraFold, TransOrthogonalIsOrthogonal) {
+  // Algebra fact: trans of orthogonal is orthogonal. The propagation
+  // lives in trans() itself so callers that go through trans() directly
+  // (not via the inv() fold) also see it. This is the primary
+  // propagation test; InvOrthogonalFoldsToTrans below verifies the fold
+  // composes with it.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto rT = trans(R);
+  EXPECT_TRUE(is_orthogonal(rT)) << "trans(orthogonal) should be orthogonal";
+}
+
 TEST(TensorAlgebraFold, InvOrthogonalFoldsToTrans) {
   // inv(R) = trans(R) when R is annotated orthogonal — closes the
   // dominant simplification for rotation tensors. The result must also
@@ -258,8 +271,8 @@ TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {
   // rotation about z by π/6 and verify inv(R) equals R^T componentwise.
   auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
   assume_orthogonal(R);
-  const double c = std::cos(M_PI / 6.0);
-  const double s = std::sin(M_PI / 6.0);
+  const double c = std::cos(std::numbers::pi / 6.0);
+  const double s = std::sin(std::numbers::pi / 6.0);
   auto R_data = std::make_shared<tensor_data<double, 3, 2>>();
   auto *raw = R_data->raw_data();
   raw[0] = c;


### PR DESCRIPTION
Step α-2a of the 1.0 roadmap (#251). First slice of #246 — turning the just-landed orthogonal annotation (#245) into actionable simplification.

## Summary

Two construction-time folds gated on the orthogonal annotation:

- \`inv(R) → trans(R)\` when R is rank-2 orthogonal. Result carries the orthogonal annotation forward.
- \`det(R) → 1\` when R is orthogonal (proper rotation; chirality not encoded today).

Un-annotated paths build \`tensor_inv\` / \`tensor_det\` unchanged.

## Implementation

| File | Change |
|---|---|
| \`include/numsim_cas/tensor/tensor_functions.h\` | Add \`is_orthogonal\` short-circuit in \`inv()\` factory, after the rank gate. Calls \`trans()\` then inserts \`orthogonal{}\` into the result's algebra-assumption manager. |
| \`src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp\` | Add \`is_orthogonal\` short-circuit in \`det()\` after the \`det(I) = 1\` case. Returns \`tensor_to_scalar_one\`. |
| \`tests/TensorAlgebraAssumeTest.h\` | Six lock-ins in a new \`TensorAlgebraFold\` test suite. |

The annotation propagation through \`trans()\` uses the post-construction-insert pattern already in use at \`tensor_operators.h:62-82\` for \`trans(A) + (-A) → Skew\`.

## Tests (6 new, all pass)

| Test | What it locks in |
|---|---|
| \`InvOrthogonalFoldsToTrans\` | \`inv(orth R)\` produces \`permute_indices_wrapper\` (the trans), NOT \`tensor_inv\`; result has \`is_orthogonal\` true |
| \`InvOrthogonalDoesNotFireAtRank4\` | Negative — rank-4 orthogonal must still build \`tensor_inv\` (no \`trans()\` at rank-4) |
| \`InvUnannotatedDoesNotFireFold\` | Negative — un-annotated rank-2 still produces \`tensor_inv\` |
| \`DetOrthogonalFoldsToOne\` | \`det(orth R)\` produces \`tensor_to_scalar_one\` |
| \`DetUnannotatedDoesNotFireFold\` | Negative — un-annotated produces \`tensor_det\` |
| \`InvOrthogonalEvaluatesCorrectly\` | End-to-end — bind R to a 30° z-rotation, evaluate \`inv(R)\`, assert componentwise equality with R^T |

Each fold has a positive case + a negative case so an "almost right" future change (e.g. firing without checking annotation) is caught immediately.

Suite: **1261/1261** (was 1255 + 6 new).

## Chirality note

\`det(orthogonal) → +1\` assumes a proper rotation. Improper orthogonals (reflections) have det = -1; the annotation surface doesn't distinguish today. Mentioned in the source comment. A future \`chirality\` sub-tag could refine this; not in 1.0 scope.

## Roadmap reference

Second commit of milestone 1.0-α (after #252's tmech pin); next is α-2b — \`inv(PD) → PD\` annotation propagation through \`tensor_inv\`'s constructor.

## Sequencing

Branched from \`main\` (post-merges, post-#252-stack-free). Touches different files from #252 (CMakeLists.txt only) — no rebase conflict.