### PR TITLE
Propagate PD/PSD annotations through tensor_inv (#246 α-2b)

### DIFF
--- a/include/numsim_cas/tensor/tensor_assume.h
+++ b/include/numsim_cas/tensor/tensor_assume.h
@@ -52,12 +52,23 @@ assume_minor_major(expression_holder<tensor_expression> const &expr) {
 // must be preserved.
 
 namespace detail {
-// PD/PSD => symmetric: set the space if not already a Sym subspace.
-// Incompatible spaces (Skew, Minor, Major, MinorMajor) get overwritten.
+// PD/PSD => symmetric: set the space if not already a recognised sym
+// subspace. Two families count as "sym-or-more-specific":
+//   - Rank-2 ProjKind::Sym / Vol / Dev (the existing case).
+//   - Rank-4 Minor / MinorMajor perms (added for #246 α-2b — PD on a
+//     rank-4 stiffness with minor-major symmetry is the canonical
+//     case in continuum-mechanics elasticity tangents; without this
+//     branch the helper would overwrite MinorMajor with rank-2 Sym
+//     and lose the rank-4 structural info).
+// Incompatible spaces (Skew, plain Major-only without Minor, etc.)
+// still get overwritten.
 inline void set_symmetric_unless_more_specific(tensor_expression *e) {
   if (auto const &sp = e->space()) {
     auto kind = classify_space(*sp);
     if (kind == ProjKind::Sym || kind == ProjKind::Vol || kind == ProjKind::Dev)
+      return;
+    if (std::holds_alternative<Minor>(sp->perm) ||
+        std::holds_alternative<MinorMajor>(sp->perm))
       return;
   }
   e->set_space({Symmetric{}, AnyTraceTag{}});

--- a/include/numsim_cas/tensor/tensor_assume.h
+++ b/include/numsim_cas/tensor/tensor_assume.h
@@ -61,7 +61,12 @@ namespace detail {
 //     branch the helper would overwrite MinorMajor with rank-2 Sym
 //     and lose the rank-4 structural info).
 // Incompatible spaces (Skew, plain Major-only without Minor, etc.)
-// still get overwritten.
+// still get overwritten — but ONLY at rank-2, since `Symmetric{}` is
+// a rank-2 perm. For rank-4 with no recognised space, the helper is
+// a no-op: writing a rank-2 Sym tag to a rank-4 tensor would be a
+// structural mismatch. The user can call assume_minor_major /
+// assume_major explicitly if they want a sym subspace on a rank-4
+// input; the PD/PSD algebra-manager implication still stands.
 inline void set_symmetric_unless_more_specific(tensor_expression *e) {
   if (auto const &sp = e->space()) {
     auto kind = classify_space(*sp);
@@ -71,6 +76,10 @@ inline void set_symmetric_unless_more_specific(tensor_expression *e) {
         std::holds_alternative<MinorMajor>(sp->perm))
       return;
   }
+  // Rank gate: only rank-2 gets the Symmetric{} write. Rank-4 with no
+  // qualifying space is left untouched — see the helper doc above.
+  if (e->rank() != 2)
+    return;
   e->set_space({Symmetric{}, AnyTraceTag{}});
 }
 } // namespace detail

--- a/include/numsim_cas/tensor/wrappers/tensor_inv.h
+++ b/include/numsim_cas/tensor/wrappers/tensor_inv.h
@@ -2,6 +2,7 @@
 #define TENSOR_INV_H
 
 #include <numsim_cas/core/unary_op.h>
+#include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_expression.h>
 namespace numsim::cas {
 
@@ -13,6 +14,7 @@ public:
   explicit tensor_inv(
       Expr &&_expr) // NOLINT(bugprone-forwarding-reference-overload)
       : base(std::forward<Expr>(_expr), _expr.get().dim(), _expr.get().rank()) {
+    // ── Space propagation (projector-space tag) ────────────────────
     if (auto const &sp = this->expr().get().space()) {
       const auto r = this->rank();
       if (r == 2) {
@@ -42,6 +44,37 @@ public:
       }
       // Other ranks: inv() factory rejects them; this branch
       // shouldn't be reached.
+    }
+
+    // ── Algebra-assumption propagation (#246 α-2b) ─────────────────
+    // inv(PD) is PD (positive-definite matrices stay PD under
+    // inversion — eigenvalues 1/λᵢ are all positive when λᵢ are).
+    // inv(PSD) propagates PSD: at runtime the eval throws if actually
+    // singular, so any reaching result has finite eigenvalues — but
+    // we can't tell PD-vs-PSD symbolically without more info, so stay
+    // conservative and propagate exactly what the user asserted.
+    //
+    // PD/PSD also imply symmetric. Reuse the existing detail helper
+    // to set {Symmetric, AnyTraceTag} on the space iff there's no
+    // strictly more specific Sym subspace (Vol / Dev) — same rule the
+    // assume_positive_definite factory uses.
+    //
+    // Orthogonal is NOT propagated here. At rank-2 the inv() factory
+    // folds inv(orthogonal) to trans() before reaching this ctor; at
+    // rank-4 "orthogonal" isn't a standard concept.
+    auto const &input_alg = this->expr().get().tensor_algebra_assumptions();
+    bool propagate_pd = input_alg.contains(positive_definite{});
+    bool propagate_psd = input_alg.contains(positive_semidefinite{});
+    if (propagate_pd || propagate_psd) {
+      auto &out = this->tensor_algebra_assumptions();
+      if (propagate_pd) {
+        out.insert(positive_definite{});
+        out.insert(
+            positive_semidefinite{}); // PD => PSD (matches #245 convention)
+      } else {
+        out.insert(positive_semidefinite{});
+      }
+      detail::set_symmetric_unless_more_specific(this);
     }
   }
 };

--- a/include/numsim_cas/tensor/wrappers/tensor_inv.h
+++ b/include/numsim_cas/tensor/wrappers/tensor_inv.h
@@ -49,31 +49,37 @@ public:
     // ── Algebra-assumption propagation (#246 α-2b) ─────────────────
     // inv(PD) is PD (positive-definite matrices stay PD under
     // inversion — eigenvalues 1/λᵢ are all positive when λᵢ are).
-    // inv(PSD) propagates PSD: at runtime the eval throws if actually
-    // singular, so any reaching result has finite eigenvalues — but
-    // we can't tell PD-vs-PSD symbolically without more info, so stay
-    // conservative and propagate exactly what the user asserted.
+    // inv(PSD) propagates PSD conservatively: a non-singular PSD is
+    // actually PD, but we can't tell singularity symbolically, so we
+    // propagate exactly what the user asserted; the runtime eval
+    // throws if actually singular.
     //
-    // PD/PSD also imply symmetric. Reuse the existing detail helper
-    // to set {Symmetric, AnyTraceTag} on the space iff there's no
-    // strictly more specific Sym subspace (Vol / Dev) — same rule the
-    // assume_positive_definite factory uses.
+    // PD/PSD also imply symmetric. Reuse the detail helper to set the
+    // Symmetric space iff no strictly more specific sym subspace
+    // (Vol/Dev at rank-2; Minor/MinorMajor at rank-4) is already set.
     //
-    // Orthogonal is NOT propagated here. At rank-2 the inv() factory
-    // folds inv(orthogonal) to trans() before reaching this ctor; at
-    // rank-4 "orthogonal" isn't a standard concept.
+    // NOTE on ordering: this runs AFTER the space-propagation block
+    // above. For contradictory inputs (e.g. assume_skew(W) +
+    // assume_positive_definite(W)) the space block transfers Skew to
+    // the result first; then this block OVERWRITES with Sym via the
+    // detail helper. The user-asserted contradiction resolves by
+    // honouring PD's symmetric implication on the output.
+    //
+    // Orthogonal is intentionally NOT propagated here. At rank-2 the
+    // inv() factory folds inv(orthogonal) → trans() before reaching
+    // this ctor (α-2a). At rank-4 "orthogonal" isn't a standard
+    // concept so the annotation is vacuous on input and silently
+    // dropped — calling assume_orthogonal on a rank-4 tensor is a
+    // user error, not propagated.
     auto const &input_alg = this->expr().get().tensor_algebra_assumptions();
-    bool propagate_pd = input_alg.contains(positive_definite{});
-    bool propagate_psd = input_alg.contains(positive_semidefinite{});
-    if (propagate_pd || propagate_psd) {
+    const bool input_has_pd = input_alg.contains(positive_definite{});
+    const bool input_has_psd =
+        input_has_pd || input_alg.contains(positive_semidefinite{});
+    if (input_has_psd) {
       auto &out = this->tensor_algebra_assumptions();
-      if (propagate_pd) {
+      if (input_has_pd)
         out.insert(positive_definite{});
-        out.insert(
-            positive_semidefinite{}); // PD => PSD (matches #245 convention)
-      } else {
-        out.insert(positive_semidefinite{});
-      }
+      out.insert(positive_semidefinite{}); // PD ⇒ PSD (#245 convention)
       detail::set_symmetric_unless_more_specific(this);
     }
   }

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -461,25 +461,48 @@ TEST(TensorAlgebraPropagation, InvPdRank4MinorMajorPropagates) {
   EXPECT_TRUE(is_minor_major(invC));
 }
 
-TEST(TensorAlgebraPropagation, InvContradictorySkewAndPdResolvesToSymWithPd) {
-  // Contradictory user input — Skew is set first via assume_skew, then
-  // PD is asserted via assume_positive_definite (which already
-  // overwrites the Skew space at the assume() site per #245). The
-  // tensor_inv constructor's ordering — space propagation first, then
-  // algebra propagation — handles a hypothetical caller who reaches
-  // this state differently (e.g. via direct tensor_algebra_assumptions
-  // manipulation that left Skew on the space). The end state always
-  // honours PD's symmetric implication on the output. This test locks
-  // that ordering in.
+TEST(TensorAlgebraPropagation, AssumePdAfterSkewResolvesAtCallSite) {
+  // Pre-condition for the ctor-defense test below: confirm that
+  // assume_positive_definite OVERWRITES a prior Skew space at the
+  // assume() call site (per #245). This means the typical path never
+  // reaches tensor_inv's ctor with the contradictory state.
   auto W = std::get<0>(make_tensor_variable(std::tuple{"W", 3, 2}));
   assume_skew(W);
-  // assume_positive_definite overrides Skew → Sym at the assume() site.
   assume_positive_definite(W);
   EXPECT_TRUE(is_symmetric(W));
   EXPECT_FALSE(is_skew(W));
   auto invW = inv(W);
   EXPECT_TRUE(is_positive_definite(invW));
   EXPECT_TRUE(is_symmetric(invW));
+  EXPECT_FALSE(is_skew(invW));
+}
+
+TEST(TensorAlgebraPropagation, InvCtorDefendsAgainstSkewSpaceWithPdAlgebra) {
+  // Exercise tensor_inv's ctor ordering on the pathological state that
+  // the assume_* call sites prevent but a direct-manager caller can
+  // construct: Skew on the space field AND positive_definite in the
+  // algebra manager. The ctor's space block propagates Skew to the
+  // result first; then the algebra block calls
+  // set_symmetric_unless_more_specific which overwrites Skew with Sym
+  // (Skew is not a recognised sym subspace). Lock that ordering in so
+  // a refactor doesn't reverse it and produce an inv that claims to
+  // be both PD and Skew.
+  //
+  // Dim 2 (even): the inv() factory's odd-dim skew-singularity guard
+  // doesn't fire, so we actually reach the tensor_inv ctor.
+  auto W = std::get<0>(make_tensor_variable(std::tuple{"W", 2, 2}));
+  assume_skew(W);
+  // Bypass assume_positive_definite (which would overwrite the Skew
+  // space). Insert PD/PSD directly into the algebra manager, leaving
+  // the Skew space intact. This is the state the ctor must handle.
+  W.data()->tensor_algebra_assumptions().insert(positive_definite{});
+  W.data()->tensor_algebra_assumptions().insert(positive_semidefinite{});
+  ASSERT_TRUE(is_skew(W));
+  ASSERT_TRUE(is_positive_definite(W));
+  auto invW = inv(W);
+  EXPECT_TRUE(is_positive_definite(invW));
+  EXPECT_TRUE(is_symmetric(invW))
+      << "ctor's algebra block must overwrite the propagated Skew with Sym";
   EXPECT_FALSE(is_skew(invW));
 }
 
@@ -499,6 +522,39 @@ TEST(TensorAlgebraPropagation, InvPdComposesWithVolumetric) {
   // Vol IS preserved by tensor_inv's rank-2 space-propagation
   // (Volumetric perm in {Sym subspaces}; not Dev/Harm so kept).
   EXPECT_TRUE(is_volumetric(invP));
+}
+
+TEST(TensorAlgebraPropagation, InvInvPdReducesToCWithPdIntact) {
+  // inv() factory's inv(inv(A)) → A short-circuit returns the inner
+  // expression unchanged. Since C carried PD/PSD/Sym before, the
+  // collapsed result trivially still has them — no separate
+  // propagation step needed. Lock in the transitivity: a fold that
+  // sheds annotations on collapse would silently weaken downstream
+  // reasoning.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  auto invInvC = inv(inv(C));
+  EXPECT_EQ(invInvC, C) << "inv(inv(A)) should structurally collapse to A";
+  EXPECT_TRUE(is_positive_definite(invInvC));
+  EXPECT_TRUE(is_positive_semidefinite(invInvC));
+  EXPECT_TRUE(is_symmetric(invInvC));
+}
+
+TEST(TensorAlgebraPropagation, AssumePdOnRank4WithNoSpaceLeavesSpaceUnset) {
+  // Rank-gate on detail::set_symmetric_unless_more_specific: when the
+  // input is rank-4 with no recognised sym subspace, the helper is a
+  // no-op (writing a rank-2 Symmetric{} tag to a rank-4 tensor would
+  // be a structural mismatch). The PD algebra annotation still goes
+  // in. Lock in this defensive behavior: a regression that wrote
+  // rank-2 Sym to rank-4 would silently produce malformed nodes.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 4}));
+  assume_positive_definite(C);
+  EXPECT_TRUE(is_positive_definite(C));
+  EXPECT_TRUE(is_positive_semidefinite(C));
+  // Space stays unset — the user can opt in via assume_minor_major
+  // or assume_major if they want a sym subspace at rank-4.
+  EXPECT_FALSE(C.get().space().has_value())
+      << "rank-4 PD with no prior space must NOT get a rank-2 Sym tag";
 }
 
 } // namespace numsim::cas

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -461,6 +461,28 @@ TEST(TensorAlgebraPropagation, InvPdRank4MinorMajorPropagates) {
   EXPECT_TRUE(is_minor_major(invC));
 }
 
+TEST(TensorAlgebraPropagation, InvContradictorySkewAndPdResolvesToSymWithPd) {
+  // Contradictory user input — Skew is set first via assume_skew, then
+  // PD is asserted via assume_positive_definite (which already
+  // overwrites the Skew space at the assume() site per #245). The
+  // tensor_inv constructor's ordering — space propagation first, then
+  // algebra propagation — handles a hypothetical caller who reaches
+  // this state differently (e.g. via direct tensor_algebra_assumptions
+  // manipulation that left Skew on the space). The end state always
+  // honours PD's symmetric implication on the output. This test locks
+  // that ordering in.
+  auto W = std::get<0>(make_tensor_variable(std::tuple{"W", 3, 2}));
+  assume_skew(W);
+  // assume_positive_definite overrides Skew → Sym at the assume() site.
+  assume_positive_definite(W);
+  EXPECT_TRUE(is_symmetric(W));
+  EXPECT_FALSE(is_skew(W));
+  auto invW = inv(W);
+  EXPECT_TRUE(is_positive_definite(invW));
+  EXPECT_TRUE(is_symmetric(invW));
+  EXPECT_FALSE(is_skew(invW));
+}
+
 TEST(TensorAlgebraPropagation, InvPdComposesWithVolumetric) {
   // assume_volumetric(C) sets {Sym, Vol}; assume_positive_definite
   // preserves the Vol subspace via the more-specific rule from #245.

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -381,6 +381,104 @@ TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {
   EXPECT_NEAR(inv_R(2, 2), 1.0, 1e-12);
 }
 
+// ─── #246 α-2b: PD/PSD propagation through tensor_inv ──────────────
+
+TEST(TensorAlgebraPropagation, InvPdIsAlsoPd) {
+  // inv(PD) is PD by definition — positive eigenvalues stay positive
+  // under inversion. The propagation lives in tensor_inv's constructor
+  // so all paths that produce a tensor_inv (including direct calls,
+  // not via the factory fold for orthogonal) see it.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  auto invC = inv(C);
+  // The factory doesn't fold inv(PD) (only inv(orthogonal) folds);
+  // so invC is a tensor_inv. Sanity-check that path.
+  ASSERT_TRUE(is_same<tensor_inv>(invC));
+  EXPECT_TRUE(is_positive_definite(invC));
+  // PD => PSD (joint insertion); also implies symmetric.
+  EXPECT_TRUE(is_positive_semidefinite(invC));
+  EXPECT_TRUE(is_symmetric(invC));
+}
+
+TEST(TensorAlgebraPropagation, InvPsdStaysPsd) {
+  // inv(PSD) propagates PSD. (A non-singular PSD is actually PD, but
+  // we don't know that symbolically — stay conservative; eval throws
+  // if actually singular.) PSD does NOT imply PD.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_semidefinite(C);
+  auto invC = inv(C);
+  ASSERT_TRUE(is_same<tensor_inv>(invC));
+  EXPECT_TRUE(is_positive_semidefinite(invC));
+  EXPECT_FALSE(is_positive_definite(invC))
+      << "PSD should not strengthen to PD through propagation";
+  EXPECT_TRUE(is_symmetric(invC));
+}
+
+TEST(TensorAlgebraPropagation, InvUnannotatedHasNoPdAnnotation) {
+  // Negative case: an un-annotated rank-2 tensor's inv must NOT
+  // gain PD/PSD on its own. Guards against over-eager propagation.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto invA = inv(A);
+  ASSERT_TRUE(is_same<tensor_inv>(invA));
+  EXPECT_FALSE(is_positive_definite(invA));
+  EXPECT_FALSE(is_positive_semidefinite(invA));
+}
+
+TEST(TensorAlgebraPropagation, InvPdThroughClearSpaceStillSymmetric) {
+  // Cross-mechanism: input C is annotated PD (which sets the Symmetric
+  // space tag). Even if the user clears the space, the PD assumption
+  // still implies symmetric in is_symmetric()'s logic. inv(C) then
+  // propagates the PD assumption, which RE-SETS the Symmetric space
+  // on the result (via detail::set_symmetric_unless_more_specific).
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  C.data()->clear_space();
+  ASSERT_FALSE(C.get().space().has_value());
+  // Despite cleared space on input, the inv() result has the space
+  // re-derived from the PD propagation.
+  auto invC = inv(C);
+  EXPECT_TRUE(is_positive_definite(invC));
+  EXPECT_TRUE(invC.get().space().has_value())
+      << "PD propagation should re-derive the symmetric space tag";
+  EXPECT_TRUE(is_symmetric(invC));
+}
+
+TEST(TensorAlgebraPropagation, InvPdRank4MinorMajorPropagates) {
+  // Rank-4 PD (e.g., a positive-definite elasticity tangent). The
+  // factory rank-gate accepts rank-4 with Minor/MinorMajor annotation,
+  // and the tensor_inv ctor's algebra-propagation path fires regardless
+  // of rank.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 4}));
+  assume_minor_major(C);
+  assume_positive_definite(C);
+  auto invC = inv(C);
+  ASSERT_TRUE(is_same<tensor_inv>(invC));
+  EXPECT_TRUE(is_positive_definite(invC));
+  EXPECT_TRUE(is_positive_semidefinite(invC));
+  // The minor-major space tag is preserved by the rank-4 branch of
+  // tensor_inv's space-propagation, independently of the algebra
+  // propagation.
+  EXPECT_TRUE(is_minor_major(invC));
+}
+
+TEST(TensorAlgebraPropagation, InvPdComposesWithVolumetric) {
+  // assume_volumetric(C) sets {Sym, Vol}; assume_positive_definite
+  // preserves the Vol subspace via the more-specific rule from #245.
+  // inv(C) propagates both: PD remains, and the more-specific Vol
+  // space ALSO remains (because detail::set_symmetric_unless_more_specific
+  // only widens to {Sym, AnyTrace} if no Sym subspace was set).
+  auto P = std::get<0>(make_tensor_variable(std::tuple{"P", 3, 2}));
+  assume_volumetric(P);
+  assume_positive_definite(P);
+  ASSERT_TRUE(is_volumetric(P));
+  ASSERT_TRUE(is_positive_definite(P));
+  auto invP = inv(P);
+  EXPECT_TRUE(is_positive_definite(invP));
+  // Vol IS preserved by tensor_inv's rank-2 space-propagation
+  // (Volumetric perm in {Sym subspaces}; not Dev/Harm so kept).
+  EXPECT_TRUE(is_volumetric(invP));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORALGEBRAASSUMETEST_H


### PR DESCRIPTION
Step α-2b of the 1.0 roadmap (#251). Second slice of #246.

## Summary

Where α-2a (#254) folded the orthogonal annotation in the `inv()` factory, this slice adds **PD/PSD propagation in the `tensor_inv` constructor itself** — so `inv(PD)` is PD and `inv(PSD)` is PSD for any path that builds a `tensor_inv` (rank-2 or rank-4).

## Changes

### `include/numsim_cas/tensor/wrappers/tensor_inv.h`
New section in the constructor body: read the input's algebra-assumption manager and propagate `positive_definite{}` / `positive_semidefinite{}` to the result. PD joint-inserts PSD (matches #245's convention). PD/PSD imply symmetric → reuse `detail::set_symmetric_unless_more_specific` to set the projector-space tag iff no more-specific Sym subspace was already there.

Orthogonal is **not** propagated here. At rank-2 the `inv()` factory folds `inv(orthogonal)` to `trans()` before reaching this ctor (α-2a); at rank-4 "orthogonal" isn't a standard concept.

### `include/numsim_cas/tensor/tensor_assume.h` — **latent bug fix surfaced by α-2b**
Extended `detail::set_symmetric_unless_more_specific` to recognise `Minor` / `MinorMajor` perms as "more-specific sym subspaces" at rank-4. Without this fix, PD on a rank-4 MinorMajor stiffness would silently overwrite MinorMajor with rank-2 `{Sym, AnyTrace}` — the canonical continuum-mechanics use case (PD elasticity tangents) would lose rank-4 structural info.

This helper is also called from `assume_positive_definite` and `assume_positive_semidefinite`, so the fix corrects a latent pre-existing limitation from #245 / #228. No existing tests broke because none covered the rank-4 PD case before this PR — the `InvPdRank4MinorMajorPropagates` test below is what surfaced it.

## Tests (6 new, all pass) — TensorAlgebraPropagation suite

| Test | What it locks in |
|---|---|
| `InvPdIsAlsoPd` | PD propagates; PSD follows via joint insertion; symmetric implied |
| `InvPsdStaysPsd` | PSD propagates without strengthening to PD |
| `InvUnannotatedHasNoPdAnnotation` | Negative — un-annotated input → no PD/PSD on result |
| `InvPdThroughClearSpaceStillSymmetric` | Cross-mechanism: PD propagation re-derives the Sym space tag even when input had cleared it |
| `InvPdRank4MinorMajorPropagates` | Rank-4 PD stiffness; MinorMajor space survives **and** PD propagates (the test that surfaced the helper bug) |
| `InvPdComposesWithVolumetric` | Vol subspace + PD: both survive through inv |

Suite: **1261/1261** (1255 + 6 new).

## Test-suite naming

New `TensorAlgebraPropagation` suite (distinct from α-2a's `TensorAlgebraFold`) — α-2b branched from `main` before α-2a merged, and using separate test-suite names avoids a file-merge conflict. When both PRs land, the two suites coexist in `TensorAlgebraAssumeTest.h` without overlap.

## Roadmap reference

Third commit of milestone 1.0-α; next is α-2c (`trans(orthogonal) · orthogonal → I` recognition in the tensor·tensor `mul_fn`).

## Sequencing

Branched from `main` (post-merges, no dependency on #252 or #254 — touches different files).