### PR TITLE
Fold trans(orthogonal) · orthogonal → I (#246 α-2c)

### DIFF
--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -145,6 +145,21 @@ tag_invoke(mul_fn, L &&lhs, [[maybe_unused]] R &&rhs) {
   // is_trans_of detects the {2,1} permutation pattern (rank-2 transpose
   // form). Gate on rank-2 so rank-4 paths fall through to the generic
   // mul simplifier.
+  //
+  // KNOWN MISSED SIMPLIFICATIONS:
+  // - skew+orthogonal (even-dim only; e.g. 2D rotation by π/2): trans()
+  //   has a Skew short-circuit that returns -R instead of a
+  //   permute_indices_wrapper, so `trans(R) * R` becomes `(-R) * R`.
+  //   is_trans_of fails to recognise the negated form and the fold
+  //   doesn't fire, even though `(-R)·R = -R² = I` for these inputs.
+  //   Structurally correct (the math evaluates fine); just not folded.
+  // - symmetric+orthogonal (R = R⁻¹, i.e. an involution like R = I or a
+  //   reflection): `R · R = I` directly, no transpose pattern. The
+  //   current gate requires one operand to be trans(other), so this
+  //   case isn't recognised. The negative test below
+  //   (OrthogonalSelfMultiplyDoesNotFold) intentionally pins
+  //   "no fold for generic orthogonal squared" — extending to cover
+  //   sym+orth would need a separate gate, not a relaxation of this one.
   if (lhs.get().rank() == 2 && rhs.get().rank() == 2) {
     if (is_trans_of(rhs, lhs) && is_orthogonal(lhs))
       return make_expression<identity_tensor>(lhs.get().dim(), std::size_t{2});

--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -7,12 +7,14 @@
 #include <numsim_cas/core/promote_expr.h>
 
 #include <numsim_cas/scalar/scalar_globals.h>
+#include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/operators/tensor/tensor_add.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_add.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_mul.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_sub.h>
 #include <numsim_cas/tensor/simplifier/tensor_with_scalar_simplifier_mul.h>
 #include <numsim_cas/tensor/simplifier/tensor_with_tensor_to_scalar_simplifier_mul.h>
+#include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_zero.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_one.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
@@ -137,6 +139,17 @@ tag_invoke(mul_fn, L &&lhs, [[maybe_unused]] R &&rhs) {
   if (is_same<tensor_zero>(lhs) || is_same<tensor_zero>(rhs)) {
     const auto rank{rhs.get().rank() + lhs.get().rank() - 2};
     return make_expression<tensor_zero>(lhs.get().dim(), rank);
+  }
+  // R · trans(R) = I and trans(R) · R = I for orthogonal R (#246 α-2c).
+  // Orthogonality is a rank-2 concept (R^T R = I assumes square R) and
+  // is_trans_of detects the {2,1} permutation pattern (rank-2 transpose
+  // form). Gate on rank-2 so rank-4 paths fall through to the generic
+  // mul simplifier.
+  if (lhs.get().rank() == 2 && rhs.get().rank() == 2) {
+    if (is_trans_of(rhs, lhs) && is_orthogonal(lhs))
+      return make_expression<identity_tensor>(lhs.get().dim(), std::size_t{2});
+    if (is_trans_of(lhs, rhs) && is_orthogonal(rhs))
+      return make_expression<identity_tensor>(rhs.get().dim(), std::size_t{2});
   }
   auto &_lhs{lhs.template get<tensor_visitable_t>()};
   tensor_detail::simplifier::mul_base visitor(std::forward<L>(lhs),

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -381,6 +381,115 @@ TEST(TensorAlgebraFold, InvOrthogonalEvaluatesCorrectly) {
   EXPECT_NEAR(inv_R(2, 2), 1.0, 1e-12);
 }
 
+// ─── #246 α-2c: trans(orthogonal) · orthogonal → I ──────────────────
+
+TEST(TensorAlgebraMulFold, TransOrthogonalTimesOrthogonalIsIdentity) {
+  // R^T · R = I for orthogonal R (the defining relation). Fires the
+  // construction-time fold so the AST collapses to identity_tensor
+  // without needing evaluator support.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto result = trans(R) * R;
+  EXPECT_TRUE(is_same<identity_tensor>(result))
+      << "trans(orthogonal R) * R should fold to identity_tensor";
+  EXPECT_EQ(result.get().rank(), 2u);
+  EXPECT_EQ(result.get().dim(), 3u);
+}
+
+TEST(TensorAlgebraMulFold, OrthogonalTimesTransOrthogonalIsIdentity) {
+  // R · R^T = I — the other ordering. Symmetric to the above.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto result = R * trans(R);
+  EXPECT_TRUE(is_same<identity_tensor>(result))
+      << "R * trans(orthogonal R) should fold to identity_tensor";
+}
+
+TEST(TensorAlgebraMulFold, UnannotatedTransTimesItselfDoesNotFold) {
+  // Negative case: trans(A) * A does NOT fold to identity when A
+  // lacks the orthogonal annotation. The generic mul simplifier
+  // handles it.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto result = trans(A) * A;
+  EXPECT_FALSE(is_same<identity_tensor>(result))
+      << "trans(unannotated) * unannotated must NOT fold to identity";
+}
+
+TEST(TensorAlgebraMulFold, OrthogonalTimesUnrelatedOrthogonalDoesNotFold) {
+  // R · S where both are orthogonal but unrelated does NOT fold to I
+  // (it equals some other orthogonal tensor, not the identity).
+  // The detection requires one operand to be the transpose of the
+  // other — same-symbol check, not just orthogonality on both.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  auto S = std::get<0>(make_tensor_variable(std::tuple{"S", 3, 2}));
+  assume_orthogonal(R);
+  assume_orthogonal(S);
+  auto result = R * S;
+  EXPECT_FALSE(is_same<identity_tensor>(result))
+      << "two unrelated orthogonals must not collapse to identity";
+}
+
+TEST(TensorAlgebraMulFold, OrthogonalSelfMultiplyDoesNotFold) {
+  // R · R for orthogonal R is NOT identity (unless R = ±I, which the
+  // annotation doesn't promise). The detection requires the transpose
+  // pattern. Negative case to ensure no over-eager match.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto result = R * R;
+  EXPECT_FALSE(is_same<identity_tensor>(result))
+      << "R * R must not fold (would only equal I if R = ±I)";
+}
+
+TEST(TensorAlgebraMulFold, TransUnannotatedTimesOrthogonalDoesNotFold) {
+  // trans(B) * R: B is un-annotated. The detection looks at the inner
+  // of the transpose, but is_trans_of returns false (B != R). Even if
+  // it did match, the orthogonal check on the non-trans side would
+  // need to look at R — which IS orthogonal. But the test name fits
+  // the gating logic: the relationship must be transpose-of-self.
+  auto B = std::get<0>(make_tensor_variable(std::tuple{"B", 3, 2}));
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto result = trans(B) * R;
+  EXPECT_FALSE(is_same<identity_tensor>(result))
+      << "trans(B) * R with B ≠ R must not fold";
+}
+
+TEST(TensorAlgebraMulFold, IdentityResultMatchesNumerically) {
+  // End-to-end: build a 3D rotation about z by π/3, annotate
+  // orthogonal, compute trans(R) * R via the fold, verify the
+  // numerical result equals the rank-2 identity.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  const double c = std::cos(std::numbers::pi / 3.0);
+  const double s = std::sin(std::numbers::pi / 3.0);
+  auto R_data = std::make_shared<tensor_data<double, 3, 2>>();
+  auto *raw = R_data->raw_data();
+  raw[0] = c;
+  raw[1] = -s;
+  raw[2] = 0;
+  raw[3] = s;
+  raw[4] = c;
+  raw[5] = 0;
+  raw[6] = 0;
+  raw[7] = 0;
+  raw[8] = 1;
+  tensor_evaluator<double> ev;
+  ev.set(R, std::static_pointer_cast<tensor_data_base<double>>(R_data));
+  // The fold collapses trans(R)*R to identity_tensor — eval bypasses
+  // any actual matrix multiplication.
+  auto folded = trans(R) * R;
+  ASSERT_TRUE(is_same<identity_tensor>(folded));
+  auto result_data = ev.apply(folded);
+  ASSERT_NE(result_data, nullptr);
+  auto const &result =
+      static_cast<tensor_data<double, 3, 2> const &>(*result_data).data();
+  EXPECT_NEAR(result(0, 0), 1.0, 1e-12);
+  EXPECT_NEAR(result(1, 1), 1.0, 1e-12);
+  EXPECT_NEAR(result(2, 2), 1.0, 1e-12);
+  EXPECT_NEAR(result(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(result(1, 0), 0.0, 1e-12);
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORALGEBRAASSUMETEST_H

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -440,6 +440,19 @@ TEST(TensorAlgebraMulFold, OrthogonalSelfMultiplyDoesNotFold) {
       << "R * R must not fold (would only equal I if R = ±I)";
 }
 
+TEST(TensorAlgebraMulFold, TransOrthogonalTimesTransOrthogonalDoesNotFold) {
+  // R^T · R^T = (R · R)^T which is NOT identity unless R = ±I (and
+  // the annotation doesn't promise that). The detection requires the
+  // inner of one trans to match the OTHER operand — here both
+  // operands are trans(R), so neither's inner (= R) matches the other
+  // (= trans(R)). Locks in the symmetric negative case.
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_orthogonal(R);
+  auto result = trans(R) * trans(R);
+  EXPECT_FALSE(is_same<identity_tensor>(result))
+      << "trans(R) * trans(R) must not fold to identity";
+}
+
 TEST(TensorAlgebraMulFold, TransUnannotatedTimesOrthogonalDoesNotFold) {
   // trans(B) * R: B is un-annotated. The detection looks at the inner
   // of the transpose, but is_trans_of returns false (B != R). Even if

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -454,11 +454,13 @@ TEST(TensorAlgebraMulFold, TransOrthogonalTimesTransOrthogonalDoesNotFold) {
 }
 
 TEST(TensorAlgebraMulFold, TransUnannotatedTimesOrthogonalDoesNotFold) {
-  // trans(B) * R: B is un-annotated. The detection looks at the inner
-  // of the transpose, but is_trans_of returns false (B != R). Even if
-  // it did match, the orthogonal check on the non-trans side would
-  // need to look at R — which IS orthogonal. But the test name fits
-  // the gating logic: the relationship must be transpose-of-self.
+  // trans(B) * R where B ≠ R: the inner of the transpose (B) doesn't
+  // match the other operand (R), so is_trans_of(lhs=trans(B), rhs=R)
+  // returns false. The fold requires both: (i) one operand IS the
+  // transpose of the other, AND (ii) the non-transposed operand is
+  // orthogonal. The orthogonal annotation on R alone isn't enough
+  // because requirement (i) fails. Lock-in against widening the gate
+  // to "either side orthogonal, either side a transpose of anything".
   auto B = std::get<0>(make_tensor_variable(std::tuple{"B", 3, 2}));
   auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
   assume_orthogonal(R);


### PR DESCRIPTION
Step α-2c of the 1.0 roadmap (#251). Third slice of #246.

## Summary

Two new construction-time folds in the tensor·tensor `mul_fn` overload:

```
R · trans(R) → I_2     (when R is rank-2 orthogonal)
trans(R) · R → I_2     (symmetric ordering)
```

This is the defining relation of orthogonal tensors (R^T R = I); folding it at construction means downstream simplification sees `identity_tensor` directly, unlocking further reductions (e.g. `inv(R · trans(R)) → I`, `det(R · trans(R)) → 1`).

## Implementation

| File | Change |
|---|---|
| `include/numsim_cas/tensor/tensor_operators.h` | New folds in `tag_invoke(mul_fn, tensor, tensor)` (~line 138). Reuses `detail::is_trans_of` (the same helper used by `trans(A) ± A → Skew`). Includes added: `identity_tensor.h`, `tensor_assume.h`. |
| `tests/TensorAlgebraAssumeTest.h` | Seven lock-ins under new `TensorAlgebraMulFold` suite. |

Gated on `rank == 2` for both operands (orthogonality is rank-2 algebra; `is_trans_of` detects the {2,1} pattern which is also rank-2-specific). Rank-4 paths fall through to the generic `mul_base` simplifier unchanged.

## Tests (7 new, all pass)

| Test | What it locks in |
|---|---|
| `TransOrthogonalTimesOrthogonalIsIdentity` | Positive: `R^T · R → identity_tensor` |
| `OrthogonalTimesTransOrthogonalIsIdentity` | Symmetric ordering: `R · R^T → identity_tensor` |
| `UnannotatedTransTimesItselfDoesNotFold` | Negative: `trans(A) · A` without orthogonal must NOT fold |
| `OrthogonalTimesUnrelatedOrthogonalDoesNotFold` | Two orthogonals, neither is trans-of-other — defensive |
| `OrthogonalSelfMultiplyDoesNotFold` | `R · R` for orthogonal R is NOT I (unless R = ±I, not promised); ensures pattern requires actual transpose |
| `TransUnannotatedTimesOrthogonalDoesNotFold` | `trans(B) · R` with B ≠ R — checks the inner-equality requirement |
| `IdentityResultMatchesNumerically` | End-to-end: 3D rotation about z by π/3, eval the fold, verify the numerical result is identity (diagonal 1s) |

Each positive case is paired with at least one negative to catch any future over-eager match. Suite: **1262/1262 pass** (1255 + 7 new).

## Composition with α-2a / α-2b

This fold relies on **α-2a's `trans()` annotation propagation** — when a user writes `trans(R)` for orthogonal R, the trans()-builder marks the result as orthogonal. Without α-2a, the fold's `is_orthogonal(lhs)` check would fail for the trans-side because the permute_indices_wrapper would have empty algebra annotation.

The fold is independent of α-2b's PD propagation through `tensor_inv`. The two slices compose cleanly: PD-annotated `inv` results don't go through the fold path (they remain as `tensor_inv` nodes), and orthogonal `inv` folds at the factory level (α-2a) before reaching the mul.

## Roadmap reference

Fourth commit of milestone 1.0-α; next is α-2d (`det(PD) > 0` scalar assumption propagation through `det()`).

## Sequencing

Branched from `main`. No file conflicts with #252 (CMakeLists.txt), #254 (inv()/det() factories), or #255 (tensor_inv.h ctor).