### PR TITLE
Close α-2b composition gap: project PD onto det(inv(.)) result

### DIFF
--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -111,9 +111,27 @@ det(expression_holder<tensor_expression> const &expr) {
 
   // det(inv(A)) = 1/det(A). Routes through the t2s div operator which
   // composes via pow(rhs, -1) — produces canonical pow(det(A), -1).
+  //
+  // Closes the α-2b composition gap surfaced by the cross-PR review:
+  // α-2b annotates tensor_inv(PD) with positive_definite{}, but the
+  // recursive det(inner) call doesn't see the outer wrapper's tag,
+  // and t2s div positivity propagation (#260) is open. So PD on the
+  // outer expression has to be projected onto the composed result
+  // here directly. PD ⇒ det > 0 strict, so 1/det is also strictly
+  // positive. PSD is NOT propagated: det may be zero and 1/det is
+  // then undefined; any positivity claim would be incorrect.
   if (is_same<tensor_inv>(expr)) {
     auto const &inner = expr.get<tensor_inv>().expr();
-    return make_expression<tensor_to_scalar_one>() / det(inner);
+    auto result = make_expression<tensor_to_scalar_one>() / det(inner);
+    if (is_positive_definite(expr)) {
+      auto &a = result.data()->assumptions();
+      a.insert(positive{});
+      a.insert(nonnegative{});
+      a.insert(nonzero{});
+      a.insert(real_tag{});
+      a.set_inferred();
+    }
+    return result;
   }
 
   // det(trans(A)) = det(A). trans() builds permute_indices_wrapper with

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -132,6 +132,9 @@ det(expression_holder<tensor_expression> const &expr) {
   if (is_same<tensor_inv>(expr)) {
     auto const &inner = expr.get<tensor_inv>().expr();
     auto result = make_expression<tensor_to_scalar_one>() / det(inner);
+    // REMOVE WHEN #260 LANDS: once t2s div/pow propagate positivity
+    // generically, `1 / positive` will produce a positive-annotated
+    // result on its own and this explicit projection is redundant.
     if (is_positive_definite(expr)) {
       auto &a = result.data()->assumptions();
       a.insert(positive{});

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -120,6 +120,15 @@ det(expression_holder<tensor_expression> const &expr) {
   // here directly. PD ⇒ det > 0 strict, so 1/det is also strictly
   // positive. PSD is NOT propagated: det may be zero and 1/det is
   // then undefined; any positivity claim would be incorrect.
+  //
+  // CONTRACT NOTE: the is_positive_definite check below interrogates
+  // `expr` (the OUTER tensor_inv wrapper), NOT `inner`. This couples
+  // to α-2b's tensor_inv ctor, which propagates PD from inner→wrapper.
+  // A future refactor that moves the check to `inner` would change
+  // the contract: a direct make_expression<tensor_inv>(C) that bypasses
+  // the inv() factory's ctor-side propagation would suddenly behave
+  // differently from inv(C). If you ever need to read PD from the
+  // inner, do so EXPLICITLY rather than swapping the argument here.
   if (is_same<tensor_inv>(expr)) {
     auto const &inner = expr.get<tensor_inv>().expr();
     auto result = make_expression<tensor_to_scalar_one>() / det(inner);

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -833,6 +833,29 @@ TEST(TensorAlgebraComposition, InvPdPreservesPositiveDefiniteSentinel) {
 }
 
 TEST(TensorAlgebraComposition,
+     InvVolumetricOrthogonalPreservesBothAnnotations) {
+  // α-2a + projector-space cross-piece sentinel. C is BOTH volumetric
+  // AND orthogonal:
+  //   inv(C)    → α-2a fold fires (is_orthogonal)        → trans(C)
+  //   trans(C)  → trans's symmetric short-circuit (vol ⊂ sym) → C
+  //   final     == C, with both annotations intact.
+  // Verifies that the projector-space annotation (volumetric) and the
+  // algebra annotation (orthogonal) BOTH survive the cross-piece
+  // inv → trans → symmetric-shortcut chain — a different code path
+  // than the PD case above, which doesn't engage α-2a's fold.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_volumetric(C);
+  assume_orthogonal(C);
+  ASSERT_TRUE(is_volumetric(C));
+  ASSERT_TRUE(is_orthogonal(C));
+  auto invC = inv(C);
+  EXPECT_TRUE(is_volumetric(invC))
+      << "volumetric annotation should survive the chain";
+  EXPECT_TRUE(is_orthogonal(invC))
+      << "orthogonal annotation should survive the chain";
+}
+
+TEST(TensorAlgebraComposition,
      TransOrthogonalTimesDifferentOrthogonalDoesNotCollapseToIdentity) {
   // Negative composition at the TENSOR level: two DIFFERENT orthogonal
   // tensors. The α-2c mul fold requires the trans-of structural match,

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -647,14 +647,16 @@ TEST(TensorAlgebraDetPropagation, DetPdConstantFoldsBypassThePropagationPath) {
   EXPECT_TRUE(is_same<tensor_to_scalar_one>(d));
 }
 
-// ─── Recursive-path gap documentation (#246 α-2d) ─────────────────
-// The propagation block in det() fires only on the terminal
-// tensor_det node. The recursive paths (det(α·A), det(inv(A)),
-// det(tensor_mul)) compose results via t2s mul/div/pow which do
-// NOT yet propagate `positive` through the operation. The tests
-// below document the CURRENT (incomplete) behavior so a future fix
-// that lands the missing operator propagation can update them in
-// lockstep. Tracked: #260 (t2s op propagation), #261 (t2s constants).
+// ─── Recursive-path gaps + closures (#246 α-2d) ───────────────────
+// The α-2d propagation block in det() fires only on the terminal
+// tensor_det node. Recursive paths compose results via t2s
+// mul/div/pow which do NOT yet propagate `positive` through the
+// operation generically (#260).
+//
+// The det(inv(PD)) chain is closed here directly: det() projects PD
+// from the outer tensor_inv wrapper (α-2b) onto the composed
+// `1/det(inner)` result at the fold site. The det(α·PD) chain
+// remains open until #260 lands.
 
 TEST(TensorAlgebraDetPropagation, DetScalarMulPdLosesPositivityViaComposition) {
   // det(α·C) = α^d · det(C). The inner det(C) DOES get positive
@@ -670,27 +672,42 @@ TEST(TensorAlgebraDetPropagation, DetScalarMulPdLosesPositivityViaComposition) {
       << "Currently expected: composition strips positive (see #260)";
 }
 
-TEST(TensorAlgebraDetPropagation, DetInvPdLosesPositivityViaComposition) {
-  // det(inv(C)) = 1/det(C). The det() factory's `is_same<tensor_inv>`
-  // branch returns `make_expression<tensor_to_scalar_one>() / det(inner)`
-  // BEFORE the terminal `make_expression<tensor_det>` where the new
-  // α-2d annotation logic lives. So:
-  //   - The outer node is a t2s division (not a tensor_det) — α-2d's
-  //     propagation doesn't fire on it.
-  //   - The recursive `det(inner)` call CAN fire α-2d on a terminal
-  //     `tensor_det(inner)`, but here `inner = C` is PD-annotated and
-  //     the recursive det() also short-circuits (the rest of the folds
-  //     don't recognise PD specifically, so it reaches the terminal
-  //     branch — that one DOES annotate positive). Even with that
-  //     inner annotation, the outer t2s `/` doesn't propagate it.
-  // Net result: outer det(inv(C)) has no positivity tag. Documenting
-  // the gap. Once #260 (t2s op propagation through mul/div/pow) lands,
-  // 1/positive should resolve to positive; flip this expectation then.
+TEST(TensorAlgebraDetPropagation, DetInvPdIsPositiveViaWrapperProjection) {
+  // det(inv(C)) = 1/det(C) for PD C. The det() factory matches
+  // is_same<tensor_inv> and returns one/det(inner) BEFORE the
+  // terminal tensor_det branch. Two independent ingredients close
+  // the chain:
+  //   - α-2b: tensor_inv(PD C) wrapper carries positive_definite{}.
+  //   - det() projects PD from the outer wrapper onto the composed
+  //     result at the fold site (PD ⇒ det > 0 strict, 1/det > 0).
+  // Avoids waiting on t2s div positivity propagation (#260) for this
+  // particular chain. PSD inputs are NOT propagated by design
+  // (det may be zero → 1/det undefined).
   auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
   assume_positive_definite(C);
   auto d = det(inv(C));
-  EXPECT_FALSE(d.data()->assumptions().contains(positive{}))
-      << "Currently expected: t2s `/` doesn't propagate positive (#260)";
+  auto const &a = d.data()->assumptions();
+  EXPECT_TRUE(a.contains(positive{}))
+      << "PD wrapper projection onto 1/det(C) should yield positive";
+  EXPECT_TRUE(a.contains(nonnegative{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+}
+
+TEST(TensorAlgebraDetPropagation, DetInvPsdDoesNotPropagatePositivity) {
+  // PSD ⇒ det ≥ 0 but possibly zero. 1/0 is undefined, so we MUST
+  // NOT claim 1/det is positive (or even nonnegative — runtime would
+  // produce NaN/inf, not 0). Locks in the PSD-skip clause of the
+  // wrapper-projection fix.
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  assume_positive_semidefinite(H);
+  auto d = det(inv(H));
+  auto const &a = d.data()->assumptions();
+  EXPECT_FALSE(a.contains(positive{}))
+      << "PSD: 1/det undefined when det=0; positive would be unsound";
+  EXPECT_FALSE(a.contains(nonnegative{}))
+      << "PSD: 1/det undefined when det=0; nonneg would be unsound";
+  EXPECT_FALSE(a.contains(nonzero{}));
 }
 
 TEST(TensorAlgebraDetPropagation, DetTransPdGetsPositiveViaSymmetricShortcut) {
@@ -755,14 +772,14 @@ TEST(TensorAlgebraConstants, TensorToScalarZeroCarriesNonnegativeNonpositive) {
 // review of the 1.0-α milestone.
 //
 // NOTE on α-2b's composition surface:
-//   det() short-circuits at is_same<tensor_inv> (returning 1/det(inner))
-//   BEFORE the bottom-of-function PD-propagation check runs. So α-2b's
-//   PD-tag on tensor_inv is invisible to det(). To then reach a positive
-//   result from 1/det(C) we would need t2s div to propagate positivity
-//   — open as #260. Consequence: α-2b currently has no meaningful
-//   cross-PR composition chain in this file; its coverage lives in
-//   TensorAlgebraPropagation as a direct is_positive_definite(inv(C))
-//   lock-in (kept below as a sentinel here too).
+//   det() projects PD from the tensor_inv wrapper (α-2b) onto the
+//   composed 1/det(inner) result at the is_same<tensor_inv> fold site.
+//   This closes the det(inv(PD)) chain without waiting on t2s div
+//   positivity propagation (#260, still open for the other paths like
+//   det(α·C)). See DetInvPdIsPositiveViaWrapperProjection in
+//   TensorAlgebraDetPropagation for the direct lock-in, and the
+//   InvPdPreservesPositiveDefiniteSentinel below for the α-2b wrapper
+//   contract on its own.
 
 TEST(TensorAlgebraComposition, EndToEndChainDetInvTimesOrthogonalIsPositive) {
   // Chain: det(inv(R) * R) for orthogonal R.

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -699,6 +699,16 @@ TEST(TensorAlgebraDetPropagation, DetInvPsdDoesNotPropagatePositivity) {
   // NOT claim 1/det is positive (or even nonnegative — runtime would
   // produce NaN/inf, not 0). Locks in the PSD-skip clause of the
   // wrapper-projection fix.
+  //
+  // Important: this test passes TRIVIALLY today because nothing
+  // currently propagates assumptions through the outer t2s pow node
+  // (#260 is open). Its real value is forward-looking: when #260
+  // lands and t2s pow gains operand→result propagation, a naive
+  // implementation that propagates nonneg → nonneg through
+  // pow(x, -1) will fire here and fail this test. The failure forces
+  // the #260 implementation to be PD-aware (positive → positive) and
+  // reject naive nonneg → nonneg. Without this sentinel, a future
+  // PR could silently introduce unsoundness on PSD-singular inputs.
   auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
   assume_positive_semidefinite(H);
   auto d = det(inv(H));


### PR DESCRIPTION
## Summary

Closes the F2 finding from the cross-PR composition review on the 1.0-α milestone. α-2b annotates `tensor_inv(PD)` wrappers with `positive_definite{}`, but `det()` matches `is_same<tensor_inv>` and returns `1/det(inner)` BEFORE any PD check — leaving the wrapper's tag invisible and the composed result un-annotated despite being mathematically strictly positive.

Two-line fix at the fold site projects PD from the outer wrapper onto the composed `one / det(inner)` result. Avoids waiting on #260 (t2s div positivity propagation through pow) for this particular chain.

## Why this PR / not amend α-2d

α-2d's `Limitation` comment explicitly documented this gap. The fix is a natural extension and conceptually belongs there, but α-2d's PR (#259) is already in review with the gap-lock-in test. This PR replaces that test with the positive lock-in plus a new PSD soundness lock-in, and is stacked on the integration branch so reviewers can see the chain against a tree that has α-2b's wrapper available.

## Dependencies

- **α-2b (#255)** — provides the `tensor_inv(PD)` wrapper annotation that the new check queries.
- **α-2d (#259)** — provides the `det()` annotation-propagation pattern this PR extends.

Merge order: α-2b → α-2d → this. Retarget to `main` per the repo convention before merging.

## Soundness note: PSD intentionally NOT propagated

PSD allows `det = 0` (singular case); `1/0` is undefined. Propagating any positivity or nonneg claim on a potentially-NaN/inf value would be unsound. Locked in by `DetInvPsdDoesNotPropagatePositivity`.

## Test plan

- [x] `DetInvPdIsPositiveViaWrapperProjection` (replaces prior gap lock-in) — passes
- [x] `DetInvPsdDoesNotPropagatePositivity` (new PSD soundness lock-in) — passes
- [x] Other α-2d propagation tests unchanged — all pass
- [x] All 5 composition tests on the integration branch — pass
- [x] Full suite: 1295 / 1295 green

## What remains for #260

`det(α·PD)` and `det(tensor_mul of PDs)` chains remain open — those still need t2s mul/div/pow positivity propagation generically. `DetScalarMulPdLosesPositivityViaComposition` is kept as the open-gap sentinel.