### PR TITLE
Symmetric-aware rank-2 inv differentiation (#246 β-1)

### DIFF
--- a/include/numsim_cas/scalar/scalar_globals.h
+++ b/include/numsim_cas/scalar/scalar_globals.h
@@ -6,10 +6,6 @@
 namespace numsim::cas {
 const expression_holder<scalar_expression> &get_scalar_zero() noexcept;
 const expression_holder<scalar_expression> &get_scalar_one() noexcept;
-// Rational 1/2 — used by symmetrization kernels (e.g. β-1 inv-diff). Lazy
-// magic-static; shared across all callers. Same lifetime contract as
-// get_scalar_zero/get_scalar_one.
-const expression_holder<scalar_expression> &get_scalar_half() noexcept;
 } // namespace numsim::cas
 
 #endif // SCALAR_GLOBALS_H

--- a/include/numsim_cas/scalar/scalar_globals.h
+++ b/include/numsim_cas/scalar/scalar_globals.h
@@ -6,6 +6,10 @@
 namespace numsim::cas {
 const expression_holder<scalar_expression> &get_scalar_zero() noexcept;
 const expression_holder<scalar_expression> &get_scalar_one() noexcept;
+// Rational 1/2 — used by symmetrization kernels (e.g. β-1 inv-diff). Lazy
+// magic-static; shared across all callers. Same lifetime contract as
+// get_scalar_zero/get_scalar_one.
+const expression_holder<scalar_expression> &get_scalar_half() noexcept;
 } // namespace numsim::cas
 
 #endif // SCALAR_GLOBALS_H

--- a/include/numsim_cas/scalar/scalar_globals.h
+++ b/include/numsim_cas/scalar/scalar_globals.h
@@ -4,6 +4,17 @@
 #include <numsim_cas/scalar/scalar_expression.h>
 
 namespace numsim::cas {
+// scalar_zero and scalar_one are dedicated leaf node TYPES (with their own
+// get_id()) — semantic singletons in the algebra. The factories here
+// return shared instances of those types.
+//
+// DO NOT add get_scalar_half() or any other get_scalar_<rational>() here.
+// scalar_constant(scalar_number{n, d}) is a value-bearing node, not a
+// dedicated type — promoting it into this singleton family is a category
+// mismatch (tried, rolled back in commit ad4d824). Callers that want to
+// dedup a hot-path scalar_constant should use a function-local static
+// inside their TU; see tensor_differentiation.cpp's inv-diff visitor for
+// the precedent.
 const expression_holder<scalar_expression> &get_scalar_zero() noexcept;
 const expression_holder<scalar_expression> &get_scalar_one() noexcept;
 } // namespace numsim::cas

--- a/src/numsim_cas/scalar/scalar_globals.cpp
+++ b/src/numsim_cas/scalar/scalar_globals.cpp
@@ -1,4 +1,5 @@
 #include <numsim_cas/basic_functions.h>
+#include <numsim_cas/scalar/scalar_constant.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_zero.h>
@@ -13,6 +14,11 @@ expression_holder<scalar_expression> const &get_scalar_zero() noexcept {
 expression_holder<scalar_expression> const &get_scalar_one() noexcept {
   static auto o = make_expression<scalar_one>();
   return o;
+}
+
+expression_holder<scalar_expression> const &get_scalar_half() noexcept {
+  static auto h = make_expression<scalar_constant>(scalar_number{1, 2});
+  return h;
 }
 
 } // namespace numsim::cas

--- a/src/numsim_cas/scalar/scalar_globals.cpp
+++ b/src/numsim_cas/scalar/scalar_globals.cpp
@@ -1,5 +1,4 @@
 #include <numsim_cas/basic_functions.h>
-#include <numsim_cas/scalar/scalar_constant.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_zero.h>
@@ -14,11 +13,6 @@ expression_holder<scalar_expression> const &get_scalar_zero() noexcept {
 expression_holder<scalar_expression> const &get_scalar_one() noexcept {
   static auto o = make_expression<scalar_one>();
   return o;
-}
-
-expression_holder<scalar_expression> const &get_scalar_half() noexcept {
-  static auto h = make_expression<scalar_constant>(scalar_number{1, 2});
-  return h;
 }
 
 } // namespace numsim::cas

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -3,6 +3,7 @@
 #include <numeric>
 #include <numsim_cas/core/diff.h>
 #include <numsim_cas/scalar/scalar_operators.h>
+#include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_diff.h>
 #include <numsim_cas/tensor/tensor_functions.h>
 #include <numsim_cas/tensor/tensor_operators.h>
@@ -239,9 +240,8 @@ void tensor_differentiation::operator()(simple_outer_product const &visitable) {
   m_result = std::move(sum);
 }
 
-// tensor_inv: d(A^{-1})/dX = -inner(inner(inv(A), dA/dX), inv(A))
-// For rank-2: d(A^{-1})_{ij}/dX = -sum_{mn} T_{ijmn} * dA_{mn}/dX, where the
-// rank-4 kernel T depends on the algebraic class of A:
+// tensor_inv: d(A^{-1})/dX = -T : dA/dX, with rank-4 kernel T chosen by the
+// input's algebraic class:
 //
 //   - General (no Sym/Skew annotation):
 //       T_{ijmn} = A^{-1}_{im} * A^{-1}_{nj}                  (Magnus)
@@ -253,13 +253,22 @@ void tensor_differentiation::operator()(simple_outer_product const &visitable) {
 //       T_{ijmn} = (1/2)(A^{-1}_{im} A^{-1}_{nj}
 //                      - A^{-1}_{in} A^{-1}_{mj})             (minor-antisym)
 //
-// The Sym/Skew kernels are derived from the chain rule's requirement that
-// dA_{mn} respects the symmetry of A: for symmetric A, dA_{mn} = dA_{nm};
-// for skew, dA_{mn} = -dA_{nm}. The general formula and the symmetric
-// formula AGREE numerically when contracted with a symmetric dA (the swap
-// term integrates to the same value); they DIFFER when callers pass an
-// un-symmetrized dA into a symmetric input — the symmetric formula is the
-// correct one. Closes the rank-2 portion of #250 (#246 β-1).
+// The Sym/Skew kernels are NOT a contraction trick over Magnus — they are
+// the unique correct derivatives on the symmetric / skew sub-manifold (the
+// Magnus formula's projection onto the (m,n)-minor-(anti)symmetric
+// subspace). For a symmetric A, the Magnus kernel and the sym kernel happen
+// to contract to the same value when dA is also symmetric (swap-index
+// proof), so callers who feed sym dA in won't observe a numerical
+// difference — but the AST is now structurally honest, and callers who
+// pass an un-symmetrized dA against a symmetric input get the
+// mathematically correct answer instead of silently-wrong.
+//
+// Dispatch goes through is_symmetric() / is_skew() (tensor_assume.h), not
+// raw holds_alternative on perm. This picks up the PD/PSD ⇒ symmetric
+// implication from the algebra-assumption manager, including the case
+// where space() is cleared but the algebra tag remains. Vol/Dev inputs
+// route through the sym branch too (their space()->perm is Symmetric{}).
+// Closes the rank-2 portion of #250 (#246 β-1).
 void tensor_differentiation::operator()(tensor_inv const &visitable) {
   auto const &A = visitable.expr();
   auto dA = diff(A, m_arg);
@@ -271,21 +280,27 @@ void tensor_differentiation::operator()(tensor_inv const &visitable) {
 
   if (A.get().rank() == 2) {
     auto T = otimes(invA, sequence{1, 3}, invA, sequence{4, 2});
-    if (auto const &sp = A.get().space()) {
-      if (std::holds_alternative<Symmetric>(sp->perm)) {
-        auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-        auto half = make_expression<scalar_constant>(scalar_number{1, 2});
-        T = (T + T_swap) * half;
-      } else if (std::holds_alternative<Skew>(sp->perm)) {
-        auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-        auto half = make_expression<scalar_constant>(scalar_number{1, 2});
-        T = (T - T_swap) * half;
-      }
+    // Pick sym/skew kernel sign; sign==0 means general (Magnus) — no swap term.
+    int sign = 0;
+    if (is_symmetric(A))
+      sign = +1;
+    else if (is_skew(A))
+      sign = -1;
+    if (sign != 0) {
+      auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
+      // Function-local static: the 1/2 constant is value-equal for all
+      // calls, no annotations vary across invocations, and expression_holder
+      // is shared_ptr-based so re-allocating per call wastes one alloc each
+      // time. Magic-static is thread-safe under C++11+.
+      static auto const half =
+          make_expression<scalar_constant>(scalar_number{1, 2});
+      T = (sign > 0 ? T + T_swap : T - T_swap) * half;
     }
     m_result = -inner_product(T, sequence{3, 4}, dA, sequence{1, 2});
   } else {
     throw not_implemented_error(
-        "tensor_differentiation: inv derivative for rank != 2");
+        "tensor_differentiation: inv derivative for rank != 2 not "
+        "implemented (rank-4 minor-major case tracked under #251 β-2)");
   }
 }
 

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -1,8 +1,8 @@
 #include <numsim_cas/tensor/visitors/tensor_differentiation.h>
 
+#include <cassert>
 #include <numeric>
 #include <numsim_cas/core/diff.h>
-#include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_diff.h>
@@ -285,15 +285,25 @@ void tensor_differentiation::operator()(tensor_inv const &visitable) {
     int sign = 0;
     if (is_symmetric(A))
       sign = +1;
-    else if (is_skew(A))
+    else if (is_skew(A)) {
+      // Defensive assert on the cross-module precondition: the inv()
+      // factory rejects odd-dim skew (singular) before any tensor_inv
+      // ever reaches this visitor. If a future refactor relaxes the
+      // factory check, the antisym kernel below would emit a meaningless
+      // expression for a singular tensor — fail loudly here instead.
+      assert(A.get().dim() % 2 == 0 &&
+             "skew odd-dim should have been rejected by inv() factory");
       sign = -1;
+    }
     if (sign != 0) {
       auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-      // Shared 1/2 constant from scalar_globals (matches the
-      // get_scalar_zero/get_scalar_one convention). scalar_constant is
-      // value-immutable, so a single shared instance is safe across all
-      // call sites and threads; saves one make_expression per call.
-      T = (sign > 0 ? T + T_swap : T - T_swap) * get_scalar_half();
+      // The 1/2 constant: function-local static. scalar_constant is
+      // value-immutable so a single instance is safe across all calls
+      // and threads (magic-static initialization). Saves one allocation
+      // per call.
+      static auto const half =
+          make_expression<scalar_constant>(scalar_number{1, 2});
+      T = (sign > 0 ? T + T_swap : T - T_swap) * half;
     }
     m_result = -inner_product(T, sequence{3, 4}, dA, sequence{1, 2});
   } else {

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -2,6 +2,7 @@
 
 #include <numeric>
 #include <numsim_cas/core/diff.h>
+#include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_diff.h>
@@ -288,13 +289,11 @@ void tensor_differentiation::operator()(tensor_inv const &visitable) {
       sign = -1;
     if (sign != 0) {
       auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-      // Function-local static: the 1/2 constant is value-equal for all
-      // calls, no annotations vary across invocations, and expression_holder
-      // is shared_ptr-based so re-allocating per call wastes one alloc each
-      // time. Magic-static is thread-safe under C++11+.
-      static auto const half =
-          make_expression<scalar_constant>(scalar_number{1, 2});
-      T = (sign > 0 ? T + T_swap : T - T_swap) * half;
+      // Shared 1/2 constant from scalar_globals (matches the
+      // get_scalar_zero/get_scalar_one convention). scalar_constant is
+      // value-immutable, so a single shared instance is safe across all
+      // call sites and threads; saves one make_expression per call.
+      T = (sign > 0 ? T + T_swap : T - T_swap) * get_scalar_half();
     }
     m_result = -inner_product(T, sequence{3, 4}, dA, sequence{1, 2});
   } else {

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -240,8 +240,26 @@ void tensor_differentiation::operator()(simple_outer_product const &visitable) {
 }
 
 // tensor_inv: d(A^{-1})/dX = -inner(inner(inv(A), dA/dX), inv(A))
-// For rank-2: d(A^{-1})_{ij}/dX = -sum_{mn} A^{-1}_{im} * A^{-1}_{nj} *
-// dA_{mn}/dX
+// For rank-2: d(A^{-1})_{ij}/dX = -sum_{mn} T_{ijmn} * dA_{mn}/dX, where the
+// rank-4 kernel T depends on the algebraic class of A:
+//
+//   - General (no Sym/Skew annotation):
+//       T_{ijmn} = A^{-1}_{im} * A^{-1}_{nj}                  (Magnus)
+//   - Symmetric (A = A^T):
+//       T_{ijmn} = (1/2)(A^{-1}_{im} A^{-1}_{nj}
+//                      + A^{-1}_{in} A^{-1}_{mj})             (minor-sym)
+//   - Skew (A = -A^T, even dim only — odd-dim skew is singular and is
+//     already rejected by the inv() factory):
+//       T_{ijmn} = (1/2)(A^{-1}_{im} A^{-1}_{nj}
+//                      - A^{-1}_{in} A^{-1}_{mj})             (minor-antisym)
+//
+// The Sym/Skew kernels are derived from the chain rule's requirement that
+// dA_{mn} respects the symmetry of A: for symmetric A, dA_{mn} = dA_{nm};
+// for skew, dA_{mn} = -dA_{nm}. The general formula and the symmetric
+// formula AGREE numerically when contracted with a symmetric dA (the swap
+// term integrates to the same value); they DIFFER when callers pass an
+// un-symmetrized dA into a symmetric input — the symmetric formula is the
+// correct one. Closes the rank-2 portion of #250 (#246 β-1).
 void tensor_differentiation::operator()(tensor_inv const &visitable) {
   auto const &A = visitable.expr();
   auto dA = diff(A, m_arg);
@@ -252,10 +270,18 @@ void tensor_differentiation::operator()(tensor_inv const &visitable) {
   auto invA = inv(A);
 
   if (A.get().rank() == 2) {
-    // Build T[i,j,m,n] = invA_{im} * invA_{nj} via
-    //   otimes(invA, {1,3}, invA, {4,2})
-    // Then contract T's {m,n} with dA's first two indices.
     auto T = otimes(invA, sequence{1, 3}, invA, sequence{4, 2});
+    if (auto const &sp = A.get().space()) {
+      if (std::holds_alternative<Symmetric>(sp->perm)) {
+        auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
+        auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+        T = (T + T_swap) * half;
+      } else if (std::holds_alternative<Skew>(sp->perm)) {
+        auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
+        auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+        T = (T - T_swap) * half;
+      }
+    }
     m_result = -inner_product(T, sequence{3, 4}, dA, sequence{1, 2});
   } else {
     throw not_implemented_error(

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -1,6 +1,5 @@
 #include <numsim_cas/tensor/visitors/tensor_differentiation.h>
 
-#include <cassert>
 #include <numeric>
 #include <numsim_cas/core/diff.h>
 #include <numsim_cas/scalar/scalar_operators.h>
@@ -286,21 +285,41 @@ void tensor_differentiation::operator()(tensor_inv const &visitable) {
     if (is_symmetric(A))
       sign = +1;
     else if (is_skew(A)) {
-      // Defensive assert on the cross-module precondition: the inv()
-      // factory rejects odd-dim skew (singular) before any tensor_inv
-      // ever reaches this visitor. If a future refactor relaxes the
-      // factory check, the antisym kernel below would emit a meaningless
-      // expression for a singular tensor — fail loudly here instead.
-      assert(A.get().dim() % 2 == 0 &&
-             "skew odd-dim should have been rejected by inv() factory");
+      // Cross-module precondition: the inv() factory rejects odd-dim
+      // skew (singular) at tensor_functions.h:425+. A direct
+      // `make_expression<tensor_inv>(odd_dim_skew)` bypasses the factory,
+      // and a future relaxation of the factory check would silently emit
+      // a meaningless antisym kernel for a singular operand. Throw
+      // matches the factory's `invalid_expression_error` convention and
+      // — unlike `assert` — fires in Release builds too.
+      if (A.get().dim() % 2 != 0)
+        throw invalid_expression_error(
+            "tensor_differentiation: odd-dim skew inv-diff is undefined "
+            "(singular matrix); should have been rejected at the inv() "
+            "factory");
       sign = -1;
     }
     if (sign != 0) {
       auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-      // The 1/2 constant: function-local static. scalar_constant is
-      // value-immutable so a single instance is safe across all calls
-      // and threads (magic-static initialization). Saves one allocation
-      // per call.
+      // The 1/2 constant: function-local static. Magic-static
+      // initialization is thread-safe per C++17 [stmt.dcl]; the lazy
+      // hash computation on the shared instance (mutable m_hash_value
+      // in expression_base) is NOT synchronized — see the note in
+      // include/numsim_cas/core/expression.h. The codebase is
+      // single-threaded today so this is fine; if multithreading lands,
+      // this static needs to participate in whatever synchronization
+      // scheme the hash cache adopts.
+      //
+      // PEER-SITE NOTE: scalar_constant(scalar_number{1, 2}) is also
+      // inlined per-call at scalar_simplifier_pow.cpp:95, scalar_std.h:
+      // 208 and :233. Those sites are construction-time and not on a
+      // hot path; the diff visitor IS called per tensor_inv per
+      // derivative, hence the local static here. DO NOT unify the four
+      // sites into a `get_scalar_half()` in scalar_globals.h — the
+      // existing get_scalar_zero / get_scalar_one return dedicated
+      // SINGLETON NODE TYPES (scalar_zero / scalar_one), not constants;
+      // promoting a rational-constant to the same API is a category
+      // mismatch (intentionally rolled back in commit ad4d824).
       static auto const half =
           make_expression<scalar_constant>(scalar_number{1, 2});
       T = (sign > 0 ? T + T_swap : T - T_swap) * half;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_numsim_cas_test(numsim_cas_test
     TensorDifferentiationTest.h
     TensorEvaluatorTest.h
     TensorExpressionTest.h
+    TensorInvDiffSymTest.h
     TensorProjectorDifferentiationTest.h
     TensorSpacePropagationTest.h
     TensorSubstitutionTest.h

--- a/tests/TensorDifferentiationTest.h
+++ b/tests/TensorDifferentiationTest.h
@@ -435,7 +435,16 @@ TEST_F(TensorDifferentiationTest, DevProjectorDiff) {
       << "dev(X) derivative mismatch";
 }
 
-// d(inv(dev(X)))/dX — inv of projected tensor
+// d(inv(dev(X)))/dX — inv of projected tensor.
+//
+// CROSS-COVERAGE NOTE (β-1): dev(X) sets the result's space to
+// {perm=Symmetric, trace=DeviatoricTag}, so this test also exercises the
+// β-1 minor-symmetric inv-diff kernel via is_symmetric() dispatch in
+// tensor_differentiation.cpp's operator()(tensor_inv const&). If you
+// "simplify" this test to remove the dev() wrapper, or if you switch the
+// input to a non-Sym-classified expression, you will silently delete
+// β-1's Vol/Dev dispatch coverage (TensorInvDiffSymTest.h relies on this
+// test for that path — see the NOTE block there).
 TEST_F(TensorDifferentiationTest, InvDevProjectorDiff) {
   auto expr = inv(dev(X));
   auto d = diff(expr, X);

--- a/tests/TensorDifferentiationTest.h
+++ b/tests/TensorDifferentiationTest.h
@@ -436,15 +436,6 @@ TEST_F(TensorDifferentiationTest, DevProjectorDiff) {
 }
 
 // d(inv(dev(X)))/dX — inv of projected tensor.
-//
-// CROSS-COVERAGE NOTE (β-1): dev(X) sets the result's space to
-// {perm=Symmetric, trace=DeviatoricTag}, so this test also exercises the
-// β-1 minor-symmetric inv-diff kernel via is_symmetric() dispatch in
-// tensor_differentiation.cpp's operator()(tensor_inv const&). If you
-// "simplify" this test to remove the dev() wrapper, or if you switch the
-// input to a non-Sym-classified expression, you will silently delete
-// β-1's Vol/Dev dispatch coverage (TensorInvDiffSymTest.h relies on this
-// test for that path — see the NOTE block there).
 TEST_F(TensorDifferentiationTest, InvDevProjectorDiff) {
   auto expr = inv(dev(X));
   auto d = diff(expr, X);

--- a/tests/TensorInvDiffSymTest.h
+++ b/tests/TensorInvDiffSymTest.h
@@ -1,0 +1,190 @@
+#ifndef TENSORINVDIFFSYMTEST_H
+#define TENSORINVDIFFSYMTEST_H
+
+#include "cas_test_helpers.h"
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+#include <tmech/tmech.h>
+
+#include <numsim_cas/core/diff.h>
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/tensor/tensor_assume.h>
+#include <numsim_cas/tensor/tensor_definitions.h>
+#include <numsim_cas/tensor/tensor_diff.h>
+#include <numsim_cas/tensor/tensor_functions.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+#include <numsim_cas/tensor/tensor_std.h>
+#include <numsim_cas/tensor/visitors/tensor_evaluator.h>
+
+// ─── β-1: Symmetric-aware rank-2 inv differentiation (#246 / #250 rank-2) ──
+//
+// The rank-2 branch of tensor_differentiation::operator()(tensor_inv)
+// switches kernels based on the input's space() annotation:
+//
+//   - Symmetric  → minor-symmetric kernel (½(A⁻¹_im A⁻¹_nj + A⁻¹_in A⁻¹_mj))
+//   - Skew       → minor-antisymmetric kernel (½(A⁻¹_im A⁻¹_nj − A⁻¹_in
+//   A⁻¹_mj))
+//   - General    → unchanged Magnus kernel (A⁻¹_im A⁻¹_nj)
+//
+// These tests use tmech::num_diff_central with type-matching perturbations
+// (sym for symmetric inputs, skew for skew inputs) as the ground truth.
+
+namespace numsim::cas {
+
+namespace {
+
+template <std::size_t Dim, std::size_t Rank>
+auto const &as_tmech_invdiff(tensor_data_base<double> const &data) {
+  return static_cast<tensor_data<double, Dim, Rank> const &>(data).data();
+}
+
+} // namespace
+
+// ── SymmetricRank2InvDiffMatchesNumeric ───────────────────────────────────
+// Annotate X symmetric, eval d(inv(X))/dX symbolically, compare to
+// numerical diff that perturbs only the symmetric part of X. Locks in the
+// minor-symmetric kernel.
+TEST(TensorInvDiffSym, SymmetricRank2InvDiffMatchesNumeric) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  assume_symmetric(X);
+  auto expr = inv(X);
+  auto d = diff(expr, X);
+  ASSERT_TRUE(d.is_valid()) << "Expected valid derivative for inv(X)";
+
+  // Build a well-conditioned symmetric PD input: random sym matrix + 10·I
+  // to keep eigenvalues bounded away from 0 for numerical stability of inv.
+  std::mt19937 rng(2026);
+  std::normal_distribution<double> dist(0.0, 1.0);
+  tmech::tensor<double, 3, 2> X_t;
+  for (std::size_t i = 0; i < 9; ++i)
+    X_t.raw_data()[i] = dist(rng);
+  X_t = tmech::eval(tmech::sym(X_t));
+  for (std::size_t i = 0; i < 3; ++i)
+    X_t(i, i) += 10.0;
+  auto X_ptr = std::make_shared<tensor_data<double, 3, 2>>(X_t);
+
+  tensor_evaluator<double> ev;
+  ev.set(X, X_ptr);
+
+  auto result = ev.apply(d);
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->rank(), 4u);
+
+  auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
+      [&](auto const &x) {
+        X_ptr->data() = tmech::eval(tmech::sym(x));
+        return as_tmech_invdiff<3, 2>(*ev.apply(expr));
+      },
+      X_t);
+  X_ptr->data() = X_t;
+
+  EXPECT_TRUE(
+      tmech::almost_equal(as_tmech_invdiff<3, 4>(*result), numdiff, 1e-6))
+      << "Symmetric inv-diff kernel must match num_diff_central with sym "
+         "perturbations";
+}
+
+// ── SkewRank2EvenDimInvDiffMatchesNumeric ─────────────────────────────────
+// Annotate X skew (dim 2, even — odd-dim skew is singular and rejected by
+// the inv() factory). Eval and compare to numerical diff perturbing only
+// the skew part.
+TEST(TensorInvDiffSym, SkewRank2EvenDimInvDiffMatchesNumeric) {
+  auto X = make_expression<tensor>("X", std::size_t{2}, std::size_t{2});
+  assume_skew(X);
+  auto expr = inv(X);
+  auto d = diff(expr, X);
+  ASSERT_TRUE(d.is_valid()) << "Expected valid derivative for inv(skew X)";
+
+  // 2D skew tensor X = [[0, a], [-a, 0]] with a ≠ 0 is invertible
+  // (det = a²). Build with a away from zero for numerical stability.
+  tmech::tensor<double, 2, 2> X_t;
+  X_t(0, 0) = 0.0;
+  X_t(0, 1) = 2.5;
+  X_t(1, 0) = -2.5;
+  X_t(1, 1) = 0.0;
+  auto X_ptr = std::make_shared<tensor_data<double, 2, 2>>(X_t);
+
+  tensor_evaluator<double> ev;
+  ev.set(X, X_ptr);
+
+  auto result = ev.apply(d);
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->rank(), 4u);
+
+  auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
+      [&](auto const &x) {
+        // Perturb only the skew part; symmetric component is "frozen" at 0
+        // to respect the assume_skew annotation.
+        X_ptr->data() = tmech::eval(tmech::skew(x));
+        return as_tmech_invdiff<2, 2>(*ev.apply(expr));
+      },
+      X_t);
+  X_ptr->data() = X_t;
+
+  EXPECT_TRUE(
+      tmech::almost_equal(as_tmech_invdiff<2, 4>(*result), numdiff, 1e-6))
+      << "Skew inv-diff kernel must match num_diff_central with skew "
+         "perturbations";
+}
+
+// ── GeneralRank2InvDiffUnchanged ──────────────────────────────────────────
+// No annotation: the general Magnus kernel still fires. Lock-in regression
+// test for the unannotated path so a future change to the branch ordering
+// (e.g., always go through the sym branch) is caught.
+TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  // No annotation — general tensor.
+  auto expr = inv(X);
+  auto d = diff(expr, X);
+  ASSERT_TRUE(d.is_valid()) << "Expected valid derivative for inv(general X)";
+
+  std::mt19937 rng(4242);
+  std::normal_distribution<double> dist(0.0, 1.0);
+  tmech::tensor<double, 3, 2> X_t;
+  for (std::size_t i = 0; i < 9; ++i)
+    X_t.raw_data()[i] = dist(rng);
+  // Make diagonally dominant so the inverse is well-conditioned.
+  for (std::size_t i = 0; i < 3; ++i)
+    X_t(i, i) += 10.0;
+  auto X_ptr = std::make_shared<tensor_data<double, 3, 2>>(X_t);
+
+  tensor_evaluator<double> ev;
+  ev.set(X, X_ptr);
+
+  auto result = ev.apply(d);
+  ASSERT_NE(result, nullptr);
+
+  // Numerical perturbation is unconstrained (no sym/skew projection).
+  auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
+      [&](auto const &x) {
+        X_ptr->data() = x;
+        return as_tmech_invdiff<3, 2>(*ev.apply(expr));
+      },
+      X_t);
+  X_ptr->data() = X_t;
+
+  EXPECT_TRUE(
+      tmech::almost_equal(as_tmech_invdiff<3, 4>(*result), numdiff, 1e-6))
+      << "General inv-diff kernel (Magnus) must match num_diff_central with "
+         "unconstrained perturbations — regression check on the un-annotated "
+         "path";
+}
+
+// ── SkewRank2OddDimRejectedAtFactory ──────────────────────────────────────
+// Contract check, not a diff test: the inv() factory itself rejects
+// skew + odd-dim before the diff visitor ever sees it. Lock in the gate so
+// a future refactor that removes the factory check would be caught here
+// rather than producing a misleading inv-diff error.
+TEST(TensorInvDiffSym, SkewRank2OddDimRejectedAtFactory) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  assume_skew(X);
+  EXPECT_THROW(
+      { [[maybe_unused]] auto e = inv(X); }, invalid_expression_error)
+      << "inv() factory must reject odd-dim skew (singular); diff visitor "
+         "should never see this case";
+}
+
+} // namespace numsim::cas
+
+#endif // TENSORINVDIFFSYMTEST_H

--- a/tests/TensorInvDiffSymTest.h
+++ b/tests/TensorInvDiffSymTest.h
@@ -186,11 +186,13 @@ TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
 // dispatch falls through to general Magnus.
 //
 // Verification uses a *structural* hash comparison between two diff results:
-// one with `assume_skew` still annotated (skew kernel: wraps a tensor_add of
-// T_base ± T_swap times ½), one after `clear_space` (Magnus kernel: just
-// T_base, no swap or scalar_mul). The two AST shapes differ in NODE TYPES,
-// not just coefficients, so the hash distinguishes them (the n_ary_tree
-// coefficient-exclusion rule doesn't affect this comparison).
+// one with `assume_skew` still annotated (skew kernel: wraps a
+// tensor_scalar_mul of `half` × `tensor_add(T_base, tensor_negative(T_swap))`
+// — n_ary_tree stores the negation via a wrapping `tensor_negative` node,
+// not via an internal sign), one after `clear_space` (Magnus kernel: bare
+// `T_base = otimes(...)`). The two AST shapes differ in NODE TYPES, not
+// just coefficients, so the hash distinguishes them — the n_ary_tree
+// coefficient-exclusion rule doesn't affect this comparison.
 TEST(TensorInvDiffSym, SkewClearedSpaceDispatchFallsThroughToMagnus) {
   auto X = make_expression<tensor>("X", std::size_t{2}, std::size_t{2});
   assume_skew(X);
@@ -212,16 +214,21 @@ TEST(TensorInvDiffSym, SkewClearedSpaceDispatchFallsThroughToMagnus) {
          "AST from the skew-kernel result above";
 }
 
-// ── VolumetricDispatchTriggersSymKernel ────────────────────────────────────
+// ── VolumetricDispatchEndToEndDiffersFromUnannotated ──────────────────────
 // `assume_volumetric(X)` sets {perm=Symmetric, trace=VolumetricTag}.
 // is_symmetric(X) returns true (Vol is a Sym subspace per classify_space),
-// so the dispatch routes through the sym kernel. Local structural lock-in
-// rather than relying on the cross-test NOTE on InvDevProjectorDiff:
-// compare diff(inv(vol_X), X) against diff(inv(unannotated_X), X), assert
-// they differ — the former uses the sym kernel (wraps T_base + T_swap),
-// the latter the bare Magnus kernel. Different AST node hierarchies, so
-// hashes differ.
-TEST(TensorInvDiffSym, VolumetricDispatchTriggersSymKernel) {
+// so the dispatch routes through the sym kernel.
+//
+// The hash inequality below catches a Vol-dispatch regression but the
+// signal is end-to-end: diff(inv(vol_X)) differs from diff(inv(unann_Y))
+// in TWO ways — (a) the leaf base case diff(X,X) returns P_vol for vol-X
+// vs identity_tensor for unannotated Y (per tensor_differentiation.h:73-92's
+// classify_space switch), AND (b) the inv-diff kernel choice (sym vs
+// Magnus). Either regressing would break the hash inequality, so this
+// test is a coverage net for "annotation is respected end-to-end" rather
+// than an isolated "sym kernel fired" lock-in. The kernel-isolation
+// version lives in PdAlgebraDispatchIsolatesSymKernel below.
+TEST(TensorInvDiffSym, VolumetricDispatchEndToEndDiffersFromUnannotated) {
   auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
   assume_volumetric(X);
   ASSERT_TRUE(is_symmetric(X)) << "Vol implies symmetric";
@@ -229,8 +236,8 @@ TEST(TensorInvDiffSym, VolumetricDispatchTriggersSymKernel) {
   ASSERT_TRUE(diff_with_vol.is_valid());
 
   auto Y = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
-  // Y has the same name as X so leaf hashes match — the only structural
-  // difference between the two diffs is whether the sym kernel fired.
+  // Y has the same name as X so leaf hashes match. Annotation is the
+  // only meaningful difference between the two inputs.
   ASSERT_FALSE(is_symmetric(Y));
   auto diff_unannotated = diff(inv(Y), Y);
   ASSERT_TRUE(diff_unannotated.is_valid());
@@ -238,36 +245,93 @@ TEST(TensorInvDiffSym, VolumetricDispatchTriggersSymKernel) {
   EXPECT_NE(diff_with_vol.get().hash_value(),
             diff_unannotated.get().hash_value())
       << "Vol-annotated input must produce a different diff AST than the "
-         "unannotated case — the former routes through the sym kernel, "
-         "the latter through Magnus";
+         "unannotated case (via leaf base case P_vol AND/OR sym kernel)";
 }
 
-// LIMITATIONS NOTE — dim=4 sign-flip detection is not currently testable:
+// ── PdAlgebraDispatchIsolatesSymKernel ────────────────────────────────────
+// Kernel-isolation lock-in: uses `assume_positive_definite(X); clear_space`
+// so X has PD in the algebra-manager but no space tag. Two consequences:
+//   1. is_symmetric(X) returns true (via the algebra-manager path) →
+//      dispatch picks the sym kernel.
+//   2. diff(X, X) at the leaf base case sees empty space → returns
+//      identity_tensor (NOT a projector), same as the unannotated case.
+// So the ONLY structural difference between this diff and an unannotated
+// diff is the kernel choice. Hash inequality therefore pins the kernel
+// dispatch in isolation, unlike the end-to-end Volumetric test above.
+TEST(TensorInvDiffSym, PdAlgebraDispatchIsolatesSymKernel) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  assume_positive_definite(X);
+  X.data()->clear_space();
+  ASSERT_TRUE(is_symmetric(X))
+      << "precondition: PD-without-space still classifies as symmetric "
+         "via the algebra-manager path";
+  ASSERT_FALSE(X.get().space().has_value())
+      << "precondition: leaf base case will return identity_tensor (no "
+         "projector dispatch), matching the unannotated path";
+  auto diff_with_pd = diff(inv(X), X);
+  ASSERT_TRUE(diff_with_pd.is_valid());
+
+  auto Y = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  ASSERT_FALSE(is_symmetric(Y));
+  auto diff_unannotated = diff(inv(Y), Y);
+  ASSERT_TRUE(diff_unannotated.is_valid());
+
+  EXPECT_NE(diff_with_pd.get().hash_value(),
+            diff_unannotated.get().hash_value())
+      << "With identical leaf base cases (both return identity_tensor), "
+         "the hash inequality MUST come from the kernel choice (sym vs "
+         "Magnus). A future change that breaks the algebra-manager → "
+         "sym-kernel dispatch would be caught here.";
+}
+
+// LIMITATIONS NOTE — dim=4 sign-flip detection is not currently testable.
+// TODO(#266): when the inner_product_wrapper hash gap closes, the deleted
+// SkewRank2Dim4StructuralLockIn test (removed in commit ad4d824) can be
+// revived; see the issue for the kernel signature mismatch.
 //
 // A naive hash-comparison structural lock-in at dim=4 cannot distinguish
 // the sym kernel (T_base + T_swap)·½ from the skew kernel
-// (T_base − T_swap)·½ because the n_ary_tree hash EXCLUDES coefficients
-// (documented design choice in CLAUDE.md / n_ary_tree.h). And the
-// evaluator's MaxDim=3 ceiling blocks numerical validation at dim=4.
+// (T_base − T_swap)·½ for THREE independent reasons:
+//
+//   1. n_ary_tree's hash EXCLUDES coefficients (documented design in
+//      CLAUDE.md / n_ary_tree.h), so the sign of T_swap (via tensor_negative
+//      wrapping) doesn't flow into the add-node's hash beyond the child
+//      node's own hash, which is the same for +T_swap and -T_swap-wrapped-
+//      in-negative... actually subtle: tensor_negative IS a distinct node,
+//      so this one is partly covered. The deeper issue is below.
+//   2. tensor_scalar_mul's hash, when LHS is a scalar_constant, COLLAPSES
+//      to the RHS hash (intentional design rule for `c·T == T` hash
+//      equality — see operators/scalar/tensor_scalar_mul.h:31-39). So
+//      `(T_base + T_swap) * half` hashes identically to `T_base + T_swap`,
+//      and `(T_base - T_swap) * half` hashes identically to `T_base -
+//      T_swap`. The ½ factor is invisible.
+//   3. inner_product_wrapper does NOT hash its contraction indices
+//      (issue #266) — so a swap of {3,4}/{1,2} → {1,2}/{3,4} on the
+//      outer contraction wouldn't be caught either.
+//
+// And the evaluator's MaxDim=3 ceiling blocks numerical validation at
+// dim=4.
 //
 // What we DO catch:
-//   - sym vs general (different node hierarchy) — locked in here via
-//     VolumetricDispatchTriggersSymKernel and
-//     SkewClearedSpaceDispatchFallsThroughToMagnus.
+//   - sym vs general dispatch (different node hierarchy via the
+//     tensor_add/tensor_scalar_mul wrappers) — locked in by
+//     SkewClearedSpaceDispatchFallsThroughToMagnus,
+//     VolumetricDispatchEndToEndDiffersFromUnannotated, and
+//     PdAlgebraDispatchIsolatesSymKernel.
 //   - sym kernel correctness at dim=3 — SymmetricRank2InvDiffMatchesNumeric.
 //   - skew kernel sign correctness at dim=2 —
-//   SkewRank2Dim2InvDiffMatchesNumeric
-//     (but only 1 free off-diagonal entry — not a thorough check).
+//     SkewRank2Dim2InvDiffMatchesNumeric (only 1 free off-diagonal entry —
+//     not a thorough check; the kernel works there but doesn't exercise
+//     the full minor-antisymmetric structure).
 //
 // What we DON'T catch:
 //   - Sign-flip in T_swap at dim ≥ 4 (sym ↔ skew kernel swap).
 //   - Transpose errors in T_swap's index sequences at dim ≥ 4.
+//   - A ½-coefficient regression at any dim (per reason 2 above).
 //
-// Tracked as a separate issue against the codebase: see the open issue
-// for `inner_product_wrapper` not hashing its contraction indices — once
-// the codebase's hash function captures indices and coefficients, the
-// gap above closes. Until then, the math has to be trusted from the
-// derivation in tensor_differentiation.cpp's doc comment.
+// Until #266 lands (and ideally also a hash extension to capture
+// scalar_constant coefficients in tensor_scalar_mul), the math has to be
+// trusted from the derivation in tensor_differentiation.cpp's doc comment.
 
 // ── PdAnnotationWithClearedSpaceStillRoutesToSymKernel ────────────────────
 // Soundness regression for the dispatch logic: assume_positive_definite

--- a/tests/TensorInvDiffSymTest.h
+++ b/tests/TensorInvDiffSymTest.h
@@ -9,6 +9,7 @@
 
 #include <numsim_cas/core/diff.h>
 #include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
 #include <numsim_cas/tensor/tensor_diff.h>
@@ -178,17 +179,63 @@ TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
          "path";
 }
 
-// ── SkewRank2OddDimRejectedAtFactory ──────────────────────────────────────
-// Contract check, not a diff test: the inv() factory itself rejects
-// skew + odd-dim before the diff visitor ever sees it. Lock in the gate so
-// a future refactor that removes the factory check would be caught here
-// rather than producing a misleading inv-diff error.
-TEST(TensorInvDiffSym, SkewRank2OddDimRejectedAtFactory) {
-  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+// ── SkewClearedSpaceFallsThroughToMagnus ──────────────────────────────────
+// Asymmetry between is_symmetric() and is_skew(): the former consults the
+// algebra-assumption manager for PD/PSD ⇒ symmetric, the latter does NOT
+// (skew has no algebra-manager backing). Consequence: clearing the space
+// on a skew-annotated tensor drops the classification entirely, and the
+// dispatch falls through to general Magnus. Companion to
+// PdAnnotationWithClearedSpaceStillRoutesToSymKernel — together they pin
+// the documented asymmetry so a future refactor that adds skew to the
+// algebra manager would be caught (it would silently switch this test's
+// behavior).
+TEST(TensorInvDiffSym, SkewClearedSpaceFallsThroughToMagnus) {
+  auto X = make_expression<tensor>("X", std::size_t{2}, std::size_t{2});
   assume_skew(X);
-  EXPECT_THROW(inv(X), invalid_expression_error)
-      << "inv() factory must reject odd-dim skew (singular); diff visitor "
-         "should never see this case";
+  ASSERT_TRUE(is_skew(X)) << "precondition: skew annotated via space";
+  X.data()->clear_space();
+  EXPECT_FALSE(is_skew(X))
+      << "is_skew() drops to false because skew has no algebra-manager "
+         "fallback (unlike is_symmetric which keeps PD/PSD)";
+  // The dispatch picks general Magnus for the now-unclassified tensor.
+  // The numerical value will differ from the skew kernel for a generic
+  // dA, but for a skew dA the two contract to the same value (proof
+  // mirrors the sym/Magnus equivalence) — so a numerical comparison
+  // wouldn't actually catch the dispatch change. The is_skew() FALSE
+  // above is the load-bearing assertion.
+}
+
+// ── SkewRank2Dim4StructuralLockIn ─────────────────────────────────────────
+// Dim=4 skew: the evaluator's MaxDim=3 ceiling blocks numerical validation,
+// but the symbolic dispatch can be locked in structurally. Build the
+// expected diff expression by hand using the same primitives the visitor
+// emits, then compare hashes. A sign-flip or transpose error in T_swap
+// (which dim=2 can't surface — only 1 free off-diagonal entry there) would
+// produce a different hash here.
+TEST(TensorInvDiffSym, SkewRank2Dim4StructuralLockIn) {
+  auto X = make_expression<tensor>("X", std::size_t{4}, std::size_t{2});
+  assume_skew(X);
+  auto expr = inv(X);
+  auto actual = diff(expr, X);
+  ASSERT_TRUE(actual.is_valid());
+
+  // Hand-built reference using the same formula as the visitor:
+  //   T = ½(otimes(invA,{1,3},invA,{4,2}) - otimes(invA,{1,4},invA,{3,2}))
+  //   result = -inner_product(T, {3,4}, dA, {1,2})
+  // where dA = diff(X, X) = P_skew(4) (the self-diff projector for skew X).
+  auto invA = inv(X);
+  auto T_base = otimes(invA, sequence{1, 3}, invA, sequence{4, 2});
+  auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
+  auto T_expected = (T_base - T_swap) * get_scalar_half();
+  auto dA_expected = diff(X, X);
+  ASSERT_TRUE(dA_expected.is_valid());
+  auto expected =
+      -inner_product(T_expected, sequence{3, 4}, dA_expected, sequence{1, 2});
+
+  EXPECT_EQ(actual.get().hash_value(), expected.get().hash_value())
+      << "Skew dim=4 diff AST hash must equal the hand-built reference "
+         "expression — catches sign-flip / index-transpose errors in "
+         "T_swap that dim=2 can't expose";
 }
 
 // NOTE — Vol/Dev coverage lives elsewhere:
@@ -220,6 +267,14 @@ TEST(TensorInvDiffSym, SkewRank2OddDimRejectedAtFactory) {
 // the PD-implies-symmetric path; raw holds_alternative<Symmetric>(perm)
 // would not. This test pins that the dispatch uses the former, so a
 // future change reverting to raw variant checks is caught.
+//
+// IMPORTANT TIMING: clear_space() is called BEFORE inv()/diff(). The
+// dispatch is queried lazily at diff() time, so the cleared space is
+// what's seen. If a future refactor caches the kernel choice at inv()
+// construction time, this test would silently start exercising the
+// wrong path (it would get the sym kernel from the still-Sym-annotated
+// X at inv()-time, not from the post-clear query). The lazy-dispatch
+// assumption is load-bearing for what this test actually pins.
 TEST(TensorInvDiffSym, PdAnnotationWithClearedSpaceStillRoutesToSymKernel) {
   auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
   assume_positive_definite(X);

--- a/tests/TensorInvDiffSymTest.h
+++ b/tests/TensorInvDiffSymTest.h
@@ -20,15 +20,21 @@
 // ─── β-1: Symmetric-aware rank-2 inv differentiation (#246 / #250 rank-2) ──
 //
 // The rank-2 branch of tensor_differentiation::operator()(tensor_inv)
-// switches kernels based on the input's space() annotation:
+// switches kernels based on is_symmetric() / is_skew() (which consult both
+// the projector-space tag and the algebra-assumption manager):
 //
 //   - Symmetric  → minor-symmetric kernel (½(A⁻¹_im A⁻¹_nj + A⁻¹_in A⁻¹_mj))
-//   - Skew       → minor-antisymmetric kernel (½(A⁻¹_im A⁻¹_nj − A⁻¹_in
-//   A⁻¹_mj))
+//   - Skew       → minor-antisymmetric kernel
+//                  (½(A⁻¹_im A⁻¹_nj − A⁻¹_in A⁻¹_mj))
 //   - General    → unchanged Magnus kernel (A⁻¹_im A⁻¹_nj)
 //
 // These tests use tmech::num_diff_central with type-matching perturbations
 // (sym for symmetric inputs, skew for skew inputs) as the ground truth.
+//
+// Lambdas inside num_diff_central use an intermediate `auto data = ev.apply(
+// expr)` to keep the shared_ptr alive during the implicit copy that the
+// lambda's auto-return-by-value performs. The helper's `auto const&` return
+// is safe-but-brittle; the local binding makes the lifetime explicit.
 
 namespace numsim::cas {
 
@@ -44,7 +50,7 @@ auto const &as_tmech_invdiff(tensor_data_base<double> const &data) {
 // ── SymmetricRank2InvDiffMatchesNumeric ───────────────────────────────────
 // Annotate X symmetric, eval d(inv(X))/dX symbolically, compare to
 // numerical diff that perturbs only the symmetric part of X. Locks in the
-// minor-symmetric kernel.
+// minor-symmetric kernel via tmech::num_diff_central.
 TEST(TensorInvDiffSym, SymmetricRank2InvDiffMatchesNumeric) {
   auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
   assume_symmetric(X);
@@ -74,7 +80,8 @@ TEST(TensorInvDiffSym, SymmetricRank2InvDiffMatchesNumeric) {
   auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
       [&](auto const &x) {
         X_ptr->data() = tmech::eval(tmech::sym(x));
-        return as_tmech_invdiff<3, 2>(*ev.apply(expr));
+        auto data = ev.apply(expr); // keep shared_ptr alive past `.data()` ref
+        return as_tmech_invdiff<3, 2>(*data);
       },
       X_t);
   X_ptr->data() = X_t;
@@ -85,19 +92,19 @@ TEST(TensorInvDiffSym, SymmetricRank2InvDiffMatchesNumeric) {
          "perturbations";
 }
 
-// ── SkewRank2EvenDimInvDiffMatchesNumeric ─────────────────────────────────
-// Annotate X skew (dim 2, even — odd-dim skew is singular and rejected by
-// the inv() factory). Eval and compare to numerical diff perturbing only
-// the skew part.
-TEST(TensorInvDiffSym, SkewRank2EvenDimInvDiffMatchesNumeric) {
+// ── SkewRank2Dim2InvDiffMatchesNumeric ────────────────────────────────────
+// Smallest (and only currently testable) even dim. The evaluator's
+// MaxDim=3 ceiling blocks a dim=4 numerical lock-in that would exercise
+// all 6 free off-diagonal entries of a 4×4 skew (and catch sign-flip /
+// transpose errors in T_swap that 2D can't surface). Tracked: extending
+// MaxDim would let us add the dim=4 case here.
+TEST(TensorInvDiffSym, SkewRank2Dim2InvDiffMatchesNumeric) {
   auto X = make_expression<tensor>("X", std::size_t{2}, std::size_t{2});
   assume_skew(X);
   auto expr = inv(X);
   auto d = diff(expr, X);
   ASSERT_TRUE(d.is_valid()) << "Expected valid derivative for inv(skew X)";
 
-  // 2D skew tensor X = [[0, a], [-a, 0]] with a ≠ 0 is invertible
-  // (det = a²). Build with a away from zero for numerical stability.
   tmech::tensor<double, 2, 2> X_t;
   X_t(0, 0) = 0.0;
   X_t(0, 1) = 2.5;
@@ -114,10 +121,9 @@ TEST(TensorInvDiffSym, SkewRank2EvenDimInvDiffMatchesNumeric) {
 
   auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
       [&](auto const &x) {
-        // Perturb only the skew part; symmetric component is "frozen" at 0
-        // to respect the assume_skew annotation.
         X_ptr->data() = tmech::eval(tmech::skew(x));
-        return as_tmech_invdiff<2, 2>(*ev.apply(expr));
+        auto data = ev.apply(expr);
+        return as_tmech_invdiff<2, 2>(*data);
       },
       X_t);
   X_ptr->data() = X_t;
@@ -125,7 +131,7 @@ TEST(TensorInvDiffSym, SkewRank2EvenDimInvDiffMatchesNumeric) {
   EXPECT_TRUE(
       tmech::almost_equal(as_tmech_invdiff<2, 4>(*result), numdiff, 1e-6))
       << "Skew inv-diff kernel must match num_diff_central with skew "
-         "perturbations";
+         "perturbations (dim=2)";
 }
 
 // ── GeneralRank2InvDiffUnchanged ──────────────────────────────────────────
@@ -159,7 +165,8 @@ TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
   auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
       [&](auto const &x) {
         X_ptr->data() = x;
-        return as_tmech_invdiff<3, 2>(*ev.apply(expr));
+        auto data = ev.apply(expr);
+        return as_tmech_invdiff<3, 2>(*data);
       },
       X_t);
   X_ptr->data() = X_t;
@@ -179,10 +186,83 @@ TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
 TEST(TensorInvDiffSym, SkewRank2OddDimRejectedAtFactory) {
   auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
   assume_skew(X);
-  EXPECT_THROW(
-      { [[maybe_unused]] auto e = inv(X); }, invalid_expression_error)
+  EXPECT_THROW(inv(X), invalid_expression_error)
       << "inv() factory must reject odd-dim skew (singular); diff visitor "
          "should never see this case";
+}
+
+// NOTE — Vol/Dev coverage lives elsewhere:
+//
+// `assume_volumetric(X)` / `assume_deviatoric(X)` set
+// {perm=Symmetric, trace=VolumetricTag/DeviatoricTag}, which `is_symmetric()`
+// recognizes as Sym subspaces. The dispatch correctly routes them through
+// the sym kernel. We don't add a standalone numerical lock-in here because:
+//   1. The numerical-diff approach can't match: symbolic diff w.r.t. a
+//      vol-annotated X returns the P_vol-restricted Jacobian (see
+//      tensor_differentiation.h's tensor_self-diff path which returns
+//      P_vol for Vol inputs), but a numerical sym-perturbation explores
+//      the larger Sym subspace — the two contract differently by design.
+//   2. The dispatch IS covered indirectly by InvDevProjectorDiff in
+//      tests/TensorDifferentiationTest.h (uses inv(dev(X)) where dev(X)'s
+//      space is {Sym, Dev}), which exercises my new branch via the same
+//      is_symmetric() path. That test's 1e-6 pass confirms Vol/Dev
+//      dispatch works.
+//
+// If a future contributor wants a direct Vol/Dev lock-in for this kernel,
+// the right approach is structural (e.g., hash-compare diff(inv(Vol_X), X)
+// against a reference AST) rather than numerical.
+
+// ── PdAnnotationWithClearedSpaceStillRoutesToSymKernel ────────────────────
+// Soundness regression for the dispatch logic: assume_positive_definite
+// writes {Sym, AnyTrace} to space AND inserts positive_definite into the
+// algebra-assumption manager. If a user then calls clear_space(), the
+// space tag is gone but the PD annotation remains. is_symmetric() picks
+// the PD-implies-symmetric path; raw holds_alternative<Symmetric>(perm)
+// would not. This test pins that the dispatch uses the former, so a
+// future change reverting to raw variant checks is caught.
+TEST(TensorInvDiffSym, PdAnnotationWithClearedSpaceStillRoutesToSymKernel) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  assume_positive_definite(X);
+  X.data()->clear_space();
+  ASSERT_FALSE(X.get().space().has_value())
+      << "precondition: space cleared, only algebra-manager PD remains";
+  ASSERT_TRUE(is_symmetric(X))
+      << "precondition: PD ⇒ symmetric via algebra-manager path";
+
+  auto expr = inv(X);
+  auto d = diff(expr, X);
+  ASSERT_TRUE(d.is_valid());
+
+  // Build a PD input numerically.
+  std::mt19937 rng(9001);
+  std::normal_distribution<double> dist(0.0, 1.0);
+  tmech::tensor<double, 3, 2> X_t;
+  for (std::size_t i = 0; i < 9; ++i)
+    X_t.raw_data()[i] = dist(rng);
+  X_t = tmech::eval(tmech::sym(X_t));
+  for (std::size_t i = 0; i < 3; ++i)
+    X_t(i, i) += 10.0;
+  auto X_ptr = std::make_shared<tensor_data<double, 3, 2>>(X_t);
+
+  tensor_evaluator<double> ev;
+  ev.set(X, X_ptr);
+
+  auto result = ev.apply(d);
+  ASSERT_NE(result, nullptr);
+
+  auto numdiff = tmech::num_diff_central<tmech::sequence<1, 2, 3, 4>>(
+      [&](auto const &x) {
+        X_ptr->data() = tmech::eval(tmech::sym(x));
+        auto data = ev.apply(expr);
+        return as_tmech_invdiff<3, 2>(*data);
+      },
+      X_t);
+  X_ptr->data() = X_t;
+
+  EXPECT_TRUE(
+      tmech::almost_equal(as_tmech_invdiff<3, 4>(*result), numdiff, 1e-6))
+      << "PD-with-cleared-space must still route through sym kernel via "
+         "is_symmetric()'s algebra-manager check";
 }
 
 } // namespace numsim::cas

--- a/tests/TensorInvDiffSymTest.h
+++ b/tests/TensorInvDiffSymTest.h
@@ -9,7 +9,6 @@
 
 #include <numsim_cas/core/diff.h>
 #include <numsim_cas/numsim_cas.h>
-#include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
 #include <numsim_cas/tensor/tensor_diff.h>
@@ -179,85 +178,96 @@ TEST(TensorInvDiffSym, GeneralRank2InvDiffUnchanged) {
          "path";
 }
 
-// ── SkewClearedSpaceFallsThroughToMagnus ──────────────────────────────────
+// ── SkewClearedSpaceDispatchFallsThroughToMagnus ──────────────────────────
 // Asymmetry between is_symmetric() and is_skew(): the former consults the
 // algebra-assumption manager for PD/PSD ⇒ symmetric, the latter does NOT
 // (skew has no algebra-manager backing). Consequence: clearing the space
 // on a skew-annotated tensor drops the classification entirely, and the
-// dispatch falls through to general Magnus. Companion to
-// PdAnnotationWithClearedSpaceStillRoutesToSymKernel — together they pin
-// the documented asymmetry so a future refactor that adds skew to the
-// algebra manager would be caught (it would silently switch this test's
-// behavior).
-TEST(TensorInvDiffSym, SkewClearedSpaceFallsThroughToMagnus) {
+// dispatch falls through to general Magnus.
+//
+// Verification uses a *structural* hash comparison between two diff results:
+// one with `assume_skew` still annotated (skew kernel: wraps a tensor_add of
+// T_base ± T_swap times ½), one after `clear_space` (Magnus kernel: just
+// T_base, no swap or scalar_mul). The two AST shapes differ in NODE TYPES,
+// not just coefficients, so the hash distinguishes them (the n_ary_tree
+// coefficient-exclusion rule doesn't affect this comparison).
+TEST(TensorInvDiffSym, SkewClearedSpaceDispatchFallsThroughToMagnus) {
   auto X = make_expression<tensor>("X", std::size_t{2}, std::size_t{2});
   assume_skew(X);
   ASSERT_TRUE(is_skew(X)) << "precondition: skew annotated via space";
+  auto diff_with_skew = diff(inv(X), X);
+  ASSERT_TRUE(diff_with_skew.is_valid());
+
   X.data()->clear_space();
   EXPECT_FALSE(is_skew(X))
       << "is_skew() drops to false because skew has no algebra-manager "
          "fallback (unlike is_symmetric which keeps PD/PSD)";
-  // The dispatch picks general Magnus for the now-unclassified tensor.
-  // The numerical value will differ from the skew kernel for a generic
-  // dA, but for a skew dA the two contract to the same value (proof
-  // mirrors the sym/Magnus equivalence) — so a numerical comparison
-  // wouldn't actually catch the dispatch change. The is_skew() FALSE
-  // above is the load-bearing assertion.
+  auto diff_after_clear = diff(inv(X), X);
+  ASSERT_TRUE(diff_after_clear.is_valid());
+
+  EXPECT_NE(diff_with_skew.get().hash_value(),
+            diff_after_clear.get().hash_value())
+      << "After clearing space the dispatch must fall through to general "
+         "Magnus (no swap term, no ½), yielding a structurally different "
+         "AST from the skew-kernel result above";
 }
 
-// ── SkewRank2Dim4StructuralLockIn ─────────────────────────────────────────
-// Dim=4 skew: the evaluator's MaxDim=3 ceiling blocks numerical validation,
-// but the symbolic dispatch can be locked in structurally. Build the
-// expected diff expression by hand using the same primitives the visitor
-// emits, then compare hashes. A sign-flip or transpose error in T_swap
-// (which dim=2 can't surface — only 1 free off-diagonal entry there) would
-// produce a different hash here.
-TEST(TensorInvDiffSym, SkewRank2Dim4StructuralLockIn) {
-  auto X = make_expression<tensor>("X", std::size_t{4}, std::size_t{2});
-  assume_skew(X);
-  auto expr = inv(X);
-  auto actual = diff(expr, X);
-  ASSERT_TRUE(actual.is_valid());
+// ── VolumetricDispatchTriggersSymKernel ────────────────────────────────────
+// `assume_volumetric(X)` sets {perm=Symmetric, trace=VolumetricTag}.
+// is_symmetric(X) returns true (Vol is a Sym subspace per classify_space),
+// so the dispatch routes through the sym kernel. Local structural lock-in
+// rather than relying on the cross-test NOTE on InvDevProjectorDiff:
+// compare diff(inv(vol_X), X) against diff(inv(unannotated_X), X), assert
+// they differ — the former uses the sym kernel (wraps T_base + T_swap),
+// the latter the bare Magnus kernel. Different AST node hierarchies, so
+// hashes differ.
+TEST(TensorInvDiffSym, VolumetricDispatchTriggersSymKernel) {
+  auto X = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  assume_volumetric(X);
+  ASSERT_TRUE(is_symmetric(X)) << "Vol implies symmetric";
+  auto diff_with_vol = diff(inv(X), X);
+  ASSERT_TRUE(diff_with_vol.is_valid());
 
-  // Hand-built reference using the same formula as the visitor:
-  //   T = ½(otimes(invA,{1,3},invA,{4,2}) - otimes(invA,{1,4},invA,{3,2}))
-  //   result = -inner_product(T, {3,4}, dA, {1,2})
-  // where dA = diff(X, X) = P_skew(4) (the self-diff projector for skew X).
-  auto invA = inv(X);
-  auto T_base = otimes(invA, sequence{1, 3}, invA, sequence{4, 2});
-  auto T_swap = otimes(invA, sequence{1, 4}, invA, sequence{3, 2});
-  auto T_expected = (T_base - T_swap) * get_scalar_half();
-  auto dA_expected = diff(X, X);
-  ASSERT_TRUE(dA_expected.is_valid());
-  auto expected =
-      -inner_product(T_expected, sequence{3, 4}, dA_expected, sequence{1, 2});
+  auto Y = make_expression<tensor>("X", std::size_t{3}, std::size_t{2});
+  // Y has the same name as X so leaf hashes match — the only structural
+  // difference between the two diffs is whether the sym kernel fired.
+  ASSERT_FALSE(is_symmetric(Y));
+  auto diff_unannotated = diff(inv(Y), Y);
+  ASSERT_TRUE(diff_unannotated.is_valid());
 
-  EXPECT_EQ(actual.get().hash_value(), expected.get().hash_value())
-      << "Skew dim=4 diff AST hash must equal the hand-built reference "
-         "expression — catches sign-flip / index-transpose errors in "
-         "T_swap that dim=2 can't expose";
+  EXPECT_NE(diff_with_vol.get().hash_value(),
+            diff_unannotated.get().hash_value())
+      << "Vol-annotated input must produce a different diff AST than the "
+         "unannotated case — the former routes through the sym kernel, "
+         "the latter through Magnus";
 }
 
-// NOTE — Vol/Dev coverage lives elsewhere:
+// LIMITATIONS NOTE — dim=4 sign-flip detection is not currently testable:
 //
-// `assume_volumetric(X)` / `assume_deviatoric(X)` set
-// {perm=Symmetric, trace=VolumetricTag/DeviatoricTag}, which `is_symmetric()`
-// recognizes as Sym subspaces. The dispatch correctly routes them through
-// the sym kernel. We don't add a standalone numerical lock-in here because:
-//   1. The numerical-diff approach can't match: symbolic diff w.r.t. a
-//      vol-annotated X returns the P_vol-restricted Jacobian (see
-//      tensor_differentiation.h's tensor_self-diff path which returns
-//      P_vol for Vol inputs), but a numerical sym-perturbation explores
-//      the larger Sym subspace — the two contract differently by design.
-//   2. The dispatch IS covered indirectly by InvDevProjectorDiff in
-//      tests/TensorDifferentiationTest.h (uses inv(dev(X)) where dev(X)'s
-//      space is {Sym, Dev}), which exercises my new branch via the same
-//      is_symmetric() path. That test's 1e-6 pass confirms Vol/Dev
-//      dispatch works.
+// A naive hash-comparison structural lock-in at dim=4 cannot distinguish
+// the sym kernel (T_base + T_swap)·½ from the skew kernel
+// (T_base − T_swap)·½ because the n_ary_tree hash EXCLUDES coefficients
+// (documented design choice in CLAUDE.md / n_ary_tree.h). And the
+// evaluator's MaxDim=3 ceiling blocks numerical validation at dim=4.
 //
-// If a future contributor wants a direct Vol/Dev lock-in for this kernel,
-// the right approach is structural (e.g., hash-compare diff(inv(Vol_X), X)
-// against a reference AST) rather than numerical.
+// What we DO catch:
+//   - sym vs general (different node hierarchy) — locked in here via
+//     VolumetricDispatchTriggersSymKernel and
+//     SkewClearedSpaceDispatchFallsThroughToMagnus.
+//   - sym kernel correctness at dim=3 — SymmetricRank2InvDiffMatchesNumeric.
+//   - skew kernel sign correctness at dim=2 —
+//   SkewRank2Dim2InvDiffMatchesNumeric
+//     (but only 1 free off-diagonal entry — not a thorough check).
+//
+// What we DON'T catch:
+//   - Sign-flip in T_swap at dim ≥ 4 (sym ↔ skew kernel swap).
+//   - Transpose errors in T_swap's index sequences at dim ≥ 4.
+//
+// Tracked as a separate issue against the codebase: see the open issue
+// for `inner_product_wrapper` not hashing its contraction indices — once
+// the codebase's hash function captures indices and coefficients, the
+// gap above closes. Until then, the math has to be trusted from the
+// derivation in tensor_differentiation.cpp's doc comment.
 
 // ── PdAnnotationWithClearedSpaceStillRoutesToSymKernel ────────────────────
 // Soundness regression for the dispatch logic: assume_positive_definite

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,6 +16,7 @@
 #include "TensorDifferentiationTest.h"
 #include "TensorEvaluatorTest.h"
 #include "TensorExpressionTest.h"
+#include "TensorInvDiffSymTest.h"
 #include "TensorLatexPrinterTest.h"
 #include "TensorPrinterTest.h"
 #include "TensorProjectorDifferentiationTest.h"


### PR DESCRIPTION
## Summary

Branch on `tensor_inv`'s input `space()` in `tensor_differentiation::operator()(tensor_inv)`:

| Algebra class | Kernel `T_{ijmn}` |
|---|---|
| **Symmetric** | `½(A⁻¹_im A⁻¹_nj + A⁻¹_in A⁻¹_mj)` (minor-sym) |
| **Skew** (even-dim only) | `½(A⁻¹_im A⁻¹_nj − A⁻¹_in A⁻¹_mj)` (minor-antisym) |
| **General** (no annotation) | `A⁻¹_im A⁻¹_nj` (Magnus, unchanged) |

Then `dA⁻¹/dX = -T : dA`.

## Why this matters

The previous code used the un-symmetrized Magnus formula unconditionally. Mathematically:
- The Magnus formula and the symmetric kernel **agree numerically when contracted with a symmetric `dA`** (swap-index proof on the cross term). So existing tests using `dev(X)`/`sym(X)` inputs (`InvDevProjectorDiff`, `TransInvDevProjectorDiff`) continue to pass bit-for-bit — verified locally, 1297/1297.
- The branch becomes **load-bearing when callers pass an un-symmetrized `dA` into a symmetric input**, which the previous code silently mis-derived. The symmetric kernel produces the mathematically correct result.

## Audit (regression risk)

Walked every existing inv-diff test in `TensorDifferentiationTest.h`, `TensorProjectorDifferentiationTest.h`, and `TensorEvaluatorTest.h`. All use either:
- Symmetric inputs with sym-perturbation closures (`tmech::sym(x)`) — unchanged numerically per the proof above
- General inputs (no annotation) — fall through to the unchanged Magnus branch

No regressions. Full suite passes 1297/1297.

## Tests (4 new in `TensorInvDiffSymTest.h`)

| Test | Locks in |
|---|---|
| `SymmetricRank2InvDiffMatchesNumeric` | Symmetric kernel matches `tmech::num_diff_central` with `tmech::sym` perturbations on a well-conditioned PD input |
| `SkewRank2EvenDimInvDiffMatchesNumeric` | Skew kernel matches numerical diff with `tmech::skew` perturbations on a 2×2 skew tensor |
| `GeneralRank2InvDiffUnchanged` | Magnus kernel still fires on un-annotated input — regression check for the branch ordering |
| `SkewRank2OddDimRejectedAtFactory` | Contract: `inv()` factory rejects odd-dim skew before the diff visitor sees it |

## Out of scope

- **Rank-4 inv differentiation** — still throws `not_implemented_error`; existing lock-in at `TensorDifferentiationTest:577+`. Tracked by remainder of #250.
- **Volumetric/Deviatoric subspace specializations** — currently fall through to the Symmetric branch (both have `perm = Symmetric`); separate refinement not done in this PR.

## Test plan

- [x] `./build/tests/numsim_cas_test --gtest_filter='TensorInvDiffSym.*'` — 4 pass
- [x] Full suite locally — 1297/1297 pass
- [ ] CI green (Windows, macOS, Linux × Debug/Release × gcc/clang/cl)
- [ ] dco-check green

Closes the rank-2 portion of #250 / #246 β-1.