### PR TITLE
Wire up TODO comments to their tracking issues

### DIFF
--- a/include/numsim_cas/scalar/scalar_make_constant.h
+++ b/include/numsim_cas/scalar/scalar_make_constant.h
@@ -52,7 +52,7 @@ tag_invoke(make_constant_fn, std::type_identity<scalar_expression>, T &&v) {
     if (v == -1)
       return -get_scalar_one();
   }
-  // TODO std::complex support
+  // TODO(#267): std::complex support
   if (v < 0) {
     return -make_expression<scalar_constant>(std::abs(static_cast<V>(v)));
   }

--- a/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
@@ -50,7 +50,7 @@ public:
   pow_pow(expr_holder_t lhs, expr_holder_t rhs);
 
   /// pow(pow(x,a),b) --> pow(x,a*b)
-  /// TODO? pow(pow(x,-a), -b) --> pow(x,-a*b) only when x,a,b>0
+  /// TODO(#268): pow(pow(x,-a), -b) --> pow(x,a*b) only when x,a,b>0
   template <typename Expr> expr_holder_t dispatch(Expr const &);
 
   expr_holder_t dispatch(scalar_negative const &rhs);

--- a/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
@@ -127,7 +127,7 @@ private:
 // dim-4 case is useful inside expressions that ultimately collapse before
 // numerical evaluation — but `tensor_evaluator::apply` on a bare
 // `levi_civita_tensor(4)` will throw. Lifting that ceiling is part of the
-// broader MaxDim-bump effort tracked elsewhere.
+// broader MaxDim-bump effort (#270).
 template <typename ValueType>
 class tensor_data_levi_civita final
     : public tensor_data_eval_up_unary<tensor_data_levi_civita<ValueType>,

--- a/include/numsim_cas/tensor/levi_civita_tensor.h
+++ b/include/numsim_cas/tensor/levi_civita_tensor.h
@@ -48,8 +48,7 @@ namespace numsim::cas {
  * see `tensor_data_levi_civita`'s doxygen for the full reasoning.
  * For dim 4 the eval framework's `MaxDim = 3` ceiling still makes a
  * bare numerical apply throw `evaluation_error`, even though the
- * symbolic construction is allowed — that's a separate limitation
- * tracked outside this node.
+ * symbolic construction is allowed — see #270 for the bump effort.
  *
  * ## Differentiation
  *

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -13,7 +13,7 @@ pow_pow::pow_pow(expr_holder_t lhs, expr_holder_t rhs)
       m_lhs_node{base::m_lhs.template get<scalar_pow>()} {}
 
 /// pow(pow(x,a),b) --> pow(x,a*b)
-/// TODO? pow(pow(x,-a), -b) --> pow(x,-a*b) only when x,a,b>0
+/// TODO(#268): pow(pow(x,-a), -b) --> pow(x,a*b) only when x,a,b>0
 template <typename Expr>
 pow_pow::expr_holder_t pow_pow::dispatch(Expr const &) {
   return pow(m_lhs_node.expr_lhs(), m_lhs_node.expr_rhs() * m_rhs);

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -104,7 +104,8 @@ det(expression_holder<tensor_expression> const &expr) {
   // annotation in this codebase doesn't distinguish proper rotations
   // (det = +1) from improper ones / reflections (det = -1); the
   // common continuum-mechanics use case is proper rotation so we
-  // default to +1. A future `chirality` sub-tag could refine this.
+  // default to +1. TODO(#269): a `chirality` sub-tag could refine this
+  // for callers working with reflections / improper rotations.
   // Closes one half of #246.
   if (is_orthogonal(expr))
     return make_expression<tensor_to_scalar_one>();

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -248,7 +248,7 @@ TEST(TensorAlgebraFold, InvUnannotatedDoesNotFireFold) {
 TEST(TensorAlgebraFold, DetOrthogonalFoldsToOne) {
   // det(R) = 1 for proper rotations (the dominant continuum-mechanics
   // case). The annotation doesn't distinguish improper rotations (det =
-  // -1); a future chirality sub-tag could refine this.
+  // -1); TODO(#269) a chirality sub-tag could refine this.
   auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
   assume_orthogonal(R);
   auto d = det(R);


### PR DESCRIPTION
## Summary

Doc-only follow-up to issues [#267](https://github.com/NumSim-Stack/numsim-cas/issues/267)–[#270](https://github.com/NumSim-Stack/numsim-cas/issues/270): each in-source \`TODO\` / "future" / "tracked elsewhere" comment now references its GitHub issue. A future grep('TODO') surfaces the linked issue number directly instead of leaving the reader to figure out whether the work is tracked.

## Wire-up table

| File | Was | Now |
|---|---|---|
| \`scalar_make_constant.h:55\` | \`TODO std::complex support\` | \`TODO(#267)\` |
| \`scalar_simplifier_pow.h:53\` | \`TODO? pow(pow(x,-a),-b)…\` | \`TODO(#268)\` (also fixed typo \`-a*b\` → \`a*b\`) |
| \`scalar_simplifier_pow.cpp:16\` | (same) | \`TODO(#268)\` |
| \`tensor_to_scalar_functions.cpp:107\` | \`A future chirality sub-tag could refine this\` | \`TODO(#269)\` |
| \`TensorAlgebraAssumeTest.h:251\` | (same wording, test side) | \`TODO(#269)\` |
| \`tensor_data_unary_wrapper.h:130\` | \`broader MaxDim-bump effort tracked elsewhere\` | \`(#270)\` |
| \`levi_civita_tensor.h:49+\` | \`separate limitation tracked outside this node\` | \`see #270\` |

## Test plan

- [x] Local build clean
- [x] Full test suite: 1293/1293 pass (no behavior change)
- [ ] CI green

Doc-only; no functional change.