### PR TITLE
Close #305: scalar mul/pow/neg propagate positivity through compositions

### DIFF
--- a/include/numsim_cas/scalar/scalar_operators.h
+++ b/include/numsim_cas/scalar/scalar_operators.h
@@ -13,6 +13,7 @@
 #include <numsim_cas/scalar/scalar_functions_fwd.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_negative.h>
+#include <numsim_cas/scalar/scalar_positivity_propagation.h>
 
 #include <numsim_cas/scalar/simplifier/scalar_simplifier_add.h>
 #include <numsim_cas/scalar/simplifier/scalar_simplifier_mul.h>
@@ -70,9 +71,16 @@ requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<scalar_expression>>
 inline expression_holder<scalar_expression> tag_invoke(mul_fn, L &&lhs,
                                                        R &&rhs) {
+  // #305 — capture operand sign views BEFORE forwarding (the visitor
+  // may consume L/R as rvalues). Same shape as the t2s mul wiring.
+  const auto lhs_view = scalar_detail::positivity::read(lhs);
+  const auto rhs_view = scalar_detail::positivity::read(rhs);
   auto &_lhs{lhs.template get<scalar_visitable_t>()};
   simplifier::mul_base visitor(std::forward<L>(lhs), std::forward<R>(rhs));
-  return _lhs.accept(visitor);
+  auto result = _lhs.accept(visitor);
+  scalar_detail::positivity::propagate_mul_from_views(lhs_view, rhs_view,
+                                                      result);
+  return result;
 }
 
 template <class L, class R>
@@ -104,8 +112,27 @@ inline expression_holder<scalar_expression> tag_invoke(div_fn, L &&lhs,
   // General: x / y → x * y^(-1)
   // Use binary_scalar_pow_simplify to bypass pow() constant folding
   // so that pow(c, -1) stays structural and the printer formats as x/c.
-  return std::forward<L>(lhs) *
-         binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
+  // #305 — apply pow propagation manually on the simplify result
+  // before the mul, since we bypassed the main pow() wrapper. The
+  // subsequent `lhs * ...` mul DOES run propagation via the mul
+  // operator's instrumentation.
+  const auto rhs_view = scalar_detail::positivity::read(rhs);
+  const auto neg_one_view =
+      scalar_detail::positivity::read(get_scalar_one()); // exp = -1
+  auto pow_result =
+      binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
+  // exp view above was on +1; the actual exponent is -1, which is a
+  // numeric constant (real-by-construction) — open-code the real
+  // bit since we can't construct a view directly.
+  scalar_detail::positivity::view exp_view{};
+  exp_view.real = true; // numeric constant
+  exp_view.negative = true;
+  exp_view.nonpositive = true;
+  exp_view.nonzero = true;
+  (void)neg_one_view;
+  scalar_detail::positivity::propagate_pow_from_views(rhs_view, exp_view,
+                                                      pow_result);
+  return std::forward<L>(lhs) * std::move(pow_result);
 }
 
 } // namespace numsim::cas::detail

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -1,0 +1,179 @@
+#ifndef SCALAR_POSITIVITY_PROPAGATION_H
+#define SCALAR_POSITIVITY_PROPAGATION_H
+
+#include <cassert>
+
+#include <numsim_cas/core/assumptions.h>
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/scalar/scalar_constant.h>
+#include <numsim_cas/scalar/scalar_expression.h>
+#include <numsim_cas/scalar/scalar_negative.h>
+#include <numsim_cas/scalar/scalar_one.h>
+#include <numsim_cas/scalar/scalar_zero.h>
+// Intentionally NOT including scalar_domain_traits.h — it transitively
+// pulls in scalar_std.h via scalar_all.h, which creates a cycle (since
+// scalar_std.h includes this header). Open-code the "is real-by-
+// construction numeric constant" check using the structural is_same
+// predicates instead.
+
+// #305 — positivity-tag propagation for scalar operators (mul, neg, pow).
+//
+// Direct parallel of `tensor_to_scalar_positivity_propagation.h` (#260).
+// Same rule table, same aliasing-mutation contract, same defense-in-depth
+// asserts. The only structural difference: scalar has no wrapper-bridge
+// node, so `read()` doesn't need the scalar_wrapper-forwarding branch.
+//
+// When #305 and #260 are both green, the obvious refactor is to lift
+// both into a templated `<Domain>` header. Deferred to #262 (cross-
+// domain unification) to keep this PR focused.
+
+namespace numsim::cas::scalar_detail::positivity {
+
+// Tag-state view. NOTE: these are tag-manager predicates, not truth
+// predicates — a caller writing incoherent tags defeats inference.
+struct view {
+  bool positive;
+  bool nonnegative;
+  bool nonpositive;
+  bool negative;
+  bool nonzero;
+  bool real;
+
+  bool at_least_nonneg_tag() const { return positive || nonnegative; }
+  bool at_least_nonpos_tag() const { return negative || nonpositive; }
+};
+
+inline view read(expression_holder<scalar_expression> const &e) {
+  // Scalar differentiation produces transient invalid holders during
+  // chain-rule decomposition (a known #287-tracked corner). Guard so
+  // a `read(invalid)` returns the all-false view rather than crashing
+  // in numeric_assumption_manager::contains via a null data pointer.
+  if (!e.is_valid())
+    return {};
+  auto const &a = e.data()->assumptions();
+  view v{a.contains(numsim::cas::positive{}),
+         a.contains(numsim::cas::nonnegative{}),
+         a.contains(numsim::cas::nonpositive{}),
+         a.contains(numsim::cas::negative{}),
+         a.contains(numsim::cas::nonzero{}),
+         a.contains(numsim::cas::real_tag{}) ||
+             a.contains(numsim::cas::integer{}) ||
+             a.contains(numsim::cas::rational{}) ||
+             a.contains(numsim::cas::irrational{})};
+  // Concrete numeric constants are real by construction. See the t2s
+  // header's same-shape note (#261 tracks the broader fix of pre-
+  // annotating constant nodes; this branch avoids waiting on it).
+  // Open-coded structural check mirroring domain_traits::try_numeric
+  // (we can't include scalar_domain_traits.h here due to the
+  // scalar_std.h cycle — domain_traits includes scalar_all → scalar_std,
+  // and scalar_std includes this header).
+  if (!v.real) {
+    if (is_same<scalar_zero>(e) || is_same<scalar_one>(e) ||
+        is_same<scalar_constant>(e))
+      v.real = true;
+    else if (is_same<scalar_negative>(e)) {
+      auto const &inner = e.template get<scalar_negative>().expr();
+      if (is_same<scalar_zero>(inner) || is_same<scalar_one>(inner) ||
+          is_same<scalar_constant>(inner))
+        v.real = true;
+    }
+  }
+  return v;
+}
+
+// Defense-in-depth: catches a future rule that would insert a tag
+// contradicting the operand's existing state. Aliasing makes this
+// critical — if `result` shares its node with an operand (via a fold
+// returning the operand directly), the insertion mutates the operand.
+#ifndef NDEBUG
+#define NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)    \
+  do {                                                                         \
+    assert(!(manager).contains(banned_tag) &&                                  \
+           "scalar positivity_propagation: rule would set a tag "              \
+           "contradicting the operand's existing state");                      \
+  } while (0)
+#else
+#define NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)    \
+  ((void)0)
+#endif
+
+inline void mark_positive(expression_holder<scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonpositive{});
+  a.insert(numsim::cas::positive{});
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void mark_negative(expression_holder<scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonnegative{});
+  a.insert(numsim::cas::negative{});
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void mark_nonnegative(expression_holder<scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void mark_nonpositive(expression_holder<scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg. ORDER MATTERS.
+inline void
+propagate_mul_from_views(view lhs, view rhs,
+                         expression_holder<scalar_expression> const &result) {
+  if (lhs.positive && rhs.positive) {
+    mark_positive(result);
+  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives
+// in the cpp file and bypasses this path. The -neg / -nonpos branches
+// are kept for future-symmetry with sign-aware mul (out of scope).
+inline void
+propagate_neg_from_view(view operand,
+                        expression_holder<scalar_expression> const &result) {
+  if (operand.positive) {
+    mark_negative(result);
+  } else if (operand.at_least_nonneg_tag()) {
+    mark_nonpositive(result);
+  } else if (operand.negative) {
+    mark_positive(result);
+  } else if (operand.at_least_nonpos_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
+// ORDER MATTERS.
+inline void
+propagate_pow_from_views(view base, view exponent,
+                         expression_holder<scalar_expression> const &result) {
+  if (base.positive && exponent.real) {
+    mark_positive(result);
+    return;
+  }
+  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+} // namespace numsim::cas::scalar_detail::positivity
+
+#endif // SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -32,6 +32,7 @@
 #include <numsim_cas/scalar/scalar_ne.h>
 #include <numsim_cas/scalar/scalar_negative.h>
 #include <numsim_cas/scalar/scalar_one.h>
+#include <numsim_cas/scalar/scalar_positivity_propagation.h>
 #include <numsim_cas/scalar/scalar_power.h>
 #include <numsim_cas/scalar/scalar_sign.h>
 #include <numsim_cas/scalar/scalar_sin.h>
@@ -108,8 +109,14 @@ template <scalar_expr_holder L, scalar_expr_holder R>
     }
   }
 
-  return binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
-                                    std::forward<R>(expr_rhs));
+  // #305 — capture sign views BEFORE forwarding to the simplifier.
+  const auto base_view = scalar_detail::positivity::read(expr_lhs);
+  const auto exp_view = scalar_detail::positivity::read(expr_rhs);
+  auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
+                                           std::forward<R>(expr_rhs));
+  scalar_detail::positivity::propagate_pow_from_views(base_view, exp_view,
+                                                      result);
+  return result;
 }
 
 template <scalar_expr_holder L, typename R>
@@ -118,8 +125,17 @@ requires std::is_arithmetic_v<std::remove_cvref_t<R>>
   auto constant{detail::tag_invoke(detail::make_constant_fn{},
                                    std::type_identity<scalar_expression>{},
                                    expr_rhs)};
-  return binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
-                                    std::move(constant));
+  // #305 — apply pow propagation. The arithmetic overload calls
+  // binary_scalar_pow_simplify directly (rather than routing
+  // through the main pow above) to avoid the special-case folds,
+  // so propagation needs to be applied here too.
+  const auto base_view = scalar_detail::positivity::read(expr_lhs);
+  const auto exp_view = scalar_detail::positivity::read(constant);
+  auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
+                                           std::move(constant));
+  scalar_detail::positivity::propagate_pow_from_views(base_view, exp_view,
+                                                      result);
+  return result;
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto sin(E &&e) {

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
@@ -15,6 +15,7 @@
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.h>
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_pow.h>
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_sub.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h>
 
 namespace numsim::cas::detail {
@@ -98,10 +99,18 @@ requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<tensor_to_scalar_expression>>
 inline expression_holder<tensor_to_scalar_expression>
 tag_invoke(mul_fn, [[maybe_unused]] L &&lhs, [[maybe_unused]] R &&rhs) {
+  // #260 — read operand positivity BEFORE forwarding (the visitor may
+  // consume L/R as rvalues). Idempotent insertion afterwards lets a
+  // folded result that already carries the tag pass through unchanged.
+  const auto lhs_view = tensor_to_scalar_detail::positivity::read(lhs);
+  const auto rhs_view = tensor_to_scalar_detail::positivity::read(rhs);
   auto &_lhs{lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                                         std::forward<R>(rhs));
-  return _lhs.accept(visitor);
+  auto result = _lhs.accept(visitor);
+  tensor_to_scalar_detail::positivity::propagate_mul_from_views(
+      lhs_view, rhs_view, result);
+  return result;
 }
 
 template <class L, class R>

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -9,46 +9,85 @@
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
 
 // #260 — positivity-tag propagation for t2s operators (mul, neg, pow).
+//
 // Each operator captures a `view` of its operand assumptions BEFORE
 // forwarding into the simplifier (which may consume the holder as an
 // rvalue), then applies the matching propagation rule to the result
-// holder. The result holder's assumption manager is shared via
-// shared_ptr, so the insertions are visible to all references.
+// holder. Joint insertions mirror scalar_assume.h's pattern: a
+// `positive` insertion also writes nonnegative + nonzero + real_tag.
+// set_inferred() marks them as established facts (forward-compat with
+// the planned assumption propagator).
 //
-// Joint insertions mirror scalar_assume.h's pattern: a `positive`
-// insertion also writes nonnegative + nonzero + real_tag, etc.
-// set_inferred() at the end marks them as established facts —
-// forward-compat for the assumption propagator (#246 broader fix).
+// ── Aliasing contract ───────────────────────────────────────────
+//
+// `result` may alias one of the operand holders. The simplifier is
+// allowed to fold (e.g. `x * 1 → x`) and return the operand's own
+// holder; in that case `result.data()` is the operand's node and
+// inserting into `result.data()->assumptions()` mutates the operand.
+//
+// All rules here are designed so this mutation is sound — they only
+// fire when the inferred tags are already implied by the operand's
+// state. e.g. `mark_positive(x)` after `propagate_mul(x_pos, 1_pos)`
+// when the fold returned x is safe because x was already positive.
+//
+// If you add a new rule, preserve this invariant: a rule that fires
+// on operand views V_lhs, V_rhs must produce a result tag that is a
+// logical consequence of V_lhs ∧ V_rhs — never strictly stronger than
+// any single operand's existing state.
+//
+// ── Robustness to direct-manager callers ────────────────────────
+//
+// Reading code that mixed `pos·nonneg → nonneg` is implemented as
+// `(pos || nonneg) && (pos || nonneg) → nonneg`. This handles the
+// case where a caller used the lower-level
+// `manager.insert(positive{})` without going through the joint-
+// insertion helpers — `positive{}` is then present without
+// `nonnegative{}`. Same shape for the pow "exponent is real" guard:
+// `real_tag || any sign tag || integer || rational || try_numeric()`.
 
 namespace numsim::cas::tensor_to_scalar_detail::positivity {
 
+// Single struct holds all the assumption bits we read off an operand.
+// Folded `view + bool real` into one type — there were two only because
+// I introduced them separately during the initial draft.
 struct view {
   bool positive;
   bool nonnegative;
   bool nonpositive;
   bool negative;
   bool nonzero;
-};
+  bool real; // real_tag OR integer/rational tag OR known numeric
 
-struct view_with_real {
-  view sign;
-  bool real;
+  // Convenience: "at least nonnegative" handles the brittle case where
+  // a caller inserted `positive{}` alone (no joint `nonnegative{}`).
+  bool is_at_least_nonneg() const { return positive || nonnegative; }
+  bool is_at_least_nonpos() const { return negative || nonpositive; }
 };
 
 // Read sign tags from the t2s expression's assumption manager. If the
 // expression is a `tensor_to_scalar_scalar_wrapper` (the bridge from
 // the scalar domain into t2s), ALSO read the wrapped scalar's tags —
 // the wrapper's own manager is fresh at construction and doesn't
-// inherit from the scalar's. Without this transparency, a wrapped
-// `pow(α, 3)` for positive α would lose its `positive` tag at the
-// wrapper boundary, and the t2s mul rule below couldn't see it.
+// inherit from the scalar's. Forwarding is single-level: we don't
+// recurse through nested wrappers (the wrapper today wraps a
+// scalar_expression, never another t2s, so single-level is exhaustive).
+//
+// `real_tag` is treated permissively: real_tag itself, any sign tag
+// (which joint-inserts real_tag in the normal path), the discrete-
+// number tags (integer, rational), and concrete numeric constants
+// (try_numeric success) all count as "real". This avoids waiting on
+// #261 (constants pre-annotation) for the common `pow(x, integer)`
+// case.
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   auto const &a = e.data()->assumptions();
   view v{a.contains(numsim::cas::positive{}),
          a.contains(numsim::cas::nonnegative{}),
          a.contains(numsim::cas::nonpositive{}),
          a.contains(numsim::cas::negative{}),
-         a.contains(numsim::cas::nonzero{})};
+         a.contains(numsim::cas::nonzero{}),
+         a.contains(numsim::cas::real_tag{}) ||
+             a.contains(numsim::cas::integer{}) ||
+             a.contains(numsim::cas::rational{})};
   if (is_same<tensor_to_scalar_scalar_wrapper>(e)) {
     auto const &inner =
         e.template get<tensor_to_scalar_scalar_wrapper>().expr();
@@ -58,32 +97,21 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
     v.nonpositive = v.nonpositive || ia.contains(numsim::cas::nonpositive{});
     v.negative = v.negative || ia.contains(numsim::cas::negative{});
     v.nonzero = v.nonzero || ia.contains(numsim::cas::nonzero{});
-  }
-  return v;
-}
-
-inline view_with_real
-read_with_real(expression_holder<tensor_to_scalar_expression> const &e) {
-  bool real = e.data()->assumptions().contains(numsim::cas::real_tag{});
-  if (!real && is_same<tensor_to_scalar_scalar_wrapper>(e)) {
-    auto const &inner =
-        e.template get<tensor_to_scalar_scalar_wrapper>().expr();
-    real = inner.data()->assumptions().contains(numsim::cas::real_tag{});
+    v.real = v.real || ia.contains(numsim::cas::real_tag{}) ||
+             ia.contains(numsim::cas::integer{}) ||
+             ia.contains(numsim::cas::rational{});
   }
   // Concrete numeric constants are real by construction — they evaluate
-  // to a `scalar_number` (double under the hood today, no complex path
-  // in t2s). Without this branch a pow-exponent like
-  // `-get_scalar_one()` would fail the real-exponent guard since
-  // numeric constants don't carry the real_tag annotation today (#261
-  // tracks that broader pre-annotation). Treating try_numeric()
-  // success as real_tag avoids waiting on #261 for the common case
-  // and is correct: a stored numeric is real by definition.
-  if (!real) {
+  // to a `scalar_number` (double under the hood today; no complex path
+  // in t2s). Treating try_numeric() success as real_tag avoids waiting
+  // on #261 (pre-annotating tensor_to_scalar_one/zero/scalar_constant)
+  // for the common `pow(x, integer)` exponent case.
+  if (!v.real) {
     using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
     if (traits::try_numeric(e))
-      real = true;
+      v.real = true;
   }
-  return {read(e), real};
+  return v;
 }
 
 inline void
@@ -119,53 +147,53 @@ mark_nonpositive(expression_holder<tensor_to_scalar_expression> const &e) {
   a.set_inferred();
 }
 
-// Mul: pos·pos → pos, (any nonneg combo) → nonneg.
-// Sign-aware rules (neg·neg → pos etc.) are out of scope per #260.
+// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg.
+// Sign-aware rules (neg·neg → pos, pos·neg → neg) are out of scope
+// per #260's "narrow scope here to mul/div/pow/neg first".
 inline void propagate_mul_from_views(
     view lhs, view rhs,
     expression_holder<tensor_to_scalar_expression> const &result) {
   if (lhs.positive && rhs.positive) {
     mark_positive(result);
-  } else if (lhs.nonnegative && rhs.nonnegative) {
-    // (pos·nonneg) and (nonneg·pos) are subsumed because positive
-    // implies nonnegative.
+  } else if (lhs.is_at_least_nonneg() && rhs.is_at_least_nonneg()) {
+    // Subsumes (pos·nonneg) and (nonneg·pos). Robust to direct-
+    // manager callers who set `positive{}` without `nonnegative{}`.
     mark_nonnegative(result);
   }
 }
 
-// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives in
-// the cpp file and bypasses this path entirely.
+// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives
+// in the cpp file and bypasses this path; the -neg/-nonpos branches
+// below are defensive — they fire if a future code path produces a
+// non-tensor_to_scalar_negative node carrying negative/nonpositive
+// (e.g. via assumption propagation from a different operator that
+// concludes a negative result without wrapping in tensor_negative).
 inline void propagate_neg_from_view(
     view operand,
     expression_holder<tensor_to_scalar_expression> const &result) {
   if (operand.positive) {
     mark_negative(result);
-  } else if (operand.nonnegative) {
+  } else if (operand.is_at_least_nonneg()) {
     mark_nonpositive(result);
   } else if (operand.negative) {
     mark_positive(result);
-  } else if (operand.nonpositive) {
+  } else if (operand.is_at_least_nonpos()) {
     mark_nonnegative(result);
   }
 }
 
-// Pow: pow(pos, real) → pos; pow(nonneg, nonneg) → nonneg. The "real
-// exponent" guard prevents a complex exponent from silently inheriting
-// positivity. The strict pow(neg, even-int) → pos rule is deferred
-// (#260 scope-out).
+// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
+// The "real exponent" guard prevents a complex exponent from silently
+// inheriting positivity. The strict pow(neg, even-int) → pos rule is
+// deferred (#260 scope-out).
 inline void propagate_pow_from_views(
-    view_with_real base, view_with_real exponent,
+    view base, view exponent,
     expression_holder<tensor_to_scalar_expression> const &result) {
-  // An exponent is "real" if real_tag is set OR if any of the sign
-  // tags is set (those joint-insert real_tag too).
-  const bool exponent_is_real =
-      exponent.real || exponent.sign.positive || exponent.sign.negative ||
-      exponent.sign.nonnegative || exponent.sign.nonpositive;
-  if (base.sign.positive && exponent_is_real) {
+  if (base.positive && exponent.real) {
     mark_positive(result);
     return;
   }
-  if (base.sign.nonnegative && exponent.sign.nonnegative) {
+  if (base.is_at_least_nonneg() && exponent.is_at_least_nonneg()) {
     mark_nonnegative(result);
   }
 }

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -1,6 +1,8 @@
 #ifndef TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
 #define TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
 
+#include <cassert>
+
 #include <numsim_cas/core/assumptions.h>
 #include <numsim_cas/core/expression_holder.h>
 #include <numsim_cas/scalar/scalar_expression.h>
@@ -123,9 +125,33 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   return v;
 }
 
+// Defense-in-depth assertion macro. Catches a rule that would insert
+// a tag contradicting the operand's existing state — e.g. a
+// hypothetical incorrect `(neg, neg) → pos` rule firing on a manager
+// that already contains `negative{}`. Aliasing makes this critical:
+// if the result holder shares its node with an operand (via a fold
+// returning the operand), the insertion mutates the operand, and a
+// wrong rule corrupts the operand's tags.
+//
+// The check is a debug-only `assert` (compiled out under NDEBUG) —
+// rules in this header are intended to be statically correct, so the
+// assertions are for future contributors who add rules.
+#ifndef NDEBUG
+#define NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)           \
+  do {                                                                         \
+    assert(!(manager).contains(banned_tag) &&                                  \
+           "positivity_propagation: rule would set a tag contradicting "       \
+           "the operand's existing state");                                    \
+  } while (0)
+#else
+#define NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag) ((void)0)
+#endif
+
 inline void
 mark_positive(expression_holder<tensor_to_scalar_expression> const &e) {
   auto &a = e.data()->assumptions();
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonpositive{});
   a.insert(numsim::cas::positive{});
   a.insert(numsim::cas::nonnegative{});
   a.insert(numsim::cas::nonzero{});
@@ -135,6 +161,8 @@ mark_positive(expression_holder<tensor_to_scalar_expression> const &e) {
 inline void
 mark_negative(expression_holder<tensor_to_scalar_expression> const &e) {
   auto &a = e.data()->assumptions();
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonnegative{});
   a.insert(numsim::cas::negative{});
   a.insert(numsim::cas::nonpositive{});
   a.insert(numsim::cas::nonzero{});
@@ -144,6 +172,7 @@ mark_negative(expression_holder<tensor_to_scalar_expression> const &e) {
 inline void
 mark_nonnegative(expression_holder<tensor_to_scalar_expression> const &e) {
   auto &a = e.data()->assumptions();
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
   a.insert(numsim::cas::nonnegative{});
   a.insert(numsim::cas::real_tag{});
   a.set_inferred();
@@ -151,6 +180,7 @@ mark_nonnegative(expression_holder<tensor_to_scalar_expression> const &e) {
 inline void
 mark_nonpositive(expression_holder<tensor_to_scalar_expression> const &e) {
   auto &a = e.data()->assumptions();
+  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
   a.insert(numsim::cas::nonpositive{});
   a.insert(numsim::cas::real_tag{});
   a.set_inferred();

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -1,0 +1,175 @@
+#ifndef TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
+#define TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
+
+#include <numsim_cas/core/assumptions.h>
+#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/scalar/scalar_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_domain_traits.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
+
+// #260 — positivity-tag propagation for t2s operators (mul, neg, pow).
+// Each operator captures a `view` of its operand assumptions BEFORE
+// forwarding into the simplifier (which may consume the holder as an
+// rvalue), then applies the matching propagation rule to the result
+// holder. The result holder's assumption manager is shared via
+// shared_ptr, so the insertions are visible to all references.
+//
+// Joint insertions mirror scalar_assume.h's pattern: a `positive`
+// insertion also writes nonnegative + nonzero + real_tag, etc.
+// set_inferred() at the end marks them as established facts —
+// forward-compat for the assumption propagator (#246 broader fix).
+
+namespace numsim::cas::tensor_to_scalar_detail::positivity {
+
+struct view {
+  bool positive;
+  bool nonnegative;
+  bool nonpositive;
+  bool negative;
+  bool nonzero;
+};
+
+struct view_with_real {
+  view sign;
+  bool real;
+};
+
+// Read sign tags from the t2s expression's assumption manager. If the
+// expression is a `tensor_to_scalar_scalar_wrapper` (the bridge from
+// the scalar domain into t2s), ALSO read the wrapped scalar's tags —
+// the wrapper's own manager is fresh at construction and doesn't
+// inherit from the scalar's. Without this transparency, a wrapped
+// `pow(α, 3)` for positive α would lose its `positive` tag at the
+// wrapper boundary, and the t2s mul rule below couldn't see it.
+inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
+  auto const &a = e.data()->assumptions();
+  view v{a.contains(numsim::cas::positive{}),
+         a.contains(numsim::cas::nonnegative{}),
+         a.contains(numsim::cas::nonpositive{}),
+         a.contains(numsim::cas::negative{}),
+         a.contains(numsim::cas::nonzero{})};
+  if (is_same<tensor_to_scalar_scalar_wrapper>(e)) {
+    auto const &inner =
+        e.template get<tensor_to_scalar_scalar_wrapper>().expr();
+    auto const &ia = inner.data()->assumptions();
+    v.positive = v.positive || ia.contains(numsim::cas::positive{});
+    v.nonnegative = v.nonnegative || ia.contains(numsim::cas::nonnegative{});
+    v.nonpositive = v.nonpositive || ia.contains(numsim::cas::nonpositive{});
+    v.negative = v.negative || ia.contains(numsim::cas::negative{});
+    v.nonzero = v.nonzero || ia.contains(numsim::cas::nonzero{});
+  }
+  return v;
+}
+
+inline view_with_real
+read_with_real(expression_holder<tensor_to_scalar_expression> const &e) {
+  bool real = e.data()->assumptions().contains(numsim::cas::real_tag{});
+  if (!real && is_same<tensor_to_scalar_scalar_wrapper>(e)) {
+    auto const &inner =
+        e.template get<tensor_to_scalar_scalar_wrapper>().expr();
+    real = inner.data()->assumptions().contains(numsim::cas::real_tag{});
+  }
+  // Concrete numeric constants are real by construction — they evaluate
+  // to a `scalar_number` (double under the hood today, no complex path
+  // in t2s). Without this branch a pow-exponent like
+  // `-get_scalar_one()` would fail the real-exponent guard since
+  // numeric constants don't carry the real_tag annotation today (#261
+  // tracks that broader pre-annotation). Treating try_numeric()
+  // success as real_tag avoids waiting on #261 for the common case
+  // and is correct: a stored numeric is real by definition.
+  if (!real) {
+    using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
+    if (traits::try_numeric(e))
+      real = true;
+  }
+  return {read(e), real};
+}
+
+inline void
+mark_positive(expression_holder<tensor_to_scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  a.insert(numsim::cas::positive{});
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void
+mark_negative(expression_holder<tensor_to_scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  a.insert(numsim::cas::negative{});
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void
+mark_nonnegative(expression_holder<tensor_to_scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+inline void
+mark_nonpositive(expression_holder<tensor_to_scalar_expression> const &e) {
+  auto &a = e.data()->assumptions();
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+// Mul: pos·pos → pos, (any nonneg combo) → nonneg.
+// Sign-aware rules (neg·neg → pos etc.) are out of scope per #260.
+inline void propagate_mul_from_views(
+    view lhs, view rhs,
+    expression_holder<tensor_to_scalar_expression> const &result) {
+  if (lhs.positive && rhs.positive) {
+    mark_positive(result);
+  } else if (lhs.nonnegative && rhs.nonnegative) {
+    // (pos·nonneg) and (nonneg·pos) are subsumed because positive
+    // implies nonnegative.
+    mark_nonnegative(result);
+  }
+}
+
+// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives in
+// the cpp file and bypasses this path entirely.
+inline void propagate_neg_from_view(
+    view operand,
+    expression_holder<tensor_to_scalar_expression> const &result) {
+  if (operand.positive) {
+    mark_negative(result);
+  } else if (operand.nonnegative) {
+    mark_nonpositive(result);
+  } else if (operand.negative) {
+    mark_positive(result);
+  } else if (operand.nonpositive) {
+    mark_nonnegative(result);
+  }
+}
+
+// Pow: pow(pos, real) → pos; pow(nonneg, nonneg) → nonneg. The "real
+// exponent" guard prevents a complex exponent from silently inheriting
+// positivity. The strict pow(neg, even-int) → pos rule is deferred
+// (#260 scope-out).
+inline void propagate_pow_from_views(
+    view_with_real base, view_with_real exponent,
+    expression_holder<tensor_to_scalar_expression> const &result) {
+  // An exponent is "real" if real_tag is set OR if any of the sign
+  // tags is set (those joint-insert real_tag too).
+  const bool exponent_is_real =
+      exponent.real || exponent.sign.positive || exponent.sign.negative ||
+      exponent.sign.nonnegative || exponent.sign.nonpositive;
+  if (base.sign.positive && exponent_is_real) {
+    mark_positive(result);
+    return;
+  }
+  if (base.sign.nonnegative && exponent.sign.nonnegative) {
+    mark_nonnegative(result);
+  }
+}
+
+} // namespace numsim::cas::tensor_to_scalar_detail::positivity
+
+#endif // TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -88,6 +88,14 @@ struct view {
 // #261 (constants pre-annotation) for the common `pow(x, integer)`
 // case.
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
+  // Guard against invalid holders. Differentiation paths can produce
+  // transient invalid intermediates (corner cases of the chain rule —
+  // see #287); a read() on those would null-deref through
+  // numeric_assumption_manager::contains. The scalar side surfaced
+  // this on FuzzyScalarDiff seed 35; same latent UB on the t2s side
+  // so we patch symmetrically.
+  if (!e.is_valid())
+    return {};
   auto const &a = e.data()->assumptions();
   view v{a.contains(numsim::cas::positive{}),
          a.contains(numsim::cas::nonnegative{}),

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -48,20 +48,27 @@
 namespace numsim::cas::tensor_to_scalar_detail::positivity {
 
 // Single struct holds all the assumption bits we read off an operand.
-// Folded `view + bool real` into one type — there were two only because
-// I introduced them separately during the initial draft.
+//
+// NOTE: these are tag-state predicates, not truth predicates. A "true"
+// for `positive` means the manager contains `positive{}`, which IS the
+// closest tractable proxy for "the value is positive" given how the
+// codebase represents assumptions today — but a caller who mutates the
+// manager into an incoherent state (e.g. inserts both `positive{}` and
+// `nonpositive{}`) would defeat any inference here.
 struct view {
   bool positive;
   bool nonnegative;
   bool nonpositive;
   bool negative;
   bool nonzero;
-  bool real; // real_tag OR integer/rational tag OR known numeric
+  bool real; // real_tag OR integer/rational/irrational OR known numeric
 
-  // Convenience: "at least nonnegative" handles the brittle case where
-  // a caller inserted `positive{}` alone (no joint `nonnegative{}`).
-  bool is_at_least_nonneg() const { return positive || nonnegative; }
-  bool is_at_least_nonpos() const { return negative || nonpositive; }
+  // "At least nonneg" via TAG state: the operand carries either
+  // `positive{}` or `nonnegative{}`. Robust to direct-manager callers
+  // who set `positive{}` without the joint `nonnegative{}`. The "tag"
+  // suffix is intentional — distinguishes from the truth claim.
+  bool at_least_nonneg_tag() const { return positive || nonnegative; }
+  bool at_least_nonpos_tag() const { return negative || nonpositive; }
 };
 
 // Read sign tags from the t2s expression's assumption manager. If the
@@ -87,7 +94,8 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
          a.contains(numsim::cas::nonzero{}),
          a.contains(numsim::cas::real_tag{}) ||
              a.contains(numsim::cas::integer{}) ||
-             a.contains(numsim::cas::rational{})};
+             a.contains(numsim::cas::rational{}) ||
+             a.contains(numsim::cas::irrational{})};
   if (is_same<tensor_to_scalar_scalar_wrapper>(e)) {
     auto const &inner =
         e.template get<tensor_to_scalar_scalar_wrapper>().expr();
@@ -99,7 +107,8 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
     v.nonzero = v.nonzero || ia.contains(numsim::cas::nonzero{});
     v.real = v.real || ia.contains(numsim::cas::real_tag{}) ||
              ia.contains(numsim::cas::integer{}) ||
-             ia.contains(numsim::cas::rational{});
+             ia.contains(numsim::cas::rational{}) ||
+             ia.contains(numsim::cas::irrational{});
   }
   // Concrete numeric constants are real by construction — they evaluate
   // to a `scalar_number` (double under the hood today; no complex path
@@ -148,44 +157,62 @@ mark_nonpositive(expression_holder<tensor_to_scalar_expression> const &e) {
 }
 
 // Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg.
+//
 // Sign-aware rules (neg·neg → pos, pos·neg → neg) are out of scope
 // per #260's "narrow scope here to mul/div/pow/neg first".
+//
+// ORDER MATTERS: stronger before weaker. The `pos·pos → pos` branch
+// must run first; swapping with the `at_least_nonneg_tag` branch
+// would collapse `pos·pos` to `nonneg` (still correct, but weaker
+// than necessary — and `nonzero` would be lost).
 inline void propagate_mul_from_views(
     view lhs, view rhs,
     expression_holder<tensor_to_scalar_expression> const &result) {
   if (lhs.positive && rhs.positive) {
     mark_positive(result);
-  } else if (lhs.is_at_least_nonneg() && rhs.is_at_least_nonneg()) {
-    // Subsumes (pos·nonneg) and (nonneg·pos). Robust to direct-
-    // manager callers who set `positive{}` without `nonnegative{}`.
+  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
     mark_nonnegative(result);
   }
 }
 
-// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives
-// in the cpp file and bypasses this path; the -neg/-nonpos branches
-// below are defensive — they fire if a future code path produces a
-// non-tensor_to_scalar_negative node carrying negative/nonpositive
-// (e.g. via assumption propagation from a different operator that
-// concludes a negative result without wrapping in tensor_negative).
+// Neg: flip sign, preserve magnitude class.
+//
+// REACHABILITY NOTE: only the `positive → negative` and
+// `at_least_nonneg_tag → nonpositive` branches are reachable from the
+// current call graph. The `-(-x) → x` fold in the t2s_negative
+// factory short-circuits before this helper runs, so an operand
+// carrying `negative{}` or `nonpositive{}` can't reach here — those
+// tags are only ever produced by THIS helper's own `mark_negative` /
+// `mark_nonpositive`, and the fold strips them.
+//
+// The `negative → positive` and `at_least_nonpos_tag → nonnegative`
+// branches are kept for future-symmetry. If/when a sign-aware op
+// (out of scope per #260) produces a `negative{}`-tagged result via
+// a non-tensor_negative node (e.g. `mul(positive, negative_const)`
+// after sign-aware mul lands), those branches start firing and the
+// neg propagation stays correct without further changes.
 inline void propagate_neg_from_view(
     view operand,
     expression_holder<tensor_to_scalar_expression> const &result) {
   if (operand.positive) {
     mark_negative(result);
-  } else if (operand.is_at_least_nonneg()) {
+  } else if (operand.at_least_nonneg_tag()) {
     mark_nonpositive(result);
   } else if (operand.negative) {
     mark_positive(result);
-  } else if (operand.is_at_least_nonpos()) {
+  } else if (operand.at_least_nonpos_tag()) {
     mark_nonnegative(result);
   }
 }
 
 // Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
+//
 // The "real exponent" guard prevents a complex exponent from silently
 // inheriting positivity. The strict pow(neg, even-int) → pos rule is
 // deferred (#260 scope-out).
+//
+// ORDER MATTERS (same shape as mul): pos+real first, then the
+// broader nonneg case.
 inline void propagate_pow_from_views(
     view base, view exponent,
     expression_holder<tensor_to_scalar_expression> const &result) {
@@ -193,7 +220,7 @@ inline void propagate_pow_from_views(
     mark_positive(result);
     return;
   }
-  if (base.is_at_least_nonneg() && exponent.is_at_least_nonneg()) {
+  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
     mark_nonnegative(result);
   }
 }

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -4,6 +4,7 @@
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_pow.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h>
 #include <numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h>
 #include <sstream>
 
@@ -57,11 +58,20 @@ template <tensor_to_scalar_expr_holder ExprLHS,
       return make_expression<tensor_to_scalar_one>();
   }
 
+  // #260 — capture sign tags on base and exponent BEFORE forwarding;
+  // the visitor may consume the holders as rvalues.
+  const auto base_view =
+      tensor_to_scalar_detail::positivity::read_with_real(expr_lhs);
+  const auto exp_view =
+      tensor_to_scalar_detail::positivity::read_with_real(expr_rhs);
   // Full simplification via visitor dispatch
   auto &_lhs{expr_lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::pow_base visitor(
       std::forward<ExprLHS>(expr_lhs), std::forward<ExprRHS>(expr_rhs));
-  return _lhs.accept(visitor);
+  auto result = _lhs.accept(visitor);
+  tensor_to_scalar_detail::positivity::propagate_pow_from_views(
+      base_view, exp_view, result);
+  return result;
 }
 
 template <tensor_to_scalar_expr_holder ExprLHS, typename ExprRHS>

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -60,10 +60,8 @@ template <tensor_to_scalar_expr_holder ExprLHS,
 
   // #260 — capture sign tags on base and exponent BEFORE forwarding;
   // the visitor may consume the holders as rvalues.
-  const auto base_view =
-      tensor_to_scalar_detail::positivity::read_with_real(expr_lhs);
-  const auto exp_view =
-      tensor_to_scalar_detail::positivity::read_with_real(expr_rhs);
+  const auto base_view = tensor_to_scalar_detail::positivity::read(expr_lhs);
+  const auto exp_view = tensor_to_scalar_detail::positivity::read(expr_rhs);
   // Full simplification via visitor dispatch
   auto &_lhs{expr_lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::pow_base visitor(

--- a/src/numsim_cas/scalar/scalar_expression.cpp
+++ b/src/numsim_cas/scalar/scalar_expression.cpp
@@ -4,6 +4,7 @@
 #include <numsim_cas/scalar/scalar_expression.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/scalar/scalar_negative.h>
+#include <numsim_cas/scalar/scalar_positivity_propagation.h>
 #include <numsim_cas/scalar/scalar_zero.h>
 
 namespace numsim::cas {
@@ -17,12 +18,17 @@ tag_invoke(detail::neg_fn, std::type_identity<scalar_expression>,
   if (is_same<scalar_zero>(e))
     return get_scalar_zero();
 
-  // -(-x) = x
+  // -(-x) = x — preserves x's existing assumptions automatically.
   if (is_same<scalar_negative>(e)) {
     return e.get<scalar_negative>().expr();
   }
 
-  return make_expression<scalar_negative>(e);
+  // #305 — capture operand sign BEFORE building the negative node so
+  // the propagation step can flip pos→neg / nonneg→nonpos / etc.
+  const auto operand_view = scalar_detail::positivity::read(e);
+  auto result = make_expression<scalar_negative>(e);
+  scalar_detail::positivity::propagate_neg_from_view(operand_view, result);
+  return result;
 }
 
 } // namespace numsim::cas

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -2,6 +2,7 @@
 #include <numsim_cas/core/tag_invoke.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h>
 
 namespace numsim::cas {
 
@@ -14,12 +15,18 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
   if (is_same<tensor_to_scalar_zero>(e))
     return make_expression<tensor_to_scalar_zero>();
 
-  // -(-x) = x
+  // -(-x) = x — preserves x's existing assumptions automatically.
   if (is_same<tensor_to_scalar_negative>(e)) {
     return e.get<tensor_to_scalar_negative>().expr();
   }
 
-  return make_expression<tensor_to_scalar_negative>(e);
+  // #260 — capture operand sign BEFORE building the negative node so
+  // the propagation step can flip pos→neg / nonneg→nonpos / etc.
+  const auto operand_view = tensor_to_scalar_detail::positivity::read(e);
+  auto result = make_expression<tensor_to_scalar_negative>(e);
+  tensor_to_scalar_detail::positivity::propagate_neg_from_view(operand_view,
+                                                               result);
+  return result;
 }
 
 } // namespace numsim::cas

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -681,6 +681,42 @@ TEST(TensorAlgebraOperatorPropagation, NegOfDoubleNegativeFoldsToOperand) {
   EXPECT_TRUE(a.contains(real_tag{}));
 }
 
+TEST(TensorAlgebraOperatorPropagation,
+     PosTagOnlyTimesNonnegTagOnlyExercisesHardening) {
+  // Direct-manager construction: insert `positive{}` alone (no joint
+  // `nonnegative{}`) into lhs, and `nonnegative{}` alone into rhs.
+  // This is the exact brittle shape the at_least_nonneg_tag()
+  // hardening was added for — joint-insertion paths (assume_positive_*)
+  // can't produce this state, so the public API never reaches it
+  // through the normal flow. This test pins the rule's behavior on
+  // a manually-malformed-but-individually-coherent manager.
+  //
+  // Without the hardening, the mul rule would test
+  // `lhs.nonnegative && rhs.nonnegative` and skip — lhs.nonnegative
+  // is false here (only positive was inserted). The hardening's
+  // `at_least_nonneg_tag()` reads "positive OR nonnegative", so the
+  // rule still fires correctly.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  auto d1 = det(C);
+  auto d2 = det(H);
+  // Defeat any α-2d propagation by clearing, then insert single tags.
+  d1.data()->assumptions().clear();
+  d1.data()->assumptions().insert(positive{}); // no joint nonneg
+  d2.data()->assumptions().clear();
+  d2.data()->assumptions().insert(nonnegative{}); // no joint anything
+  auto p = d1 * d2;
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(nonnegative{}))
+      << "Hardening should fire: at_least_nonneg_tag covers the "
+         "pos-only × nonneg-only case";
+  EXPECT_TRUE(a.contains(real_tag{}));
+  // Can't conclude positive (rhs is only nonneg, may be zero) nor
+  // nonzero.
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonzero{}));
+}
+
 TEST(TensorAlgebraOperatorPropagation, PosTimesMixedNonnegIsNonneg) {
   // Robustness: pos × nonneg → nonneg. The lock-in covers the joint-
   // insertion convention (positive ⇒ nonneg in the manager) but the

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -754,6 +754,103 @@ TEST(TensorAlgebraDetPropagation, DetTransPdGetsPositiveViaSymmetricShortcut) {
          "recursive det(C) fires the propagation";
 }
 
+// ─── #305: scalar operator positivity propagation ────────────────────
+// Mirror of TensorAlgebraOperatorPropagation but for scalar mul/pow/neg.
+// Uses scalar variables annotated via expression_holder::assumption()
+// rather than detn(PD)-style indirection.
+
+TEST(ScalarAlgebraOperatorPropagation, MulOfTwoPositivesIsPositive) {
+  auto a = std::get<0>(make_scalar_variable("a"));
+  auto b = std::get<0>(make_scalar_variable("b"));
+  a.assumption(positive{});
+  b.assumption(positive{});
+  auto p = a * b;
+  auto const &x = p.data()->assumptions();
+  EXPECT_TRUE(x.contains(positive{}));
+  EXPECT_TRUE(x.contains(nonzero{}));
+  EXPECT_TRUE(x.contains(real_tag{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation, MulOfPositiveAndUnknownHasNoSign) {
+  auto a = std::get<0>(make_scalar_variable("a"));
+  auto b = std::get<0>(make_scalar_variable("b"));
+  a.assumption(positive{});
+  auto p = a * b;
+  EXPECT_FALSE(p.data()->assumptions().contains(positive{}));
+  EXPECT_FALSE(p.data()->assumptions().contains(nonnegative{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation, NegOfPositiveIsNegative) {
+  auto a = std::get<0>(make_scalar_variable("a"));
+  a.assumption(positive{});
+  auto n = -a;
+  auto const &x = n.data()->assumptions();
+  EXPECT_TRUE(x.contains(negative{}));
+  EXPECT_TRUE(x.contains(nonpositive{}));
+  EXPECT_TRUE(x.contains(nonzero{}));
+  EXPECT_TRUE(x.contains(real_tag{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation, PowOfPositiveBaseRealExpIsPositive) {
+  auto a = std::get<0>(make_scalar_variable("a"));
+  a.assumption(positive{});
+  // Integer exponent is real-by-construction (open-coded check in
+  // scalar_positivity_propagation::read).
+  auto p = pow(a, 3);
+  auto const &x = p.data()->assumptions();
+  EXPECT_TRUE(x.contains(positive{}));
+  EXPECT_TRUE(x.contains(nonzero{}));
+  EXPECT_TRUE(x.contains(real_tag{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation, DivOfTwoPositivesIsPositive) {
+  // scalar div decomposes to lhs * pow(rhs, -1).
+  auto a = std::get<0>(make_scalar_variable("a"));
+  auto b = std::get<0>(make_scalar_variable("b"));
+  a.assumption(positive{});
+  b.assumption(positive{});
+  auto q = a / b;
+  auto const &x = q.data()->assumptions();
+  EXPECT_TRUE(x.contains(positive{}));
+  EXPECT_TRUE(x.contains(nonzero{}));
+  EXPECT_TRUE(x.contains(real_tag{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation,
+     DetPositiveScalarMulPdIsPositiveCrossDomainLockIn) {
+  // The flagship cross-domain lock-in from #260's review and #305's
+  // body. det(α·C) decomposes structurally in the det() factory to
+  // pow(α, d) · det(C). For positive α and PD C:
+  //   - scalar pow(α, 3) → positive (via #305's scalar pow rule)
+  //   - det(C) → positive (via α-2d's terminal det propagation)
+  //   - t2s mul of (scalar_wrapper(scalar_pow), tensor_det) →
+  //     positive (via #260's t2s mul rule, which reads through the
+  //     scalar_wrapper to the inner scalar's positivity)
+  // All three pieces need to work for the dcontract identity to
+  // hold via assumption alone.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto alpha = std::get<0>(make_scalar_variable("alpha"));
+  assume_positive_definite(C);
+  alpha.assumption(positive{});
+  auto d = det(alpha * C);
+  auto const &x = d.data()->assumptions();
+  EXPECT_TRUE(x.contains(positive{}));
+  EXPECT_TRUE(x.contains(nonnegative{}));
+  EXPECT_TRUE(x.contains(nonzero{}));
+  EXPECT_TRUE(x.contains(real_tag{}));
+}
+
+TEST(ScalarAlgebraOperatorPropagation, DetUnknownScalarMulPdHasNoSign) {
+  // Negative-case sibling: un-annotated α means det(α·C) has
+  // unknown sign even if C is PD. The rules must NOT fire.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto alpha = std::get<0>(make_scalar_variable("alpha"));
+  assume_positive_definite(C);
+  auto d = det(alpha * C);
+  EXPECT_FALSE(d.data()->assumptions().contains(positive{}));
+  EXPECT_FALSE(d.data()->assumptions().contains(nonnegative{}));
+}
+
 // ─── #246 α-2c: trans(orthogonal) · orthogonal → I ──────────────────
 
 TEST(TensorAlgebraMulFold, TransOrthogonalTimesOrthogonalIsIdentity) {

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -644,6 +644,56 @@ TEST(TensorAlgebraOperatorPropagation, DivOfTwoPositivesIsPositive) {
   EXPECT_TRUE(a.contains(real_tag{}));
 }
 
+TEST(TensorAlgebraOperatorPropagation, DivOfTwoUnknownsHasNoSign) {
+  // Negative case for div: two unannotated operands → no propagation.
+  // Symmetric counterpart to MulOfUnannotatedAndPositiveHasNoSign,
+  // closes the coverage gap for div.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto B = std::get<0>(make_tensor_variable(std::tuple{"B", 3, 2}));
+  auto q = det(A) / det(B);
+  auto const &a = q.data()->assumptions();
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonnegative{}));
+  EXPECT_FALSE(a.contains(negative{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, NegOfDoubleNegativeFoldsToOperand) {
+  // -(-x) → x at the construction-time fold (tensor_to_scalar_negative
+  // factory). The fold returns x directly so propagate_neg_from_view
+  // never runs — but x already carries its own positivity tags, so
+  // the round-trip preserves them. Locks in this preservation: a
+  // future change to the fold (e.g. wrapping for hash consistency)
+  // that drops the operand's assumptions would catch here.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  auto d = det(C);
+  EXPECT_TRUE(d.data()->assumptions().contains(positive{}));
+  auto neg_neg_d = -(-d);
+  auto const &a = neg_neg_d.data()->assumptions();
+  EXPECT_TRUE(a.contains(positive{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, PosTimesMixedNonnegIsNonneg) {
+  // Robustness: pos × nonneg → nonneg. The lock-in covers the joint-
+  // insertion convention (positive ⇒ nonneg in the manager) but the
+  // implementation also handles the brittle path where a direct
+  // manager caller writes positive{} alone.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  assume_positive_definite(C);     // det(C) carries positive ⇒ nonneg
+  assume_positive_semidefinite(H); // det(H) carries nonneg only
+  auto p = det(C) * det(H);
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(nonnegative{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+  // PD × PSD can be zero (PSD may be zero) so must NOT conclude
+  // positive / nonzero.
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonzero{}));
+}
+
 TEST(TensorAlgebraDetPropagation, DetTransPdGetsPositiveViaSymmetricShortcut) {
   // det(trans(PD C)) — actually DOES get the positive annotation,
   // for a non-obvious reason: PD ⇒ symmetric, and trans()'s symmetric

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -511,29 +511,137 @@ TEST(TensorAlgebraDetPropagation, DetPdConstantFoldsBypassThePropagationPath) {
 //   - det(tensor_mul) — also gap-open via #260; not specifically
 //     tested here (covered by composition-test PR's broader matrix).
 
-TEST(TensorAlgebraDetPropagation, DetScalarMulPd_Issue260_Sentinel) {
-  // SENTINEL for #260 (t2s mul/div/pow positivity propagation).
-  //
-  // Mathematically: det(α·C) = α^d · det(C), and for PD C the inner
-  // det(C) gets `positive` via the terminal-tensor_det propagation
-  // (α-2d). But α^d · positive is currently NOT folded to positive —
-  // the t2s mul operator doesn't propagate `positive` through the
-  // composition. So the outer expression has no positivity tag today.
-  //
-  // The EXPECT_FALSE here is INVERTED-on-purpose: this test passes
-  // today because the gap is open, but a #260 implementation that
-  // lands correct `positive * positive → positive` propagation will
-  // make it fail. The failure is the desired signal — at that point
-  // flip the expectation to EXPECT_TRUE and rename to ...IsPositive.
-  // Sentinel framing reflected in the test name so a reader scanning
-  // the test list knows it's a tracked-future-change marker rather
-  // than a permanent contract.
+// ─── #260: t2s operator positivity propagation ──────────────────────
+// Each rule from the issue table gets a positive + a negative test.
+// Using det(PD) and det(PSD) as the positivity / nonneg sources since
+// those are the t2s leaves with stable annotation contracts from α-2d.
+
+TEST(TensorAlgebraOperatorPropagation, MulOfTwoPositivesIsPositive) {
+  // pos × pos → pos. det(PD) × det(PD) — both factors carry positive
+  // via α-2d, and the t2s mul should compose them.
+  auto C1 = std::get<0>(make_tensor_variable(std::tuple{"C1", 3, 2}));
+  auto C2 = std::get<0>(make_tensor_variable(std::tuple{"C2", 3, 2}));
+  assume_positive_definite(C1);
+  assume_positive_definite(C2);
+  auto p = det(C1) * det(C2);
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(positive{}));
+  EXPECT_TRUE(a.contains(nonnegative{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, MulOfTwoNonnegativesIsNonnegative) {
+  // nonneg × nonneg → nonneg. det(PSD) × det(PSD).
+  auto H1 = std::get<0>(make_tensor_variable(std::tuple{"H1", 3, 2}));
+  auto H2 = std::get<0>(make_tensor_variable(std::tuple{"H2", 3, 2}));
+  assume_positive_semidefinite(H1);
+  assume_positive_semidefinite(H2);
+  auto p = det(H1) * det(H2);
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(nonnegative{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+  // PSD × PSD is nonneg but possibly zero — must NOT conclude
+  // positive / nonzero.
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonzero{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, MulOfUnannotatedAndPositiveHasNoSign) {
+  // Negative: unknown × positive → unknown. Guards against the rule
+  // firing on one-operand annotation.
   auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
-  auto alpha = make_scalar_variable("alpha");
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
   assume_positive_definite(C);
-  auto d = det(std::get<0>(alpha) * C);
-  EXPECT_FALSE(d.data()->assumptions().contains(positive{}))
-      << "Sentinel: flip to EXPECT_TRUE when #260 lands t2s mul positivity";
+  auto p = det(C) * det(A);
+  auto const &a = p.data()->assumptions();
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonnegative{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, NegOfPositiveIsNegative) {
+  // -pos → neg.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  auto n = -det(C);
+  auto const &a = n.data()->assumptions();
+  EXPECT_TRUE(a.contains(negative{}));
+  EXPECT_TRUE(a.contains(nonpositive{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+  EXPECT_FALSE(a.contains(positive{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, NegOfNonnegativeIsNonpositive) {
+  // -nonneg → nonpos (may include zero).
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  assume_positive_semidefinite(H);
+  auto n = -det(H);
+  auto const &a = n.data()->assumptions();
+  EXPECT_TRUE(a.contains(nonpositive{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+  EXPECT_FALSE(a.contains(negative{}));
+  EXPECT_FALSE(a.contains(nonzero{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, NegOfUnannotatedHasNoSign) {
+  // Negative: -(unknown) → unknown.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto n = -det(A);
+  auto const &a = n.data()->assumptions();
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(negative{}));
+  EXPECT_FALSE(a.contains(nonpositive{}));
+  EXPECT_FALSE(a.contains(nonnegative{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation,
+     PowOfPositiveBaseRealExponentIsPositive) {
+  // pow(pos, real-exponent) → pos. Use pow(det(PD), 2) — the integer
+  // exponent 2 is wrapped as a scalar_constant, which is real_tag by
+  // construction of any numeric constant in the codebase.
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  assume_positive_definite(C);
+  auto p = pow(det(C), 2);
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(positive{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, PowOfNonnegBaseNonnegExpIsNonneg) {
+  // pow(nonneg, nonneg-exp) → nonneg. Use pow(det(PSD), 2).
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  assume_positive_semidefinite(H);
+  auto p = pow(det(H), 2);
+  auto const &a = p.data()->assumptions();
+  EXPECT_TRUE(a.contains(nonnegative{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonzero{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, PowOfUnannotatedBaseHasNoSign) {
+  // Negative: pow(unknown, anything) is unknown.
+  auto A = std::get<0>(make_tensor_variable(std::tuple{"A", 3, 2}));
+  auto p = pow(det(A), 2);
+  auto const &a = p.data()->assumptions();
+  EXPECT_FALSE(a.contains(positive{}));
+  EXPECT_FALSE(a.contains(nonnegative{}));
+}
+
+TEST(TensorAlgebraOperatorPropagation, DivOfTwoPositivesIsPositive) {
+  // div decomposes to lhs * pow(rhs, -1). Both mul and pow propagation
+  // need to fire for the composite to land positive.
+  auto C1 = std::get<0>(make_tensor_variable(std::tuple{"C1", 3, 2}));
+  auto C2 = std::get<0>(make_tensor_variable(std::tuple{"C2", 3, 2}));
+  assume_positive_definite(C1);
+  assume_positive_definite(C2);
+  auto q = det(C1) / det(C2);
+  auto const &a = q.data()->assumptions();
+  EXPECT_TRUE(a.contains(positive{}));
+  EXPECT_TRUE(a.contains(nonzero{}));
+  EXPECT_TRUE(a.contains(real_tag{}));
 }
 
 TEST(TensorAlgebraDetPropagation, DetTransPdGetsPositiveViaSymmetricShortcut) {

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -658,12 +658,18 @@ TEST(TensorAlgebraOperatorPropagation, DivOfTwoUnknownsHasNoSign) {
 }
 
 TEST(TensorAlgebraOperatorPropagation, NegOfDoubleNegativeFoldsToOperand) {
-  // -(-x) → x at the construction-time fold (tensor_to_scalar_negative
-  // factory). The fold returns x directly so propagate_neg_from_view
-  // never runs — but x already carries its own positivity tags, so
-  // the round-trip preserves them. Locks in this preservation: a
-  // future change to the fold (e.g. wrapping for hash consistency)
-  // that drops the operand's assumptions would catch here.
+  // -(-x) → x at the construction-time fold in the t2s_negative
+  // factory. Tests an INTERACTION between the fold and the
+  // propagation helper rather than the helper alone: the fold
+  // short-circuits before propagate_neg_from_view runs, so the
+  // helper never executes — but the user-visible contract
+  // (-(-positive) is positive) is what we care about. The
+  // operand's tags survive the round-trip because the fold
+  // returns x's own holder, so x's assumption manager is the
+  // result manager. A future fold change that wraps for hash
+  // consistency (or any other reason builds a fresh node) would
+  // need the helper to re-derive positivity from the operand;
+  // this test catches that regression.
   auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
   assume_positive_definite(C);
   auto d = det(C);


### PR DESCRIPTION
## Summary

- Mirror of #260 for the scalar domain. New `scalar_positivity_propagation.h` parallel to the t2s helper.
- Wired into scalar mul, pow (both holder×holder and arithmetic-exponent overloads), div, and neg.
- Cross-domain lock-in `DetPositiveScalarMulPdIsPositiveCrossDomainLockIn` (the flagship test that motivated #305) now passes — `det(positive_α · PD_C)` correctly carries `positive` end-to-end.

## Closes

#305.

## Stacked on

#260 (PR #304). Base for review is `260-t2s-op-positivity-propagation` so the diff shows only the scalar-side additions. After #260 merges to main, retarget base to `main` BEFORE merging this.

## Bug found mid-integration

Fuzz seed 35 (FuzzyScalarDiff Depth3) segfaulted on the new mul propagation — scalar differentiation produces transient invalid expression holders during chain-rule decomposition. `read()`'s `e.data()->assumptions()` null-dereffed. Fixed with an `is_valid()` guard; applied the symmetric guard to the t2s helper too (same latent UB, just hadn't been triggered by any t2s test).

## Include cycle

`scalar_domain_traits.h` transitively pulls in `scalar_std.h` via `scalar_all.h`, creating a cycle when included from this helper (since `scalar_std.h` includes the helper). Open-coded the "is real-by-construction numeric constant" check using direct `is_same<scalar_zero / scalar_one / scalar_constant / scalar_negative>` instead of `domain_traits::try_numeric`. Equivalent semantics; avoids deferring the work behind a refactor.

## Test plan

- [x] 7 new tests in `ScalarAlgebraOperatorPropagation` suite (per-rule positive + negative cases + the cross-domain flagship).
- [x] 1542 main tests pass (was 1535 on #260's branch; +7 from the new tests).
- [x] 782 fuzz tests pass (no regression after the seed-35 segfault fix).
- [ ] CI matrix validation.

## Not in scope

- Sign-aware scalar rules (`neg·neg → pos`, etc.) — defer with #306 (#306 is t2s-side; symmetric scalar follow-up would be a natural extension).
- Add operator positivity (`pos + pos → pos`) — defer with #307.
- Domain-agnostic unification of t2s + scalar helpers — defer with #262 (broader cross-domain scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)