### PR TITLE
Fix diff visitor accumulator init (eliminates invalid intermediates)

### DIFF
--- a/include/numsim_cas/core/positivity_propagation.h
+++ b/include/numsim_cas/core/positivity_propagation.h
@@ -1,0 +1,188 @@
+#ifndef NUMSIM_CAS_CORE_POSITIVITY_PROPAGATION_H
+#define NUMSIM_CAS_CORE_POSITIVITY_PROPAGATION_H
+
+#include <cassert>
+
+#include <numsim_cas/core/assumptions.h>
+#include <numsim_cas/core/expression_holder.h>
+
+// Domain-agnostic positivity-tag propagation for arithmetic operators
+// (mul, neg, pow). #260 (t2s) and #305 (scalar) both built parallel
+// helpers; this header lifts everything except the domain-specific
+// `read(expr)` function (which inspects domain-specific node types
+// like scalar_constant or tensor_to_scalar_scalar_wrapper).
+//
+// Each domain header in the parent dirs supplies its own `read()`
+// returning a `view`, then delegates the rule machinery here.
+//
+// ── Aliasing contract ───────────────────────────────────────────
+//
+// `result` may alias one of the operand holders. The simplifier is
+// allowed to fold (e.g. `x * 1 → x`) and return the operand's own
+// holder; in that case `result.data()` is the operand's node and
+// inserting into `result.data()->assumptions()` mutates the operand.
+//
+// All rules here are designed so this mutation is sound — they only
+// fire when the inferred tags are already implied by the operand's
+// state. e.g. `mark_positive(x)` after a fold returning `x` is safe
+// because x was already positive in the rule's precondition.
+//
+// If you add a new rule, preserve this invariant: a rule that fires
+// on operand views V_lhs, V_rhs must produce a result tag that is a
+// logical consequence of V_lhs ∧ V_rhs — never strictly stronger
+// than what either operand's state implies.
+//
+// ── Robustness to direct-manager callers ────────────────────────
+//
+// `at_least_nonneg_tag()` is `positive || nonnegative`. A direct-
+// manager caller who inserts `positive{}` alone (without the joint
+// `nonnegative{}` insertion done by the assume_* helpers) still gets
+// the right answer — the rule sees `positive` and concludes
+// nonneg-ness implicitly.
+
+namespace numsim::cas::positivity {
+
+// Tag-state view of an expression's assumption manager. NOTE: these
+// are tag-state predicates, not truth predicates. A caller who
+// mutates the manager into an incoherent state (e.g. inserts both
+// `positive{}` and `nonpositive{}`) defeats any inference here.
+struct view {
+  bool positive;
+  bool nonnegative;
+  bool nonpositive;
+  bool negative;
+  bool nonzero;
+  bool real; // real_tag OR integer/rational/irrational OR known numeric
+
+  // "At least nonneg" via TAG state: the operand carries either
+  // `positive{}` or `nonnegative{}`. Robust to direct-manager callers
+  // who set `positive{}` without the joint `nonnegative{}`. The "tag"
+  // suffix distinguishes from a truth claim.
+  bool at_least_nonneg_tag() const { return positive || nonnegative; }
+  bool at_least_nonpos_tag() const { return negative || nonpositive; }
+};
+
+// Defense-in-depth: a rule that inserts a tag contradicting the
+// operand's existing state would be incorrect under aliasing
+// (mutating an operand we shouldn't). Debug-only — compiled out
+// under NDEBUG.
+#ifndef NDEBUG
+#define NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(manager, banned_tag)     \
+  do {                                                                         \
+    assert(!(manager).contains(banned_tag) &&                                  \
+           "positivity_propagation: rule would set a tag contradicting "       \
+           "the operand's existing state");                                    \
+  } while (0)
+#else
+#define NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(manager, banned_tag)     \
+  ((void)0)
+#endif
+
+// Joint-insertion helpers, mirror scalar_assume.h's pattern.
+// Templated on the expression type so the same helpers work across
+// scalar, t2s, and any future domain whose expression base supplies
+// `assumptions()`.
+template <typename Expr>
+inline void mark_positive(expression_holder<Expr> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonpositive{});
+  a.insert(numsim::cas::positive{});
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+template <typename Expr>
+inline void mark_negative(expression_holder<Expr> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonnegative{});
+  a.insert(numsim::cas::negative{});
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::nonzero{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+template <typename Expr>
+inline void mark_nonnegative(expression_holder<Expr> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
+  a.insert(numsim::cas::nonnegative{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+template <typename Expr>
+inline void mark_nonpositive(expression_holder<Expr> const &e) {
+  auto &a = e.data()->assumptions();
+  NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
+  a.insert(numsim::cas::nonpositive{});
+  a.insert(numsim::cas::real_tag{});
+  a.set_inferred();
+}
+
+// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg.
+// ORDER MATTERS: stronger before weaker — swapping would collapse
+// pos·pos to nonneg and lose nonzero{}.
+template <typename Expr>
+inline void propagate_mul_from_views(view lhs, view rhs,
+                                     expression_holder<Expr> const &result) {
+  if (lhs.positive && rhs.positive) {
+    mark_positive(result);
+  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+// Neg: flip sign, preserve magnitude class.
+//
+// REACHABILITY NOTE: only the `positive → negative` and
+// `at_least_nonneg_tag → nonpositive` branches are reachable from
+// the current call graph. The `-(-x) → x` fold in each domain's
+// negative factory short-circuits before this helper runs, so an
+// operand carrying `negative{}` or `nonpositive{}` can't reach here
+// — those tags are only ever produced by THIS helper's own
+// `mark_negative` / `mark_nonpositive`, and the fold strips them.
+//
+// The `negative → positive` and `at_least_nonpos_tag → nonnegative`
+// branches are kept for future-symmetry. If/when a sign-aware op
+// (out of scope per #260) produces a `negative{}`-tagged result via
+// a non-negative-node (e.g. `mul(positive, negative_const)` after
+// sign-aware mul lands per #306), those branches start firing and
+// the neg propagation stays correct without further changes.
+template <typename Expr>
+inline void propagate_neg_from_view(view operand,
+                                    expression_holder<Expr> const &result) {
+  if (operand.positive) {
+    mark_negative(result);
+  } else if (operand.at_least_nonneg_tag()) {
+    mark_nonpositive(result);
+  } else if (operand.negative) {
+    mark_positive(result);
+  } else if (operand.at_least_nonpos_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
+// The "real exponent" guard prevents a complex exponent from
+// silently inheriting positivity. The strict pow(neg, even-int) →
+// pos rule is deferred (#260 scope-out, tracked in #306).
+template <typename Expr>
+inline void propagate_pow_from_views(view base, view exponent,
+                                     expression_holder<Expr> const &result) {
+  if (base.positive && exponent.real) {
+    mark_positive(result);
+    return;
+  }
+  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
+    mark_nonnegative(result);
+  }
+}
+
+} // namespace numsim::cas::positivity
+
+#endif // NUMSIM_CAS_CORE_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/core/positivity_propagation.h
+++ b/include/numsim_cas/core/positivity_propagation.h
@@ -185,4 +185,6 @@ inline void propagate_pow_from_views(view base, view exponent,
 
 } // namespace numsim::cas::positivity
 
+#undef NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION
+
 #endif // NUMSIM_CAS_CORE_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/core/positivity_propagation.h
+++ b/include/numsim_cas/core/positivity_propagation.h
@@ -6,66 +6,26 @@
 #include <numsim_cas/core/assumptions.h>
 #include <numsim_cas/core/expression_holder.h>
 
-// Domain-agnostic positivity-tag propagation for arithmetic operators
-// (mul, neg, pow). #260 (t2s) and #305 (scalar) both built parallel
-// helpers; this header lifts everything except the domain-specific
-// `read(expr)` function (which inspects domain-specific node types
-// like scalar_constant or tensor_to_scalar_scalar_wrapper).
+// Domain-agnostic positivity-tag propagation for mul/neg/pow (#260 t2s,
+// #305 scalar). Each domain supplies its own `read(expr)` returning a
+// normalized numeric_assumption_manager snapshot; the rules live here.
 //
-// Each domain header in the parent dirs supplies its own `read()`
-// returning a `numeric_assumption_manager` SNAPSHOT of the operand's
-// sign tags (normalized so real_tag is materialized — see below), then
-// delegates the rule machinery here.
+// read() returns a value COPY of the operand's manager, taken BEFORE the
+// simplifier moves the operand (it reuses refcount-1 temporaries, so the
+// holder may be moved-from by the time `result` exists). It also inserts
+// real_tag whenever the operand is real-by-implication (integer/rational/
+// irrational or a numeric constant), so rules only check real_tag. Cost:
+// one small set copy per op — see #310 for removing the eager path.
 //
-// ── Why a snapshot (not a live manager reference) ────────────────
-//
-// The eager call sites read operand sign-tags BEFORE forwarding the
-// operands into the simplifier, which consumes them as rvalues (it
-// reuses refcount-1 temporaries). By the time `result` exists the
-// operand holders may be moved-from, so we cannot read them then — the
-// rule inputs must be captured up front. `read()` returns a value copy
-// of the operand's `numeric_assumption_manager`, reusing the existing
-// typed assumption tags instead of a bespoke bool mirror. The rules
-// below query it with `.contains(positive{})` etc.
-//
-// COST: the snapshot is a `std::set` copy per mul/pow/neg construction
-// (vs. the alloc-free bool struct this replaced). The manager holds a
-// handful of tags and the operator already allocates the result node,
-// so this is intentionally accepted as negligible. If it ever shows up
-// in a construction-heavy profile, back `numeric_assumption_manager`
-// onto a bitset (the 13 numeric tags fit in a uint16_t) and the copy
-// becomes trivial again — or drop the eager path entirely (#310), which
-// removes read()/propagate_* and this cost with it.
-//
-// `read()` also NORMALIZES the snapshot: it inserts real_tag whenever
-// the operand is real-by-implication (integer/rational/irrational, or a
-// numeric constant), so the rules only ever check real_tag. Complex
-// constants are rejected at construction (scalar_constant.h), so every
-// numeric constant reaching here is real.
-//
-// ── Aliasing contract ───────────────────────────────────────────
-//
-// `result` may alias one of the operand holders. The simplifier is
-// allowed to fold (e.g. `x * 1 → x`) and return the operand's own
-// holder; in that case `result.data()` is the operand's node and
-// inserting into `result.data()->assumptions()` mutates the operand.
-//
-// All rules here are designed so this mutation is sound — they only
-// fire when the inferred tags are already implied by the operand's
-// state. e.g. `mark_positive(x)` after a fold returning `x` is safe
-// because x was already positive in the rule's precondition.
-//
-// If you add a new rule, preserve this invariant: a rule that fires on
-// operand snapshots S_lhs, S_rhs must produce a result tag that is a
-// logical consequence of S_lhs ∧ S_rhs — never strictly stronger than
-// what either operand's state implies.
+// Aliasing: `result` may alias an operand (folds like `x*1 → x` return
+// the operand's holder). Rules must therefore only assert tags already
+// implied by the operand's precondition — a consequence of the operand
+// snapshots, never strictly stronger.
 
 namespace numsim::cas::positivity {
 
-// "At least nonneg": the operand snapshot carries `positive` or
-// `nonnegative`. Robust to direct-manager callers who set `positive`
-// without the joint `nonnegative` insertion done by the assume_*
-// helpers — the rule sees `positive` and concludes nonneg-ness.
+// "positive OR nonnegative" / "negative OR nonpositive". Robust to
+// callers who set `positive` without the joint `nonnegative`.
 inline bool at_least_nonneg(numeric_assumption_manager const &m) {
   return m.contains(numsim::cas::positive{}) ||
          m.contains(numsim::cas::nonnegative{});
@@ -75,10 +35,8 @@ inline bool at_least_nonpos(numeric_assumption_manager const &m) {
          m.contains(numsim::cas::nonpositive{});
 }
 
-// Defense-in-depth: a rule that inserts a tag contradicting the
-// operand's existing state would be incorrect under aliasing
-// (mutating an operand we shouldn't). Debug-only — compiled out
-// under NDEBUG.
+// Debug guard: catch a rule that would set a tag contradicting the
+// operand's state (unsound under aliasing). Compiled out under NDEBUG.
 #ifndef NDEBUG
 #define NUMSIM_CAS_POSITIVITY_ASSERT_NO_CONTRADICTION(manager, banned_tag)     \
   do {                                                                         \
@@ -91,10 +49,8 @@ inline bool at_least_nonpos(numeric_assumption_manager const &m) {
   ((void)0)
 #endif
 
-// Joint-insertion helpers, mirror scalar_assume.h's pattern.
-// Templated on the expression type so the same helpers work across
-// scalar, t2s, and any future domain whose expression base supplies
-// `assumptions()`.
+// Joint-insertion helpers, mirror scalar_assume.h. Templated so they
+// work across any domain whose expression base has `assumptions()`.
 template <typename Expr>
 inline void mark_positive(expression_holder<Expr> const &e) {
   auto &a = e.data()->assumptions();
@@ -137,9 +93,8 @@ inline void mark_nonpositive(expression_holder<Expr> const &e) {
   a.set_inferred();
 }
 
-// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg.
-// ORDER MATTERS: stronger before weaker — swapping would collapse
-// pos·pos to nonneg and lose nonzero{}.
+// pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg. Stronger rule first, else
+// pos·pos collapses to nonneg and loses nonzero{}.
 template <typename Expr>
 inline void propagate_mul(numeric_assumption_manager const &lhs,
                           numeric_assumption_manager const &rhs,
@@ -152,22 +107,10 @@ inline void propagate_mul(numeric_assumption_manager const &lhs,
   }
 }
 
-// Neg: flip sign, preserve magnitude class.
-//
-// REACHABILITY NOTE: only the `positive → negative` and
-// `at_least_nonneg → nonpositive` branches are reachable from the
-// current call graph. The `-(-x) → x` fold in each domain's negative
-// factory short-circuits before this helper runs, so an operand
-// carrying `negative` or `nonpositive` can't reach here — those tags
-// are only ever produced by THIS helper's own `mark_negative` /
-// `mark_nonpositive`, and the fold strips them.
-//
-// The `negative → positive` and `at_least_nonpos → nonnegative`
-// branches are kept for future-symmetry. If/when a sign-aware op (out
-// of scope per #260) produces a `negative`-tagged result via a
-// non-negative-node (e.g. `mul(positive, negative_const)` after
-// sign-aware mul lands per #306), those branches start firing and the
-// neg propagation stays correct without further changes.
+// Sign flip, magnitude class preserved. Only the first two branches are
+// reachable today (the `-(-x) → x` fold strips negative/nonpositive
+// operands before this runs); the latter two are kept for the sign-aware
+// ops in #306.
 template <typename Expr>
 inline void propagate_neg(numeric_assumption_manager const &operand,
                           expression_holder<Expr> const &result) {
@@ -182,12 +125,9 @@ inline void propagate_neg(numeric_assumption_manager const &operand,
   }
 }
 
-// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
-// The "real exponent" guard prevents a complex exponent from silently
-// inheriting positivity. (Complex constants are rejected at
-// construction, but a real_tag check is still the right precondition —
-// it also covers the general non-constant exponent case.) The strict
-// pow(neg, even-int) → pos rule is deferred (#260 scope-out, #306).
+// pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg. The real-exponent
+// guard blocks a complex exponent inheriting positivity. pow(neg, even)
+// deferred (#306).
 template <typename Expr>
 inline void propagate_pow(numeric_assumption_manager const &base,
                           numeric_assumption_manager const &exponent,

--- a/include/numsim_cas/core/positivity_propagation.h
+++ b/include/numsim_cas/core/positivity_propagation.h
@@ -28,6 +28,15 @@
 // typed assumption tags instead of a bespoke bool mirror. The rules
 // below query it with `.contains(positive{})` etc.
 //
+// COST: the snapshot is a `std::set` copy per mul/pow/neg construction
+// (vs. the alloc-free bool struct this replaced). The manager holds a
+// handful of tags and the operator already allocates the result node,
+// so this is intentionally accepted as negligible. If it ever shows up
+// in a construction-heavy profile, back `numeric_assumption_manager`
+// onto a bitset (the 13 numeric tags fit in a uint16_t) and the copy
+// becomes trivial again — or drop the eager path entirely (#310), which
+// removes read()/propagate_* and this cost with it.
+//
 // `read()` also NORMALIZES the snapshot: it inserts real_tag whenever
 // the operand is real-by-implication (integer/rational/irrational, or a
 // numeric constant), so the rules only ever check real_tag. Complex

--- a/include/numsim_cas/core/positivity_propagation.h
+++ b/include/numsim_cas/core/positivity_propagation.h
@@ -13,7 +13,26 @@
 // like scalar_constant or tensor_to_scalar_scalar_wrapper).
 //
 // Each domain header in the parent dirs supplies its own `read()`
-// returning a `view`, then delegates the rule machinery here.
+// returning a `numeric_assumption_manager` SNAPSHOT of the operand's
+// sign tags (normalized so real_tag is materialized — see below), then
+// delegates the rule machinery here.
+//
+// ── Why a snapshot (not a live manager reference) ────────────────
+//
+// The eager call sites read operand sign-tags BEFORE forwarding the
+// operands into the simplifier, which consumes them as rvalues (it
+// reuses refcount-1 temporaries). By the time `result` exists the
+// operand holders may be moved-from, so we cannot read them then — the
+// rule inputs must be captured up front. `read()` returns a value copy
+// of the operand's `numeric_assumption_manager`, reusing the existing
+// typed assumption tags instead of a bespoke bool mirror. The rules
+// below query it with `.contains(positive{})` etc.
+//
+// `read()` also NORMALIZES the snapshot: it inserts real_tag whenever
+// the operand is real-by-implication (integer/rational/irrational, or a
+// numeric constant), so the rules only ever check real_tag. Complex
+// constants are rejected at construction (scalar_constant.h), so every
+// numeric constant reaching here is real.
 //
 // ── Aliasing contract ───────────────────────────────────────────
 //
@@ -27,40 +46,25 @@
 // state. e.g. `mark_positive(x)` after a fold returning `x` is safe
 // because x was already positive in the rule's precondition.
 //
-// If you add a new rule, preserve this invariant: a rule that fires
-// on operand views V_lhs, V_rhs must produce a result tag that is a
-// logical consequence of V_lhs ∧ V_rhs — never strictly stronger
-// than what either operand's state implies.
-//
-// ── Robustness to direct-manager callers ────────────────────────
-//
-// `at_least_nonneg_tag()` is `positive || nonnegative`. A direct-
-// manager caller who inserts `positive{}` alone (without the joint
-// `nonnegative{}` insertion done by the assume_* helpers) still gets
-// the right answer — the rule sees `positive` and concludes
-// nonneg-ness implicitly.
+// If you add a new rule, preserve this invariant: a rule that fires on
+// operand snapshots S_lhs, S_rhs must produce a result tag that is a
+// logical consequence of S_lhs ∧ S_rhs — never strictly stronger than
+// what either operand's state implies.
 
 namespace numsim::cas::positivity {
 
-// Tag-state view of an expression's assumption manager. NOTE: these
-// are tag-state predicates, not truth predicates. A caller who
-// mutates the manager into an incoherent state (e.g. inserts both
-// `positive{}` and `nonpositive{}`) defeats any inference here.
-struct view {
-  bool positive;
-  bool nonnegative;
-  bool nonpositive;
-  bool negative;
-  bool nonzero;
-  bool real; // real_tag OR integer/rational/irrational OR known numeric
-
-  // "At least nonneg" via TAG state: the operand carries either
-  // `positive{}` or `nonnegative{}`. Robust to direct-manager callers
-  // who set `positive{}` without the joint `nonnegative{}`. The "tag"
-  // suffix distinguishes from a truth claim.
-  bool at_least_nonneg_tag() const { return positive || nonnegative; }
-  bool at_least_nonpos_tag() const { return negative || nonpositive; }
-};
+// "At least nonneg": the operand snapshot carries `positive` or
+// `nonnegative`. Robust to direct-manager callers who set `positive`
+// without the joint `nonnegative` insertion done by the assume_*
+// helpers — the rule sees `positive` and concludes nonneg-ness.
+inline bool at_least_nonneg(numeric_assumption_manager const &m) {
+  return m.contains(numsim::cas::positive{}) ||
+         m.contains(numsim::cas::nonnegative{});
+}
+inline bool at_least_nonpos(numeric_assumption_manager const &m) {
+  return m.contains(numsim::cas::negative{}) ||
+         m.contains(numsim::cas::nonpositive{});
+}
 
 // Defense-in-depth: a rule that inserts a tag contradicting the
 // operand's existing state would be incorrect under aliasing
@@ -128,11 +132,13 @@ inline void mark_nonpositive(expression_holder<Expr> const &e) {
 // ORDER MATTERS: stronger before weaker — swapping would collapse
 // pos·pos to nonneg and lose nonzero{}.
 template <typename Expr>
-inline void propagate_mul_from_views(view lhs, view rhs,
-                                     expression_holder<Expr> const &result) {
-  if (lhs.positive && rhs.positive) {
+inline void propagate_mul(numeric_assumption_manager const &lhs,
+                          numeric_assumption_manager const &rhs,
+                          expression_holder<Expr> const &result) {
+  if (lhs.contains(numsim::cas::positive{}) &&
+      rhs.contains(numsim::cas::positive{})) {
     mark_positive(result);
-  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
+  } else if (at_least_nonneg(lhs) && at_least_nonneg(rhs)) {
     mark_nonnegative(result);
   }
 }
@@ -140,47 +146,50 @@ inline void propagate_mul_from_views(view lhs, view rhs,
 // Neg: flip sign, preserve magnitude class.
 //
 // REACHABILITY NOTE: only the `positive → negative` and
-// `at_least_nonneg_tag → nonpositive` branches are reachable from
-// the current call graph. The `-(-x) → x` fold in each domain's
-// negative factory short-circuits before this helper runs, so an
-// operand carrying `negative{}` or `nonpositive{}` can't reach here
-// — those tags are only ever produced by THIS helper's own
-// `mark_negative` / `mark_nonpositive`, and the fold strips them.
+// `at_least_nonneg → nonpositive` branches are reachable from the
+// current call graph. The `-(-x) → x` fold in each domain's negative
+// factory short-circuits before this helper runs, so an operand
+// carrying `negative` or `nonpositive` can't reach here — those tags
+// are only ever produced by THIS helper's own `mark_negative` /
+// `mark_nonpositive`, and the fold strips them.
 //
-// The `negative → positive` and `at_least_nonpos_tag → nonnegative`
-// branches are kept for future-symmetry. If/when a sign-aware op
-// (out of scope per #260) produces a `negative{}`-tagged result via
-// a non-negative-node (e.g. `mul(positive, negative_const)` after
-// sign-aware mul lands per #306), those branches start firing and
-// the neg propagation stays correct without further changes.
+// The `negative → positive` and `at_least_nonpos → nonnegative`
+// branches are kept for future-symmetry. If/when a sign-aware op (out
+// of scope per #260) produces a `negative`-tagged result via a
+// non-negative-node (e.g. `mul(positive, negative_const)` after
+// sign-aware mul lands per #306), those branches start firing and the
+// neg propagation stays correct without further changes.
 template <typename Expr>
-inline void propagate_neg_from_view(view operand,
-                                    expression_holder<Expr> const &result) {
-  if (operand.positive) {
+inline void propagate_neg(numeric_assumption_manager const &operand,
+                          expression_holder<Expr> const &result) {
+  if (operand.contains(numsim::cas::positive{})) {
     mark_negative(result);
-  } else if (operand.at_least_nonneg_tag()) {
+  } else if (at_least_nonneg(operand)) {
     mark_nonpositive(result);
-  } else if (operand.negative) {
+  } else if (operand.contains(numsim::cas::negative{})) {
     mark_positive(result);
-  } else if (operand.at_least_nonpos_tag()) {
+  } else if (at_least_nonpos(operand)) {
     mark_nonnegative(result);
   }
 }
 
 // Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
-// The "real exponent" guard prevents a complex exponent from
-// silently inheriting positivity. The strict pow(neg, even-int) →
-// pos rule is deferred (#260 scope-out, tracked in #306).
+// The "real exponent" guard prevents a complex exponent from silently
+// inheriting positivity. (Complex constants are rejected at
+// construction, but a real_tag check is still the right precondition —
+// it also covers the general non-constant exponent case.) The strict
+// pow(neg, even-int) → pos rule is deferred (#260 scope-out, #306).
 template <typename Expr>
-inline void propagate_pow_from_views(view base, view exponent,
-                                     expression_holder<Expr> const &result) {
-  if (base.positive && exponent.real) {
+inline void propagate_pow(numeric_assumption_manager const &base,
+                          numeric_assumption_manager const &exponent,
+                          expression_holder<Expr> const &result) {
+  if (base.contains(numsim::cas::positive{}) &&
+      exponent.contains(numsim::cas::real_tag{})) {
     mark_positive(result);
     return;
   }
-  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
+  if (at_least_nonneg(base) && at_least_nonneg(exponent))
     mark_nonnegative(result);
-  }
 }
 
 } // namespace numsim::cas::positivity

--- a/include/numsim_cas/scalar/scalar_constant.h
+++ b/include/numsim_cas/scalar/scalar_constant.h
@@ -1,7 +1,11 @@
 #ifndef SCALAR_CONSTANT_H
 #define SCALAR_CONSTANT_H
 
+#include <complex>
+#include <variant>
+
 #include <numsim_cas/core/assumptions.h>
+#include <numsim_cas/core/cas_error.h>
 #include <numsim_cas/core/hash_functions.h>
 #include <numsim_cas/core/scalar_number.h>
 #include <numsim_cas/scalar/scalar_expression.h>
@@ -14,6 +18,17 @@ public:
   scalar_constant() = delete;
   template <typename T>
   explicit scalar_constant(T const &v) : base(), m_value(v) {
+    // numsim-cas is a real-valued CAS for constitutive modelling; complex
+    // numbers never arise in that domain (stress/strain/energy are real;
+    // principal values come from symmetric PD tensors). Symbols already
+    // cannot be assumed complex, and no operation folds to a complex
+    // constant (sqrt(-1), pow(-1,1/2) stay symbolic). Rejecting complex
+    // here is the single boundary that keeps complex values out of every
+    // expression — so the positivity rules downstream can treat every
+    // constant, symbol, and subexpression as real. See cas_error.h.
+    if (std::holds_alternative<std::complex<double>>(m_value.raw()))
+      throw invalid_expression_error(
+          "scalar_constant: complex values are not supported");
     // SymPy-style closed-form constant: derive numeric assumptions from
     // the value at construction time (same pattern as
     // tensor_to_scalar_zero/one). The user can no longer call

--- a/include/numsim_cas/scalar/scalar_constant.h
+++ b/include/numsim_cas/scalar/scalar_constant.h
@@ -26,6 +26,13 @@ public:
     // here is the single boundary that keeps complex values out of every
     // expression — so the positivity rules downstream can treat every
     // constant, symbol, and subexpression as real. See cas_error.h.
+    //
+    // This is a structural check on the variant alternative, so a
+    // zero-imaginary complex (e.g. complex{5.0, 0.0}) is ALSO rejected:
+    // it is mathematically real but was spelled complex, and accepting
+    // it would quietly admit the alternative we've decided to exclude.
+    // Callers who want a real constant must spell it real (5.0, not
+    // complex{5.0, 0.0}).
     if (std::holds_alternative<std::complex<double>>(m_value.raw()))
       throw invalid_expression_error(
           "scalar_constant: complex values are not supported");
@@ -152,7 +159,11 @@ private:
               a.insert(nonpositive{});
             }
           }
-          // complex: no sign predicates apply; also not real.
+          // complex: unreachable — the constructor rejects complex
+          // values before annotate_from_value() runs. Kept so the
+          // std::visit remains total over the variant; if the ctor
+          // guard is ever removed, a complex constant correctly gets
+          // no sign predicates and no real_tag.
         },
         m_value.raw());
     a.set_inferred();

--- a/include/numsim_cas/scalar/scalar_constant.h
+++ b/include/numsim_cas/scalar/scalar_constant.h
@@ -18,21 +18,10 @@ public:
   scalar_constant() = delete;
   template <typename T>
   explicit scalar_constant(T const &v) : base(), m_value(v) {
-    // numsim-cas is a real-valued CAS for constitutive modelling; complex
-    // numbers never arise in that domain (stress/strain/energy are real;
-    // principal values come from symmetric PD tensors). Symbols already
-    // cannot be assumed complex, and no operation folds to a complex
-    // constant (sqrt(-1), pow(-1,1/2) stay symbolic). Rejecting complex
-    // here is the single boundary that keeps complex values out of every
-    // expression — so the positivity rules downstream can treat every
-    // constant, symbol, and subexpression as real. See cas_error.h.
-    //
-    // This is a structural check on the variant alternative, so a
-    // zero-imaginary complex (e.g. complex{5.0, 0.0}) is ALSO rejected:
-    // it is mathematically real but was spelled complex, and accepting
-    // it would quietly admit the alternative we've decided to exclude.
-    // Callers who want a real constant must spell it real (5.0, not
-    // complex{5.0, 0.0}).
+    // numsim-cas is a real-valued CAS: reject complex at this single
+    // boundary so every constant downstream is real. Structural variant
+    // check, so a zero-imaginary complex{5.0, 0.0} is rejected too —
+    // spell real constants as real (#267).
     if (std::holds_alternative<std::complex<double>>(m_value.raw()))
       throw invalid_expression_error(
           "scalar_constant: complex values are not supported");
@@ -159,11 +148,8 @@ private:
               a.insert(nonpositive{});
             }
           }
-          // complex: unreachable — the constructor rejects complex
-          // values before annotate_from_value() runs. Kept so the
-          // std::visit remains total over the variant; if the ctor
-          // guard is ever removed, a complex constant correctly gets
-          // no sign predicates and no real_tag.
+          // complex: unreachable (ctor rejects complex first); kept so
+          // the visit stays total. No predicates would apply anyway.
         },
         m_value.raw());
     a.set_inferred();

--- a/include/numsim_cas/scalar/scalar_operators.h
+++ b/include/numsim_cas/scalar/scalar_operators.h
@@ -73,13 +73,12 @@ inline expression_holder<scalar_expression> tag_invoke(mul_fn, L &&lhs,
                                                        R &&rhs) {
   // #305 — capture operand sign views BEFORE forwarding (the visitor
   // may consume L/R as rvalues). Same shape as the t2s mul wiring.
-  const auto lhs_view = scalar_detail::positivity::read(lhs);
-  const auto rhs_view = scalar_detail::positivity::read(rhs);
+  const auto lhs_view = positivity::read(lhs);
+  const auto rhs_view = positivity::read(rhs);
   auto &_lhs{lhs.template get<scalar_visitable_t>()};
   simplifier::mul_base visitor(std::forward<L>(lhs), std::forward<R>(rhs));
   auto result = _lhs.accept(visitor);
-  scalar_detail::positivity::propagate_mul_from_views(lhs_view, rhs_view,
-                                                      result);
+  positivity::propagate_mul_from_views(lhs_view, rhs_view, result);
   return result;
 }
 
@@ -116,22 +115,20 @@ inline expression_holder<scalar_expression> tag_invoke(div_fn, L &&lhs,
   // before the mul, since we bypassed the main pow() wrapper. The
   // subsequent `lhs * ...` mul DOES run propagation via the mul
   // operator's instrumentation.
-  const auto rhs_view = scalar_detail::positivity::read(rhs);
-  const auto neg_one_view =
-      scalar_detail::positivity::read(get_scalar_one()); // exp = -1
+  const auto rhs_view = positivity::read(rhs);
+  const auto neg_one_view = positivity::read(get_scalar_one()); // exp = -1
   auto pow_result =
       binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
   // exp view above was on +1; the actual exponent is -1, which is a
   // numeric constant (real-by-construction) — open-code the real
   // bit since we can't construct a view directly.
-  scalar_detail::positivity::view exp_view{};
+  positivity::view exp_view{};
   exp_view.real = true; // numeric constant
   exp_view.negative = true;
   exp_view.nonpositive = true;
   exp_view.nonzero = true;
   (void)neg_one_view;
-  scalar_detail::positivity::propagate_pow_from_views(rhs_view, exp_view,
-                                                      pow_result);
+  positivity::propagate_pow_from_views(rhs_view, exp_view, pow_result);
   return std::forward<L>(lhs) * std::move(pow_result);
 }
 

--- a/include/numsim_cas/scalar/scalar_operators.h
+++ b/include/numsim_cas/scalar/scalar_operators.h
@@ -116,18 +116,17 @@ inline expression_holder<scalar_expression> tag_invoke(div_fn, L &&lhs,
   // subsequent `lhs * ...` mul DOES run propagation via the mul
   // operator's instrumentation.
   const auto rhs_view = positivity::read(rhs);
-  const auto neg_one_view = positivity::read(get_scalar_one()); // exp = -1
   auto pow_result =
       binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
-  // exp view above was on +1; the actual exponent is -1, which is a
-  // numeric constant (real-by-construction) — open-code the real
-  // bit since we can't construct a view directly.
-  positivity::view exp_view{};
-  exp_view.real = true; // numeric constant
-  exp_view.negative = true;
-  exp_view.nonpositive = true;
-  exp_view.nonzero = true;
-  (void)neg_one_view;
+  // The exponent here is the literal -1 (a real numeric constant).
+  // Hand-construct the view rather than building a `-scalar_one`
+  // holder just to feed read() — same result, no allocation.
+  positivity::view const exp_view{.positive = false,
+                                  .nonnegative = false,
+                                  .nonpositive = true,
+                                  .negative = true,
+                                  .nonzero = true,
+                                  .real = true};
   positivity::propagate_pow_from_views(rhs_view, exp_view, pow_result);
   return std::forward<L>(lhs) * std::move(pow_result);
 }

--- a/include/numsim_cas/scalar/scalar_operators.h
+++ b/include/numsim_cas/scalar/scalar_operators.h
@@ -71,14 +71,14 @@ requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<scalar_expression>>
 inline expression_holder<scalar_expression> tag_invoke(mul_fn, L &&lhs,
                                                        R &&rhs) {
-  // #305 — capture operand sign views BEFORE forwarding (the visitor
+  // #305 — snapshot operand sign tags BEFORE forwarding (the visitor
   // may consume L/R as rvalues). Same shape as the t2s mul wiring.
-  const auto lhs_view = positivity::read(lhs);
-  const auto rhs_view = positivity::read(rhs);
+  const auto lhs_tags = positivity::read(lhs);
+  const auto rhs_tags = positivity::read(rhs);
   auto &_lhs{lhs.template get<scalar_visitable_t>()};
   simplifier::mul_base visitor(std::forward<L>(lhs), std::forward<R>(rhs));
   auto result = _lhs.accept(visitor);
-  positivity::propagate_mul_from_views(lhs_view, rhs_view, result);
+  positivity::propagate_mul(lhs_tags, rhs_tags, result);
   return result;
 }
 
@@ -115,19 +115,18 @@ inline expression_holder<scalar_expression> tag_invoke(div_fn, L &&lhs,
   // before the mul, since we bypassed the main pow() wrapper. The
   // subsequent `lhs * ...` mul DOES run propagation via the mul
   // operator's instrumentation.
-  const auto rhs_view = positivity::read(rhs);
+  const auto rhs_tags = positivity::read(rhs);
   auto pow_result =
       binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
   // The exponent here is the literal -1 (a real numeric constant).
-  // Hand-construct the view rather than building a `-scalar_one`
+  // Hand-build the tag snapshot rather than building a `-scalar_one`
   // holder just to feed read() — same result, no allocation.
-  positivity::view const exp_view{.positive = false,
-                                  .nonnegative = false,
-                                  .nonpositive = true,
-                                  .negative = true,
-                                  .nonzero = true,
-                                  .real = true};
-  positivity::propagate_pow_from_views(rhs_view, exp_view, pow_result);
+  numeric_assumption_manager exp_tags;
+  exp_tags.insert(negative{});
+  exp_tags.insert(nonpositive{});
+  exp_tags.insert(nonzero{});
+  exp_tags.insert(real_tag{});
+  positivity::propagate_pow(rhs_tags, exp_tags, pow_result);
   return std::forward<L>(lhs) * std::move(pow_result);
 }
 

--- a/include/numsim_cas/scalar/scalar_operators.h
+++ b/include/numsim_cas/scalar/scalar_operators.h
@@ -71,8 +71,7 @@ requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<scalar_expression>>
 inline expression_holder<scalar_expression> tag_invoke(mul_fn, L &&lhs,
                                                        R &&rhs) {
-  // #305 — snapshot operand sign tags BEFORE forwarding (the visitor
-  // may consume L/R as rvalues). Same shape as the t2s mul wiring.
+  // #305 — snapshot sign tags before forwarding (visitor may move L/R).
   const auto lhs_tags = positivity::read(lhs);
   const auto rhs_tags = positivity::read(rhs);
   auto &_lhs{lhs.template get<scalar_visitable_t>()};
@@ -108,19 +107,14 @@ inline expression_holder<scalar_expression> tag_invoke(div_fn, L &&lhs,
   if (rhs_val && *rhs_val == scalar_number{1}) {
     return std::forward<L>(lhs);
   }
-  // General: x / y → x * y^(-1)
-  // Use binary_scalar_pow_simplify to bypass pow() constant folding
-  // so that pow(c, -1) stays structural and the printer formats as x/c.
-  // #305 — apply pow propagation manually on the simplify result
-  // before the mul, since we bypassed the main pow() wrapper. The
-  // subsequent `lhs * ...` mul DOES run propagation via the mul
-  // operator's instrumentation.
+  // General: x / y → x * y^(-1). binary_scalar_pow_simplify bypasses
+  // pow()'s folding so pow(c, -1) stays structural (printer shows x/c);
+  // propagate pow here since we skipped the pow() wrapper (the mul below
+  // runs its own propagation).
   const auto rhs_tags = positivity::read(rhs);
   auto pow_result =
       binary_scalar_pow_simplify(std::forward<R>(rhs), -get_scalar_one());
-  // The exponent here is the literal -1 (a real numeric constant).
-  // Hand-build the tag snapshot rather than building a `-scalar_one`
-  // holder just to feed read() — same result, no allocation.
+  // Exponent is the literal -1; hand-build its tags, no holder needed.
   numeric_assumption_manager exp_tags;
   exp_tags.insert(negative{});
   exp_tags.insert(nonpositive{});

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -41,12 +41,13 @@ struct view {
 inline view read(expression_holder<scalar_expression> const &e) {
   // Defense-in-depth: an invalid holder would null-deref through
   // numeric_assumption_manager::contains. Today no caller in the
-  // codebase passes an invalid holder here — the accumulator-init
-  // fix in scalar_differentiation.cpp (`expr_result = scalar_zero,
-  // expr_result_in = scalar_one`) eliminates the only known source.
+  // codebase passes an invalid holder here — the scalar diff
+  // visitor uses identity-init (`expr_result = scalar_zero,
+  // expr_result_in = scalar_one` in scalar_differentiation.cpp) for
+  // its accumulators, which eliminates the only known source.
   // Keeping the guard belt-and-suspenders: it's a single-branch
-  // overhead and protects against future visitors that haven't
-  // adopted the identity-init pattern yet.
+  // overhead and protects against future visitors that don't follow
+  // the same pattern. See PR #309 for the audit.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -67,20 +67,4 @@ inline view read(expression_holder<scalar_expression> const &e) {
 
 } // namespace numsim::cas::positivity
 
-// Backward-compat namespace alias: existing scalar-domain call sites
-// reference `scalar_detail::positivity::*`. Re-export the shared
-// helpers + the scalar read() under that name so the operator-file
-// instrumentation doesn't need to change.
-namespace numsim::cas::scalar_detail::positivity {
-using numsim::cas::positivity::mark_negative;
-using numsim::cas::positivity::mark_nonnegative;
-using numsim::cas::positivity::mark_nonpositive;
-using numsim::cas::positivity::mark_positive;
-using numsim::cas::positivity::propagate_mul_from_views;
-using numsim::cas::positivity::propagate_neg_from_view;
-using numsim::cas::positivity::propagate_pow_from_views;
-using numsim::cas::positivity::read;
-using numsim::cas::positivity::view;
-} // namespace numsim::cas::scalar_detail::positivity
-
 #endif // SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -39,15 +39,20 @@ struct view {
 };
 
 inline view read(expression_holder<scalar_expression> const &e) {
-  // Defense-in-depth: an invalid holder would null-deref through
-  // numeric_assumption_manager::contains. Today no caller in the
-  // codebase passes an invalid holder here — the scalar diff
-  // visitor uses identity-init (`expr_result = scalar_zero,
-  // expr_result_in = scalar_one` in scalar_differentiation.cpp) for
-  // its accumulators, which eliminates the only known source.
-  // Keeping the guard belt-and-suspenders: it's a single-branch
-  // overhead and protects against future visitors that don't follow
-  // the same pattern. See PR #309 for the audit.
+  // Invalid-holder guard: an invalid holder would null-deref through
+  // numeric_assumption_manager::contains. This is reached from any
+  // `tag_invoke(mul_fn / pow_fn / neg_fn, scalar, ...)` call, which
+  // includes:
+  //   * user code: `expression_holder<scalar_expression>{} * x`
+  //     constructs an invalid lhs that the *= safety net would
+  //     normally handle silently, but our read() bypasses it.
+  //   * diff visitor accumulator state — was the source of the
+  //     FuzzyScalarDiff seed 35 crash that surfaced this latent UB.
+  //     scalar_differentiation now identity-inits its accumulators
+  //     (scalar_zero / scalar_one), so the diff-internal source is
+  //     closed. The guard remains for the user-code path and any
+  //     future visitor that doesn't follow the identity-init
+  //     pattern.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -10,11 +10,6 @@
 #include <numsim_cas/scalar/scalar_negative.h>
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_zero.h>
-// Intentionally NOT including scalar_domain_traits.h — it transitively
-// pulls in scalar_std.h via scalar_all.h, which creates a cycle (since
-// scalar_std.h includes this header). Open-code the "is real-by-
-// construction numeric constant" check using the structural is_same
-// predicates instead.
 
 // #305 — positivity-tag propagation for scalar operators (mul, neg, pow).
 //
@@ -44,10 +39,14 @@ struct view {
 };
 
 inline view read(expression_holder<scalar_expression> const &e) {
-  // Scalar differentiation produces transient invalid holders during
-  // chain-rule decomposition (a known #287-tracked corner). Guard so
-  // a `read(invalid)` returns the all-false view rather than crashing
-  // in numeric_assumption_manager::contains via a null data pointer.
+  // Defense-in-depth: an invalid holder would null-deref through
+  // numeric_assumption_manager::contains. Today no caller in the
+  // codebase passes an invalid holder here — the accumulator-init
+  // fix in scalar_differentiation.cpp (`expr_result = scalar_zero,
+  // expr_result_in = scalar_one`) eliminates the only known source.
+  // Keeping the guard belt-and-suspenders: it's a single-branch
+  // overhead and protects against future visitors that haven't
+  // adopted the identity-init pattern yet.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -1,43 +1,26 @@
 #ifndef SCALAR_POSITIVITY_PROPAGATION_H
 #define SCALAR_POSITIVITY_PROPAGATION_H
 
-#include <cassert>
-
-#include <numsim_cas/core/assumptions.h>
-#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/core/positivity_propagation.h>
 #include <numsim_cas/scalar/scalar_constant.h>
 #include <numsim_cas/scalar/scalar_expression.h>
 #include <numsim_cas/scalar/scalar_negative.h>
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_zero.h>
 
-// #305 — positivity-tag propagation for scalar operators (mul, neg, pow).
-//
-// Direct parallel of `tensor_to_scalar_positivity_propagation.h` (#260).
-// Same rule table, same aliasing-mutation contract, same defense-in-depth
-// asserts. The only structural difference: scalar has no wrapper-bridge
-// node, so `read()` doesn't need the scalar_wrapper-forwarding branch.
-//
-// When #305 and #260 are both green, the obvious refactor is to lift
-// both into a templated `<Domain>` header. Deferred to #262 (cross-
-// domain unification) to keep this PR focused.
+// Scalar adapter for the domain-agnostic positivity propagation
+// (see `core/positivity_propagation.h`). Only the `read()` function
+// is domain-specific: it inspects scalar-domain leaf node types
+// (scalar_zero/one/constant/negative) for the "is real-by-
+// construction numeric constant" check. Everything else
+// (mark_*, propagate_*, view) is shared.
 
-namespace numsim::cas::scalar_detail::positivity {
+namespace numsim::cas::positivity {
 
-// Tag-state view. NOTE: these are tag-manager predicates, not truth
-// predicates — a caller writing incoherent tags defeats inference.
-struct view {
-  bool positive;
-  bool nonnegative;
-  bool nonpositive;
-  bool negative;
-  bool nonzero;
-  bool real;
-
-  bool at_least_nonneg_tag() const { return positive || nonnegative; }
-  bool at_least_nonpos_tag() const { return negative || nonpositive; }
-};
-
+// Read sign tags from a scalar expression's assumption manager.
+// Promotes the "concrete numeric constant" check to `real` so
+// `pow(x, integer)` exponents fire the real-exponent guard without
+// waiting on #261 (constants pre-annotation).
 inline view read(expression_holder<scalar_expression> const &e) {
   // Invalid-holder guard: an invalid holder would null-deref through
   // numeric_assumption_manager::contains. This is reached from any
@@ -47,10 +30,9 @@ inline view read(expression_holder<scalar_expression> const &e) {
   //     constructs an invalid lhs that the *= safety net would
   //     normally handle silently, but our read() bypasses it.
   //   * diff visitor accumulator state — was the source of the
-  //     FuzzyScalarDiff seed 35 crash that surfaced this latent UB.
-  //     scalar_differentiation now identity-inits its accumulators
-  //     (scalar_zero / scalar_one), so the diff-internal source is
-  //     closed. The guard remains for the user-code path and any
+  //     FuzzyScalarDiff seed 35 crash. scalar_differentiation now
+  //     identity-inits its accumulators so the diff-internal source
+  //     is closed. The guard remains for the user-code path and any
   //     future visitor that doesn't follow the identity-init
   //     pattern.
   if (!e.is_valid())
@@ -65,13 +47,10 @@ inline view read(expression_holder<scalar_expression> const &e) {
              a.contains(numsim::cas::integer{}) ||
              a.contains(numsim::cas::rational{}) ||
              a.contains(numsim::cas::irrational{})};
-  // Concrete numeric constants are real by construction. See the t2s
-  // header's same-shape note (#261 tracks the broader fix of pre-
-  // annotating constant nodes; this branch avoids waiting on it).
-  // Open-coded structural check mirroring domain_traits::try_numeric
-  // (we can't include scalar_domain_traits.h here due to the
-  // scalar_std.h cycle — domain_traits includes scalar_all → scalar_std,
-  // and scalar_std includes this header).
+  // Concrete numeric constants are real by construction. Open-coded
+  // structural check (instead of domain_traits::try_numeric) to
+  // sidestep the scalar_domain_traits → scalar_all → scalar_std
+  // include cycle.
   if (!v.real) {
     if (is_same<scalar_zero>(e) || is_same<scalar_one>(e) ||
         is_same<scalar_constant>(e))
@@ -86,99 +65,22 @@ inline view read(expression_holder<scalar_expression> const &e) {
   return v;
 }
 
-// Defense-in-depth: catches a future rule that would insert a tag
-// contradicting the operand's existing state. Aliasing makes this
-// critical — if `result` shares its node with an operand (via a fold
-// returning the operand directly), the insertion mutates the operand.
-#ifndef NDEBUG
-#define NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)    \
-  do {                                                                         \
-    assert(!(manager).contains(banned_tag) &&                                  \
-           "scalar positivity_propagation: rule would set a tag "              \
-           "contradicting the operand's existing state");                      \
-  } while (0)
-#else
-#define NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)    \
-  ((void)0)
-#endif
+} // namespace numsim::cas::positivity
 
-inline void mark_positive(expression_holder<scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonpositive{});
-  a.insert(numsim::cas::positive{});
-  a.insert(numsim::cas::nonnegative{});
-  a.insert(numsim::cas::nonzero{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void mark_negative(expression_holder<scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonnegative{});
-  a.insert(numsim::cas::negative{});
-  a.insert(numsim::cas::nonpositive{});
-  a.insert(numsim::cas::nonzero{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void mark_nonnegative(expression_holder<scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
-  a.insert(numsim::cas::nonnegative{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void mark_nonpositive(expression_holder<scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_SCALAR_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
-  a.insert(numsim::cas::nonpositive{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-
-// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg. ORDER MATTERS.
-inline void
-propagate_mul_from_views(view lhs, view rhs,
-                         expression_holder<scalar_expression> const &result) {
-  if (lhs.positive && rhs.positive) {
-    mark_positive(result);
-  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
-// Neg: flip sign, preserve magnitude class. The -(-x) → x fold lives
-// in the cpp file and bypasses this path. The -neg / -nonpos branches
-// are kept for future-symmetry with sign-aware mul (out of scope).
-inline void
-propagate_neg_from_view(view operand,
-                        expression_holder<scalar_expression> const &result) {
-  if (operand.positive) {
-    mark_negative(result);
-  } else if (operand.at_least_nonneg_tag()) {
-    mark_nonpositive(result);
-  } else if (operand.negative) {
-    mark_positive(result);
-  } else if (operand.at_least_nonpos_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
-// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
-// ORDER MATTERS.
-inline void
-propagate_pow_from_views(view base, view exponent,
-                         expression_holder<scalar_expression> const &result) {
-  if (base.positive && exponent.real) {
-    mark_positive(result);
-    return;
-  }
-  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
+// Backward-compat namespace alias: existing scalar-domain call sites
+// reference `scalar_detail::positivity::*`. Re-export the shared
+// helpers + the scalar read() under that name so the operator-file
+// instrumentation doesn't need to change.
+namespace numsim::cas::scalar_detail::positivity {
+using numsim::cas::positivity::mark_negative;
+using numsim::cas::positivity::mark_nonnegative;
+using numsim::cas::positivity::mark_nonpositive;
+using numsim::cas::positivity::mark_positive;
+using numsim::cas::positivity::propagate_mul_from_views;
+using numsim::cas::positivity::propagate_neg_from_view;
+using numsim::cas::positivity::propagate_pow_from_views;
+using numsim::cas::positivity::read;
+using numsim::cas::positivity::view;
 } // namespace numsim::cas::scalar_detail::positivity
 
 #endif // SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -8,48 +8,27 @@
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_zero.h>
 
-// Scalar adapter for the domain-agnostic positivity propagation
-// (see `core/positivity_propagation.h`). Only the `read()` function
-// is domain-specific: it inspects scalar-domain leaf node types
-// (scalar_zero/one/constant/negative) for the "is real-by-
-// construction numeric constant" check. Everything else
-// (mark_*, propagate_*) is shared.
+// Scalar adapter for core/positivity_propagation.h. Only read() is
+// domain-specific; mark_*/propagate_* are shared.
 
 namespace numsim::cas::positivity {
 
 // Snapshot a scalar expression's sign tags, normalized so real_tag is
-// materialized (integer/rational/irrational and numeric constants all
-// imply real) — so `pow(x, integer)` exponents fire the real-exponent
-// guard without waiting on #261 (constants pre-annotation).
+// materialized (integer/rational/irrational and numeric constants imply
+// real — lets pow(x, integer) fire the real-exponent guard, #261).
 inline numeric_assumption_manager
 read(expression_holder<scalar_expression> const &e) {
-  // Invalid-holder guard: an invalid holder would null-deref through
-  // e.data()->assumptions(). This is reached from any
-  // `tag_invoke(mul_fn / pow_fn / neg_fn, scalar, ...)` call, which
-  // includes:
-  //   * user code: `expression_holder<scalar_expression>{} * x`
-  //     constructs an invalid lhs that the *= safety net would
-  //     normally handle silently, but our read() bypasses it.
-  //   * diff visitor accumulator state — was the source of the
-  //     FuzzyScalarDiff seed 35 crash. scalar_differentiation now
-  //     identity-inits its accumulators so the diff-internal source
-  //     is closed. The guard remains for the user-code path and any
-  //     future visitor that doesn't follow the identity-init
-  //     pattern.
+  // Guard invalid holders (user code, or a diff accumulator before its
+  // first assignment) — assumptions() would null-deref otherwise.
   if (!e.is_valid())
     return {};
   numeric_assumption_manager m = e.data()->assumptions(); // value snapshot
-  // real-by-implication.
   if (m.contains(numsim::cas::integer{}) ||
       m.contains(numsim::cas::rational{}) ||
       m.contains(numsim::cas::irrational{}))
     m.insert(numsim::cas::real_tag{});
-  // Concrete numeric constants are real by construction. Open-coded
-  // structural check (instead of domain_traits::try_numeric) to
-  // sidestep the scalar_domain_traits → scalar_all → scalar_std
-  // include cycle. Promoting any scalar_constant to real is sound
-  // because complex constants are rejected at scalar_constant
-  // construction (scalar_constant.h) — every constant here is real.
+  // Numeric constants are real (complex is rejected at construction).
+  // Structural check avoids the domain_traits include cycle.
   if (!m.contains(numsim::cas::real_tag{})) {
     if (is_same<scalar_zero>(e) || is_same<scalar_one>(e) ||
         is_same<scalar_constant>(e))

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -13,17 +13,18 @@
 // is domain-specific: it inspects scalar-domain leaf node types
 // (scalar_zero/one/constant/negative) for the "is real-by-
 // construction numeric constant" check. Everything else
-// (mark_*, propagate_*, view) is shared.
+// (mark_*, propagate_*) is shared.
 
 namespace numsim::cas::positivity {
 
-// Read sign tags from a scalar expression's assumption manager.
-// Promotes the "concrete numeric constant" check to `real` so
-// `pow(x, integer)` exponents fire the real-exponent guard without
-// waiting on #261 (constants pre-annotation).
-inline view read(expression_holder<scalar_expression> const &e) {
+// Snapshot a scalar expression's sign tags, normalized so real_tag is
+// materialized (integer/rational/irrational and numeric constants all
+// imply real) — so `pow(x, integer)` exponents fire the real-exponent
+// guard without waiting on #261 (constants pre-annotation).
+inline numeric_assumption_manager
+read(expression_holder<scalar_expression> const &e) {
   // Invalid-holder guard: an invalid holder would null-deref through
-  // numeric_assumption_manager::contains. This is reached from any
+  // e.data()->assumptions(). This is reached from any
   // `tag_invoke(mul_fn / pow_fn / neg_fn, scalar, ...)` call, which
   // includes:
   //   * user code: `expression_holder<scalar_expression>{} * x`
@@ -37,34 +38,30 @@ inline view read(expression_holder<scalar_expression> const &e) {
   //     pattern.
   if (!e.is_valid())
     return {};
-  auto const &a = e.data()->assumptions();
-  view v{a.contains(numsim::cas::positive{}),
-         a.contains(numsim::cas::nonnegative{}),
-         a.contains(numsim::cas::nonpositive{}),
-         a.contains(numsim::cas::negative{}),
-         a.contains(numsim::cas::nonzero{}),
-         a.contains(numsim::cas::real_tag{}) ||
-             a.contains(numsim::cas::integer{}) ||
-             a.contains(numsim::cas::rational{}) ||
-             a.contains(numsim::cas::irrational{})};
+  numeric_assumption_manager m = e.data()->assumptions(); // value snapshot
+  // real-by-implication.
+  if (m.contains(numsim::cas::integer{}) ||
+      m.contains(numsim::cas::rational{}) ||
+      m.contains(numsim::cas::irrational{}))
+    m.insert(numsim::cas::real_tag{});
   // Concrete numeric constants are real by construction. Open-coded
   // structural check (instead of domain_traits::try_numeric) to
   // sidestep the scalar_domain_traits → scalar_all → scalar_std
   // include cycle. Promoting any scalar_constant to real is sound
   // because complex constants are rejected at scalar_constant
   // construction (scalar_constant.h) — every constant here is real.
-  if (!v.real) {
+  if (!m.contains(numsim::cas::real_tag{})) {
     if (is_same<scalar_zero>(e) || is_same<scalar_one>(e) ||
         is_same<scalar_constant>(e))
-      v.real = true;
+      m.insert(numsim::cas::real_tag{});
     else if (is_same<scalar_negative>(e)) {
       auto const &inner = e.template get<scalar_negative>().expr();
       if (is_same<scalar_zero>(inner) || is_same<scalar_one>(inner) ||
           is_same<scalar_constant>(inner))
-        v.real = true;
+        m.insert(numsim::cas::real_tag{});
     }
   }
-  return v;
+  return m;
 }
 
 } // namespace numsim::cas::positivity

--- a/include/numsim_cas/scalar/scalar_positivity_propagation.h
+++ b/include/numsim_cas/scalar/scalar_positivity_propagation.h
@@ -50,7 +50,9 @@ inline view read(expression_holder<scalar_expression> const &e) {
   // Concrete numeric constants are real by construction. Open-coded
   // structural check (instead of domain_traits::try_numeric) to
   // sidestep the scalar_domain_traits → scalar_all → scalar_std
-  // include cycle.
+  // include cycle. Promoting any scalar_constant to real is sound
+  // because complex constants are rejected at scalar_constant
+  // construction (scalar_constant.h) — every constant here is real.
   if (!v.real) {
     if (is_same<scalar_zero>(e) || is_same<scalar_one>(e) ||
         is_same<scalar_constant>(e))

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -110,12 +110,11 @@ template <scalar_expr_holder L, scalar_expr_holder R>
   }
 
   // #305 — capture sign views BEFORE forwarding to the simplifier.
-  const auto base_view = scalar_detail::positivity::read(expr_lhs);
-  const auto exp_view = scalar_detail::positivity::read(expr_rhs);
+  const auto base_view = positivity::read(expr_lhs);
+  const auto exp_view = positivity::read(expr_rhs);
   auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
                                            std::forward<R>(expr_rhs));
-  scalar_detail::positivity::propagate_pow_from_views(base_view, exp_view,
-                                                      result);
+  positivity::propagate_pow_from_views(base_view, exp_view, result);
   return result;
 }
 
@@ -129,12 +128,11 @@ requires std::is_arithmetic_v<std::remove_cvref_t<R>>
   // binary_scalar_pow_simplify directly (rather than routing
   // through the main pow above) to avoid the special-case folds,
   // so propagation needs to be applied here too.
-  const auto base_view = scalar_detail::positivity::read(expr_lhs);
-  const auto exp_view = scalar_detail::positivity::read(constant);
+  const auto base_view = positivity::read(expr_lhs);
+  const auto exp_view = positivity::read(constant);
   auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
                                            std::move(constant));
-  scalar_detail::positivity::propagate_pow_from_views(base_view, exp_view,
-                                                      result);
+  positivity::propagate_pow_from_views(base_view, exp_view, result);
   return result;
 }
 

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -109,12 +109,12 @@ template <scalar_expr_holder L, scalar_expr_holder R>
     }
   }
 
-  // #305 — capture sign views BEFORE forwarding to the simplifier.
-  const auto base_view = positivity::read(expr_lhs);
-  const auto exp_view = positivity::read(expr_rhs);
+  // #305 — snapshot sign tags BEFORE forwarding to the simplifier.
+  const auto base_tags = positivity::read(expr_lhs);
+  const auto exp_tags = positivity::read(expr_rhs);
   auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
                                            std::forward<R>(expr_rhs));
-  positivity::propagate_pow_from_views(base_view, exp_view, result);
+  positivity::propagate_pow(base_tags, exp_tags, result);
   return result;
 }
 
@@ -128,11 +128,11 @@ requires std::is_arithmetic_v<std::remove_cvref_t<R>>
   // binary_scalar_pow_simplify directly (rather than routing
   // through the main pow above) to avoid the special-case folds,
   // so propagation needs to be applied here too.
-  const auto base_view = positivity::read(expr_lhs);
-  const auto exp_view = positivity::read(constant);
+  const auto base_tags = positivity::read(expr_lhs);
+  const auto exp_tags = positivity::read(constant);
   auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),
                                            std::move(constant));
-  positivity::propagate_pow_from_views(base_view, exp_view, result);
+  positivity::propagate_pow(base_tags, exp_tags, result);
   return result;
 }
 

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -124,10 +124,7 @@ requires std::is_arithmetic_v<std::remove_cvref_t<R>>
   auto constant{detail::tag_invoke(detail::make_constant_fn{},
                                    std::type_identity<scalar_expression>{},
                                    expr_rhs)};
-  // #305 — apply pow propagation. The arithmetic overload calls
-  // binary_scalar_pow_simplify directly (rather than routing
-  // through the main pow above) to avoid the special-case folds,
-  // so propagation needs to be applied here too.
+  // #305 — this overload bypasses the main pow() above, so propagate here.
   const auto base_tags = positivity::read(expr_lhs);
   const auto exp_tags = positivity::read(constant);
   auto result = binary_scalar_pow_simplify(std::forward<L>(expr_lhs),

--- a/include/numsim_cas/scalar/visitors/scalar_differentiation.h
+++ b/include/numsim_cas/scalar/visitors/scalar_differentiation.h
@@ -44,8 +44,26 @@ public:
 
   /**
    * @brief Differentiate an expression (const lvalue).
+   *
+   * \par Contract
+   * Always returns a VALID `expression_holder` — never the
+   * default-constructed (invalid) state. If a visitor overload
+   * leaves `m_result` unset (or unset == invalid), `apply_imp`
+   * substitutes `scalar_zero` at the boundary. Callers can rely
+   * on this and skip `is_valid()` checks on the result.
+   *
+   * This contract is load-bearing for instrumentation that reads
+   * `result.data()->...` directly (e.g. the positivity propagation
+   * helper at `scalar_positivity_propagation.h`). Visitor
+   * accumulator variables MUST be initialized to identity elements
+   * (`scalar_zero` for additive, `scalar_one` for multiplicative)
+   * to preserve the same contract for INTERMEDIATE state — a
+   * caller reading the accumulator mid-iteration would otherwise
+   * null-deref through the invalid holder. See PR #309 for the
+   * audit and pattern.
+   *
    * @param expr Expression to differentiate.
-   * @return The symbolic derivative d(expr)/d(m_arg).
+   * @return The symbolic derivative d(expr)/d(m_arg). Always valid.
    */
   auto apply(expr_holder_t const &expr) { return apply_imp(expr); }
 
@@ -326,15 +344,22 @@ private:
    * If the current visitor has set \f$m\_result = F'(u)\f$, this
    * multiplies by \f$u'(a)\f$ to obtain \f$F'(u(a))\,u'(a)\f$.
    *
+   * \warning Behavior change (PR #309): previously skipped the
+   * multiplication when `inner.is_valid()` was false, leaving
+   * `m_result = F'(u)` un-multiplied — a silently-wrong derivative
+   * for the rare "couldn't differentiate inner" case. After
+   * apply_imp's invalid→zero contract was tightened, `inner` is
+   * always valid (zero if `u` was constant), and the multiplication
+   * runs unconditionally: `F'(u) * 0 = 0` for constant inner, which
+   * is the correct chain-rule outcome.
+   *
    * @tparam T Unary node type exposing expr().
    * @param unary Unary node.
    */
   template <typename T> void apply_inner_unary(T const &unary) {
     scalar_differentiation inner_diff(m_arg);
     auto inner{inner_diff.apply(unary.expr())};
-    if (inner.is_valid()) {
-      m_result *= std::move(inner);
-    }
+    m_result *= std::move(inner);
   }
 
   /**

--- a/include/numsim_cas/scalar/visitors/scalar_differentiation.h
+++ b/include/numsim_cas/scalar/visitors/scalar_differentiation.h
@@ -59,8 +59,15 @@ public:
    * (`scalar_zero` for additive, `scalar_one` for multiplicative)
    * to preserve the same contract for INTERMEDIATE state — a
    * caller reading the accumulator mid-iteration would otherwise
-   * null-deref through the invalid holder. See PR #309 for the
-   * audit and pattern.
+   * null-deref through the invalid holder.
+   *
+   * \note The tensor-domain diff visitors
+   * (`tensor_differentiation`, `tensor_to_scalar_differentiation`)
+   * achieve the same intermediate-state guarantee via a different
+   * pattern: explicit `if (acc.is_valid()) acc += d; else acc =
+   * std::move(d);` checks. The asymmetry is intentional — tensor
+   * has no global identity (dim/rank vary with `m_arg`) so the
+   * scalar identity-init pattern doesn't transfer directly.
    *
    * @param expr Expression to differentiate.
    * @return The symbolic derivative d(expr)/d(m_arg). Always valid.
@@ -344,10 +351,19 @@ private:
    * If the current visitor has set \f$m\_result = F'(u)\f$, this
    * multiplies by \f$u'(a)\f$ to obtain \f$F'(u(a))\,u'(a)\f$.
    *
-   * \warning Behavior change (PR #309): previously skipped the
+   * \par Precondition
+   * `m_result` MUST be valid before calling. All current callers
+   * set it explicitly (e.g. `scalar_sin` sets `m_result = cos(u)`
+   * before calling). If a future unary handler forgets, the
+   * `operator*=` safety net would silently assign `inner` to
+   * `m_result`, yielding `u'(x)` instead of `F'(u) * u'(x)` — a
+   * wrong derivative with no compile-time signal. The debug
+   * assert below catches it.
+   *
+   * \warning Behavior change (previously this helper skipped the
    * multiplication when `inner.is_valid()` was false, leaving
    * `m_result = F'(u)` un-multiplied — a silently-wrong derivative
-   * for the rare "couldn't differentiate inner" case. After
+   * for the rare "couldn't differentiate inner" case). After
    * apply_imp's invalid→zero contract was tightened, `inner` is
    * always valid (zero if `u` was constant), and the multiplication
    * runs unconditionally: `F'(u) * 0 = 0` for constant inner, which
@@ -357,6 +373,9 @@ private:
    * @param unary Unary node.
    */
   template <typename T> void apply_inner_unary(T const &unary) {
+    assert(m_result.is_valid() &&
+           "apply_inner_unary: caller must set m_result = F'(u) before "
+           "invoking the chain rule");
     scalar_differentiation inner_diff(m_arg);
     auto inner{inner_diff.apply(unary.expr())};
     m_result *= std::move(inner);

--- a/include/numsim_cas/scalar/visitors/scalar_differentiation.h
+++ b/include/numsim_cas/scalar/visitors/scalar_differentiation.h
@@ -54,20 +54,23 @@ public:
    *
    * This contract is load-bearing for instrumentation that reads
    * `result.data()->...` directly (e.g. the positivity propagation
-   * helper at `scalar_positivity_propagation.h`). Visitor
-   * accumulator variables MUST be initialized to identity elements
-   * (`scalar_zero` for additive, `scalar_one` for multiplicative)
-   * to preserve the same contract for INTERMEDIATE state — a
-   * caller reading the accumulator mid-iteration would otherwise
-   * null-deref through the invalid holder.
+   * helper at `scalar_positivity_propagation.h`). To preserve the
+   * same contract for INTERMEDIATE state during accumulation, use
+   * one of these two patterns when building results iteratively:
    *
-   * \note The tensor-domain diff visitors
-   * (`tensor_differentiation`, `tensor_to_scalar_differentiation`)
-   * achieve the same intermediate-state guarantee via a different
-   * pattern: explicit `if (acc.is_valid()) acc += d; else acc =
-   * std::move(d);` checks. The asymmetry is intentional — tensor
-   * has no global identity (dim/rank vary with `m_arg`) so the
-   * scalar identity-init pattern doesn't transfer directly.
+   *   1. **Identity-init**: `acc = get_scalar_zero()` for additive,
+   *      `acc = get_scalar_one()` for multiplicative. Used here in
+   *      the scalar diff visitors (cheap singleton identities are
+   *      available).
+   *   2. **Explicit-check**: `if (acc.is_valid()) acc += d; else
+   *      acc = std::move(d);`. Used in the tensor-domain diff
+   *      visitors (`tensor_differentiation`,
+   *      `tensor_to_scalar_differentiation`) because tensor has no
+   *      global identity (dim/rank vary with `m_arg`).
+   *
+   * Either pattern preserves the invariant "accumulator holder is
+   * never invalid mid-iteration." Both produce identical observable
+   * behavior; the choice is per-domain ergonomics.
    *
    * @param expr Expression to differentiate.
    * @return The symbolic derivative d(expr)/d(m_arg). Always valid.

--- a/include/numsim_cas/scalar/visitors/scalar_differentiation.h
+++ b/include/numsim_cas/scalar/visitors/scalar_differentiation.h
@@ -45,35 +45,14 @@ public:
   /**
    * @brief Differentiate an expression (const lvalue).
    *
-   * \par Contract
-   * Always returns a VALID `expression_holder` — never the
-   * default-constructed (invalid) state. If a visitor overload
-   * leaves `m_result` unset (or unset == invalid), `apply_imp`
-   * substitutes `scalar_zero` at the boundary. Callers can rely
-   * on this and skip `is_valid()` checks on the result.
+   * Always returns a VALID holder — apply_imp substitutes scalar_zero if
+   * a visitor leaves m_result unset. Instrumentation that reads
+   * result.data() directly (e.g. positivity propagation) relies on this.
+   * To keep intermediate accumulators valid, init to an identity
+   * (get_scalar_zero/one) or explicit-check (`if (acc.is_valid())`); the
+   * tensor domains use the latter since they have no global identity.
    *
-   * This contract is load-bearing for instrumentation that reads
-   * `result.data()->...` directly (e.g. the positivity propagation
-   * helper at `scalar_positivity_propagation.h`). To preserve the
-   * same contract for INTERMEDIATE state during accumulation, use
-   * one of these two patterns when building results iteratively:
-   *
-   *   1. **Identity-init**: `acc = get_scalar_zero()` for additive,
-   *      `acc = get_scalar_one()` for multiplicative. Used here in
-   *      the scalar diff visitors (cheap singleton identities are
-   *      available).
-   *   2. **Explicit-check**: `if (acc.is_valid()) acc += d; else
-   *      acc = std::move(d);`. Used in the tensor-domain diff
-   *      visitors (`tensor_differentiation`,
-   *      `tensor_to_scalar_differentiation`) because tensor has no
-   *      global identity (dim/rank vary with `m_arg`).
-   *
-   * Either pattern preserves the invariant "accumulator holder is
-   * never invalid mid-iteration." Both produce identical observable
-   * behavior; the choice is per-domain ergonomics.
-   *
-   * @param expr Expression to differentiate.
-   * @return The symbolic derivative d(expr)/d(m_arg). Always valid.
+   * @return d(expr)/d(m_arg). Always valid.
    */
   auto apply(expr_holder_t const &expr) { return apply_imp(expr); }
 
@@ -349,31 +328,12 @@ public:
 
 private:
   /**
-   * @brief Apply chain rule for unary nodes.
+   * @brief Chain rule for unary nodes: m_result = F'(u) *= u'(a).
    *
-   * If the current visitor has set \f$m\_result = F'(u)\f$, this
-   * multiplies by \f$u'(a)\f$ to obtain \f$F'(u(a))\,u'(a)\f$.
-   *
-   * \par Precondition
-   * `m_result` MUST be valid before calling. All current callers
-   * set it explicitly (e.g. `scalar_sin` sets `m_result = cos(u)`
-   * before calling). If a future unary handler forgets, the
-   * `operator*=` safety net would silently assign `inner` to
-   * `m_result`, yielding `u'(x)` instead of `F'(u) * u'(x)` — a
-   * wrong derivative with no compile-time signal. The debug
-   * assert below catches it.
-   *
-   * \warning Behavior change (previously this helper skipped the
-   * multiplication when `inner.is_valid()` was false, leaving
-   * `m_result = F'(u)` un-multiplied — a silently-wrong derivative
-   * for the rare "couldn't differentiate inner" case). After
-   * apply_imp's invalid→zero contract was tightened, `inner` is
-   * always valid (zero if `u` was constant), and the multiplication
-   * runs unconditionally: `F'(u) * 0 = 0` for constant inner, which
-   * is the correct chain-rule outcome.
-   *
-   * @tparam T Unary node type exposing expr().
-   * @param unary Unary node.
+   * Precondition: m_result valid (the caller set F'(u); the assert
+   * catches a handler that forgot — else the *= safety net would yield
+   * u'(x) instead of F'(u)*u'(x)). inner is always valid now (zero for
+   * constant u), so `F'(u) * 0 = 0` is the correct outcome.
    */
   template <typename T> void apply_inner_unary(T const &unary) {
     assert(m_result.is_valid() &&

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
@@ -102,14 +102,13 @@ tag_invoke(mul_fn, [[maybe_unused]] L &&lhs, [[maybe_unused]] R &&rhs) {
   // #260 — read operand positivity BEFORE forwarding (the visitor may
   // consume L/R as rvalues). Idempotent insertion afterwards lets a
   // folded result that already carries the tag pass through unchanged.
-  const auto lhs_view = tensor_to_scalar_detail::positivity::read(lhs);
-  const auto rhs_view = tensor_to_scalar_detail::positivity::read(rhs);
+  const auto lhs_view = positivity::read(lhs);
+  const auto rhs_view = positivity::read(rhs);
   auto &_lhs{lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                                         std::forward<R>(rhs));
   auto result = _lhs.accept(visitor);
-  tensor_to_scalar_detail::positivity::propagate_mul_from_views(
-      lhs_view, rhs_view, result);
+  positivity::propagate_mul_from_views(lhs_view, rhs_view, result);
   return result;
 }
 

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
@@ -99,9 +99,7 @@ requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<tensor_to_scalar_expression>>
 inline expression_holder<tensor_to_scalar_expression>
 tag_invoke(mul_fn, [[maybe_unused]] L &&lhs, [[maybe_unused]] R &&rhs) {
-  // #260 — read operand positivity BEFORE forwarding (the visitor may
-  // consume L/R as rvalues). Idempotent insertion afterwards lets a
-  // folded result that already carries the tag pass through unchanged.
+  // #260 — snapshot sign tags before forwarding (visitor may move L/R).
   const auto lhs_tags = positivity::read(lhs);
   const auto rhs_tags = positivity::read(rhs);
   auto &_lhs{lhs.template get<tensor_to_scalar_visitable_t>()};

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h
@@ -102,13 +102,13 @@ tag_invoke(mul_fn, [[maybe_unused]] L &&lhs, [[maybe_unused]] R &&rhs) {
   // #260 — read operand positivity BEFORE forwarding (the visitor may
   // consume L/R as rvalues). Idempotent insertion afterwards lets a
   // folded result that already carries the tag pass through unchanged.
-  const auto lhs_view = positivity::read(lhs);
-  const auto rhs_view = positivity::read(rhs);
+  const auto lhs_tags = positivity::read(lhs);
+  const auto rhs_tags = positivity::read(rhs);
   auto &_lhs{lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                                         std::forward<R>(rhs));
   auto result = _lhs.accept(visitor);
-  positivity::propagate_mul_from_views(lhs_view, rhs_view, result);
+  positivity::propagate_mul(lhs_tags, rhs_tags, result);
   return result;
 }
 

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -88,15 +88,18 @@ struct view {
 // #261 (constants pre-annotation) for the common `pow(x, integer)`
 // case.
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
-  // Defense-in-depth: an invalid holder would null-deref through
-  // numeric_assumption_manager::contains. The tensor-domain diff
-  // visitors use the explicit `is_valid()` accumulation pattern
-  // (`if (sum.is_valid()) sum += d; else sum = std::move(d);`),
-  // which eliminates the only known source of invalid intermediates.
-  // (Scalar uses identity-init via singletons — natural difference;
-  // tensor's dim/rank-dependent identities don't have global
-  // singletons.) Keeping the guard belt-and-suspenders. See PR #309
-  // for the audit.
+  // Invalid-holder guard: an invalid holder would null-deref through
+  // numeric_assumption_manager::contains. Reached from any
+  // `tag_invoke(mul_fn / pow_fn / neg_fn, t2s, ...)` call, which
+  // includes:
+  //   * user code: `expression_holder<tensor_to_scalar_expression>{}
+  //     * x` constructs an invalid lhs that the *= safety net would
+  //     normally handle silently, but our read() bypasses it.
+  //   * diff visitor accumulator state — tensor_to_scalar_add and
+  //     all other tensor-domain diff accumulators use the explicit
+  //     `if (acc.is_valid()) ...` pattern, so the diff-internal
+  //     source is closed. The guard remains for the user-code path
+  //     and any future visitor that doesn't follow the pattern.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -89,13 +89,14 @@ struct view {
 // case.
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   // Defense-in-depth: an invalid holder would null-deref through
-  // numeric_assumption_manager::contains. The
-  // tensor_to_scalar_differentiation.cpp accumulator fix
-  // (`tensor_to_scalar_add` now uses the explicit `is_valid()`
-  // check pattern instead of relying on `expression_holder::
-  // operator+=`'s invalid-lhs safety net) eliminates the only
-  // known source. Keeping the guard belt-and-suspenders for any
-  // future visitor that hasn't adopted the pattern.
+  // numeric_assumption_manager::contains. The tensor-domain diff
+  // visitors use the explicit `is_valid()` accumulation pattern
+  // (`if (sum.is_valid()) sum += d; else sum = std::move(d);`),
+  // which eliminates the only known source of invalid intermediates.
+  // (Scalar uses identity-init via singletons — natural difference;
+  // tensor's dim/rank-dependent identities don't have global
+  // singletons.) Keeping the guard belt-and-suspenders. See PR #309
+  // for the audit.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -1,92 +1,27 @@
 #ifndef TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
 #define TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H
 
-#include <cassert>
-
-#include <numsim_cas/core/assumptions.h>
-#include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/core/positivity_propagation.h>
 #include <numsim_cas/scalar/scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_domain_traits.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
 
-// #260 — positivity-tag propagation for t2s operators (mul, neg, pow).
-//
-// Each operator captures a `view` of its operand assumptions BEFORE
-// forwarding into the simplifier (which may consume the holder as an
-// rvalue), then applies the matching propagation rule to the result
-// holder. Joint insertions mirror scalar_assume.h's pattern: a
-// `positive` insertion also writes nonnegative + nonzero + real_tag.
-// set_inferred() marks them as established facts (forward-compat with
-// the planned assumption propagator).
-//
-// ── Aliasing contract ───────────────────────────────────────────
-//
-// `result` may alias one of the operand holders. The simplifier is
-// allowed to fold (e.g. `x * 1 → x`) and return the operand's own
-// holder; in that case `result.data()` is the operand's node and
-// inserting into `result.data()->assumptions()` mutates the operand.
-//
-// All rules here are designed so this mutation is sound — they only
-// fire when the inferred tags are already implied by the operand's
-// state. e.g. `mark_positive(x)` after `propagate_mul(x_pos, 1_pos)`
-// when the fold returned x is safe because x was already positive.
-//
-// If you add a new rule, preserve this invariant: a rule that fires
-// on operand views V_lhs, V_rhs must produce a result tag that is a
-// logical consequence of V_lhs ∧ V_rhs — never strictly stronger than
-// any single operand's existing state.
-//
-// ── Robustness to direct-manager callers ────────────────────────
-//
-// Reading code that mixed `pos·nonneg → nonneg` is implemented as
-// `(pos || nonneg) && (pos || nonneg) → nonneg`. This handles the
-// case where a caller used the lower-level
-// `manager.insert(positive{})` without going through the joint-
-// insertion helpers — `positive{}` is then present without
-// `nonnegative{}`. Same shape for the pow "exponent is real" guard:
-// `real_tag || any sign tag || integer || rational || try_numeric()`.
+// T2S adapter for the domain-agnostic positivity propagation (see
+// `core/positivity_propagation.h`). Only the `read()` function is
+// domain-specific: it forwards through `tensor_to_scalar_scalar_wrapper`
+// (the bridge from the scalar domain into t2s) to the inner scalar's
+// tags, and checks numeric constants via domain_traits::try_numeric.
+// Everything else (mark_*, propagate_*, view) is shared.
 
-namespace numsim::cas::tensor_to_scalar_detail::positivity {
+namespace numsim::cas::positivity {
 
-// Single struct holds all the assumption bits we read off an operand.
-//
-// NOTE: these are tag-state predicates, not truth predicates. A "true"
-// for `positive` means the manager contains `positive{}`, which IS the
-// closest tractable proxy for "the value is positive" given how the
-// codebase represents assumptions today — but a caller who mutates the
-// manager into an incoherent state (e.g. inserts both `positive{}` and
-// `nonpositive{}`) would defeat any inference here.
-struct view {
-  bool positive;
-  bool nonnegative;
-  bool nonpositive;
-  bool negative;
-  bool nonzero;
-  bool real; // real_tag OR integer/rational/irrational OR known numeric
-
-  // "At least nonneg" via TAG state: the operand carries either
-  // `positive{}` or `nonnegative{}`. Robust to direct-manager callers
-  // who set `positive{}` without the joint `nonnegative{}`. The "tag"
-  // suffix is intentional — distinguishes from the truth claim.
-  bool at_least_nonneg_tag() const { return positive || nonnegative; }
-  bool at_least_nonpos_tag() const { return negative || nonpositive; }
-};
-
-// Read sign tags from the t2s expression's assumption manager. If the
-// expression is a `tensor_to_scalar_scalar_wrapper` (the bridge from
-// the scalar domain into t2s), ALSO read the wrapped scalar's tags —
-// the wrapper's own manager is fresh at construction and doesn't
-// inherit from the scalar's. Forwarding is single-level: we don't
-// recurse through nested wrappers (the wrapper today wraps a
-// scalar_expression, never another t2s, so single-level is exhaustive).
-//
-// `real_tag` is treated permissively: real_tag itself, any sign tag
-// (which joint-inserts real_tag in the normal path), the discrete-
-// number tags (integer, rational), and concrete numeric constants
-// (try_numeric success) all count as "real". This avoids waiting on
-// #261 (constants pre-annotation) for the common `pow(x, integer)`
-// case.
+// Read sign tags from a t2s expression's assumption manager. If the
+// expression is a `tensor_to_scalar_scalar_wrapper`, ALSO read the
+// wrapped scalar's tags — the wrapper's own manager is fresh at
+// construction and doesn't inherit. Wrapper-forwarding is
+// single-level (the wrapper today wraps a scalar_expression, never
+// another t2s).
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   // Invalid-holder guard: an invalid holder would null-deref through
   // numeric_assumption_manager::contains. Reached from any
@@ -126,11 +61,9 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
              ia.contains(numsim::cas::rational{}) ||
              ia.contains(numsim::cas::irrational{});
   }
-  // Concrete numeric constants are real by construction — they evaluate
-  // to a `scalar_number` (double under the hood today; no complex path
-  // in t2s). Treating try_numeric() success as real_tag avoids waiting
-  // on #261 (pre-annotating tensor_to_scalar_one/zero/scalar_constant)
-  // for the common `pow(x, integer)` exponent case.
+  // Concrete numeric constants are real by construction. #261 will
+  // pre-annotate these, but until then we promote try_numeric()
+  // success to real_tag here.
   if (!v.real) {
     using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
     if (traits::try_numeric(e))
@@ -139,136 +72,22 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   return v;
 }
 
-// Defense-in-depth assertion macro. Catches a rule that would insert
-// a tag contradicting the operand's existing state — e.g. a
-// hypothetical incorrect `(neg, neg) → pos` rule firing on a manager
-// that already contains `negative{}`. Aliasing makes this critical:
-// if the result holder shares its node with an operand (via a fold
-// returning the operand), the insertion mutates the operand, and a
-// wrong rule corrupts the operand's tags.
-//
-// The check is a debug-only `assert` (compiled out under NDEBUG) —
-// rules in this header are intended to be statically correct, so the
-// assertions are for future contributors who add rules.
-#ifndef NDEBUG
-#define NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag)           \
-  do {                                                                         \
-    assert(!(manager).contains(banned_tag) &&                                  \
-           "positivity_propagation: rule would set a tag contradicting "       \
-           "the operand's existing state");                                    \
-  } while (0)
-#else
-#define NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(manager, banned_tag) ((void)0)
-#endif
+} // namespace numsim::cas::positivity
 
-inline void
-mark_positive(expression_holder<tensor_to_scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonpositive{});
-  a.insert(numsim::cas::positive{});
-  a.insert(numsim::cas::nonnegative{});
-  a.insert(numsim::cas::nonzero{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void
-mark_negative(expression_holder<tensor_to_scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::nonnegative{});
-  a.insert(numsim::cas::negative{});
-  a.insert(numsim::cas::nonpositive{});
-  a.insert(numsim::cas::nonzero{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void
-mark_nonnegative(expression_holder<tensor_to_scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::negative{});
-  a.insert(numsim::cas::nonnegative{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-inline void
-mark_nonpositive(expression_holder<tensor_to_scalar_expression> const &e) {
-  auto &a = e.data()->assumptions();
-  NUMSIM_CAS_PROP_ASSERT_NO_CONTRADICTION(a, numsim::cas::positive{});
-  a.insert(numsim::cas::nonpositive{});
-  a.insert(numsim::cas::real_tag{});
-  a.set_inferred();
-}
-
-// Mul: pos·pos → pos; (≥nonneg)·(≥nonneg) → nonneg.
-//
-// Sign-aware rules (neg·neg → pos, pos·neg → neg) are out of scope
-// per #260's "narrow scope here to mul/div/pow/neg first".
-//
-// ORDER MATTERS: stronger before weaker. The `pos·pos → pos` branch
-// must run first; swapping with the `at_least_nonneg_tag` branch
-// would collapse `pos·pos` to `nonneg` (still correct, but weaker
-// than necessary — and `nonzero` would be lost).
-inline void propagate_mul_from_views(
-    view lhs, view rhs,
-    expression_holder<tensor_to_scalar_expression> const &result) {
-  if (lhs.positive && rhs.positive) {
-    mark_positive(result);
-  } else if (lhs.at_least_nonneg_tag() && rhs.at_least_nonneg_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
-// Neg: flip sign, preserve magnitude class.
-//
-// REACHABILITY NOTE: only the `positive → negative` and
-// `at_least_nonneg_tag → nonpositive` branches are reachable from the
-// current call graph. The `-(-x) → x` fold in the t2s_negative
-// factory short-circuits before this helper runs, so an operand
-// carrying `negative{}` or `nonpositive{}` can't reach here — those
-// tags are only ever produced by THIS helper's own `mark_negative` /
-// `mark_nonpositive`, and the fold strips them.
-//
-// The `negative → positive` and `at_least_nonpos_tag → nonnegative`
-// branches are kept for future-symmetry. If/when a sign-aware op
-// (out of scope per #260) produces a `negative{}`-tagged result via
-// a non-tensor_negative node (e.g. `mul(positive, negative_const)`
-// after sign-aware mul lands), those branches start firing and the
-// neg propagation stays correct without further changes.
-inline void propagate_neg_from_view(
-    view operand,
-    expression_holder<tensor_to_scalar_expression> const &result) {
-  if (operand.positive) {
-    mark_negative(result);
-  } else if (operand.at_least_nonneg_tag()) {
-    mark_nonpositive(result);
-  } else if (operand.negative) {
-    mark_positive(result);
-  } else if (operand.at_least_nonpos_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
-// Pow: pow(pos, real) → pos; pow(≥nonneg, ≥nonneg) → nonneg.
-//
-// The "real exponent" guard prevents a complex exponent from silently
-// inheriting positivity. The strict pow(neg, even-int) → pos rule is
-// deferred (#260 scope-out).
-//
-// ORDER MATTERS (same shape as mul): pos+real first, then the
-// broader nonneg case.
-inline void propagate_pow_from_views(
-    view base, view exponent,
-    expression_holder<tensor_to_scalar_expression> const &result) {
-  if (base.positive && exponent.real) {
-    mark_positive(result);
-    return;
-  }
-  if (base.at_least_nonneg_tag() && exponent.at_least_nonneg_tag()) {
-    mark_nonnegative(result);
-  }
-}
-
+// Backward-compat namespace alias: existing t2s call sites reference
+// `tensor_to_scalar_detail::positivity::*`. Re-export the shared
+// helpers + the t2s read() under that name so the operator-file
+// instrumentation doesn't need to change.
+namespace numsim::cas::tensor_to_scalar_detail::positivity {
+using numsim::cas::positivity::mark_negative;
+using numsim::cas::positivity::mark_nonnegative;
+using numsim::cas::positivity::mark_nonpositive;
+using numsim::cas::positivity::mark_positive;
+using numsim::cas::positivity::propagate_mul_from_views;
+using numsim::cas::positivity::propagate_neg_from_view;
+using numsim::cas::positivity::propagate_pow_from_views;
+using numsim::cas::positivity::read;
+using numsim::cas::positivity::view;
 } // namespace numsim::cas::tensor_to_scalar_detail::positivity
 
 #endif // TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -74,20 +74,4 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
 
 } // namespace numsim::cas::positivity
 
-// Backward-compat namespace alias: existing t2s call sites reference
-// `tensor_to_scalar_detail::positivity::*`. Re-export the shared
-// helpers + the t2s read() under that name so the operator-file
-// instrumentation doesn't need to change.
-namespace numsim::cas::tensor_to_scalar_detail::positivity {
-using numsim::cas::positivity::mark_negative;
-using numsim::cas::positivity::mark_nonnegative;
-using numsim::cas::positivity::mark_nonpositive;
-using numsim::cas::positivity::mark_positive;
-using numsim::cas::positivity::propagate_mul_from_views;
-using numsim::cas::positivity::propagate_neg_from_view;
-using numsim::cas::positivity::propagate_pow_from_views;
-using numsim::cas::positivity::read;
-using numsim::cas::positivity::view;
-} // namespace numsim::cas::tensor_to_scalar_detail::positivity
-
 #endif // TENSOR_TO_SCALAR_POSITIVITY_PROPAGATION_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -88,12 +88,14 @@ struct view {
 // #261 (constants pre-annotation) for the common `pow(x, integer)`
 // case.
 inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
-  // Guard against invalid holders. Differentiation paths can produce
-  // transient invalid intermediates (corner cases of the chain rule —
-  // see #287); a read() on those would null-deref through
-  // numeric_assumption_manager::contains. The scalar side surfaced
-  // this on FuzzyScalarDiff seed 35; same latent UB on the t2s side
-  // so we patch symmetrically.
+  // Defense-in-depth: an invalid holder would null-deref through
+  // numeric_assumption_manager::contains. The
+  // tensor_to_scalar_differentiation.cpp accumulator fix
+  // (`tensor_to_scalar_add` now uses the explicit `is_valid()`
+  // check pattern instead of relying on `expression_holder::
+  // operator+=`'s invalid-lhs safety net) eliminates the only
+  // known source. Keeping the guard belt-and-suspenders for any
+  // future visitor that hasn't adopted the pattern.
   if (!e.is_valid())
     return {};
   auto const &a = e.data()->assumptions();

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -12,19 +12,20 @@
 // domain-specific: it forwards through `tensor_to_scalar_scalar_wrapper`
 // (the bridge from the scalar domain into t2s) to the inner scalar's
 // tags, and checks numeric constants via domain_traits::try_numeric.
-// Everything else (mark_*, propagate_*, view) is shared.
+// Everything else (mark_*, propagate_*) is shared.
 
 namespace numsim::cas::positivity {
 
-// Read sign tags from a t2s expression's assumption manager. If the
-// expression is a `tensor_to_scalar_scalar_wrapper`, ALSO read the
-// wrapped scalar's tags — the wrapper's own manager is fresh at
-// construction and doesn't inherit. Wrapper-forwarding is
+// Snapshot a t2s expression's sign tags (normalized so real_tag is
+// materialized). If the expression is a `tensor_to_scalar_scalar_wrapper`,
+// ALSO merge the wrapped scalar's tags — the wrapper's own manager is
+// fresh at construction and doesn't inherit. Wrapper-forwarding is
 // single-level (the wrapper today wraps a scalar_expression, never
 // another t2s).
-inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
+inline numeric_assumption_manager
+read(expression_holder<tensor_to_scalar_expression> const &e) {
   // Invalid-holder guard: an invalid holder would null-deref through
-  // numeric_assumption_manager::contains. Reached from any
+  // e.data()->assumptions(). Reached from any
   // `tag_invoke(mul_fn / pow_fn / neg_fn, t2s, ...)` call, which
   // includes:
   //   * user code: `expression_holder<tensor_to_scalar_expression>{}
@@ -37,41 +38,29 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
   //     and any future visitor that doesn't follow the pattern.
   if (!e.is_valid())
     return {};
-  auto const &a = e.data()->assumptions();
-  view v{a.contains(numsim::cas::positive{}),
-         a.contains(numsim::cas::nonnegative{}),
-         a.contains(numsim::cas::nonpositive{}),
-         a.contains(numsim::cas::negative{}),
-         a.contains(numsim::cas::nonzero{}),
-         a.contains(numsim::cas::real_tag{}) ||
-             a.contains(numsim::cas::integer{}) ||
-             a.contains(numsim::cas::rational{}) ||
-             a.contains(numsim::cas::irrational{})};
+  numeric_assumption_manager m = e.data()->assumptions(); // value snapshot
   if (is_same<tensor_to_scalar_scalar_wrapper>(e)) {
     auto const &inner =
         e.template get<tensor_to_scalar_scalar_wrapper>().expr();
-    auto const &ia = inner.data()->assumptions();
-    v.positive = v.positive || ia.contains(numsim::cas::positive{});
-    v.nonnegative = v.nonnegative || ia.contains(numsim::cas::nonnegative{});
-    v.nonpositive = v.nonpositive || ia.contains(numsim::cas::nonpositive{});
-    v.negative = v.negative || ia.contains(numsim::cas::negative{});
-    v.nonzero = v.nonzero || ia.contains(numsim::cas::nonzero{});
-    v.real = v.real || ia.contains(numsim::cas::real_tag{}) ||
-             ia.contains(numsim::cas::integer{}) ||
-             ia.contains(numsim::cas::rational{}) ||
-             ia.contains(numsim::cas::irrational{});
+    for (auto const &t : inner.data()->assumptions().data())
+      m.insert(t);
   }
+  // real-by-implication.
+  if (m.contains(numsim::cas::integer{}) ||
+      m.contains(numsim::cas::rational{}) ||
+      m.contains(numsim::cas::irrational{}))
+    m.insert(numsim::cas::real_tag{});
   // Concrete numeric constants are real by construction. #261 will
   // pre-annotate these, but until then we promote try_numeric() success
   // to real_tag here. Sound because complex constants are rejected at
   // scalar_constant construction (scalar_constant.h), so try_numeric()
   // can only return a real value.
-  if (!v.real) {
+  if (!m.contains(numsim::cas::real_tag{})) {
     using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
     if (traits::try_numeric(e))
-      v.real = true;
+      m.insert(numsim::cas::real_tag{});
   }
-  return v;
+  return m;
 }
 
 } // namespace numsim::cas::positivity

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -62,8 +62,10 @@ inline view read(expression_holder<tensor_to_scalar_expression> const &e) {
              ia.contains(numsim::cas::irrational{});
   }
   // Concrete numeric constants are real by construction. #261 will
-  // pre-annotate these, but until then we promote try_numeric()
-  // success to real_tag here.
+  // pre-annotate these, but until then we promote try_numeric() success
+  // to real_tag here. Sound because complex constants are rejected at
+  // scalar_constant construction (scalar_constant.h), so try_numeric()
+  // can only return a real value.
   if (!v.real) {
     using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
     if (traits::try_numeric(e))

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h
@@ -7,35 +7,18 @@
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_scalar_wrapper.h>
 
-// T2S adapter for the domain-agnostic positivity propagation (see
-// `core/positivity_propagation.h`). Only the `read()` function is
-// domain-specific: it forwards through `tensor_to_scalar_scalar_wrapper`
-// (the bridge from the scalar domain into t2s) to the inner scalar's
-// tags, and checks numeric constants via domain_traits::try_numeric.
-// Everything else (mark_*, propagate_*) is shared.
+// T2S adapter for core/positivity_propagation.h. Only read() is
+// domain-specific; mark_*/propagate_* are shared.
 
 namespace numsim::cas::positivity {
 
-// Snapshot a t2s expression's sign tags (normalized so real_tag is
-// materialized). If the expression is a `tensor_to_scalar_scalar_wrapper`,
-// ALSO merge the wrapped scalar's tags — the wrapper's own manager is
-// fresh at construction and doesn't inherit. Wrapper-forwarding is
-// single-level (the wrapper today wraps a scalar_expression, never
-// another t2s).
+// Snapshot a t2s expression's sign tags (real_tag materialized). For a
+// scalar_wrapper, also merge the wrapped scalar's tags (the wrapper's
+// own manager is fresh). Wrapper-forwarding is single-level.
 inline numeric_assumption_manager
 read(expression_holder<tensor_to_scalar_expression> const &e) {
-  // Invalid-holder guard: an invalid holder would null-deref through
-  // e.data()->assumptions(). Reached from any
-  // `tag_invoke(mul_fn / pow_fn / neg_fn, t2s, ...)` call, which
-  // includes:
-  //   * user code: `expression_holder<tensor_to_scalar_expression>{}
-  //     * x` constructs an invalid lhs that the *= safety net would
-  //     normally handle silently, but our read() bypasses it.
-  //   * diff visitor accumulator state — tensor_to_scalar_add and
-  //     all other tensor-domain diff accumulators use the explicit
-  //     `if (acc.is_valid()) ...` pattern, so the diff-internal
-  //     source is closed. The guard remains for the user-code path
-  //     and any future visitor that doesn't follow the pattern.
+  // Guard invalid holders (user code, or a diff accumulator before its
+  // first assignment) — assumptions() would null-deref otherwise.
   if (!e.is_valid())
     return {};
   numeric_assumption_manager m = e.data()->assumptions(); // value snapshot
@@ -45,16 +28,11 @@ read(expression_holder<tensor_to_scalar_expression> const &e) {
     for (auto const &t : inner.data()->assumptions().data())
       m.insert(t);
   }
-  // real-by-implication.
   if (m.contains(numsim::cas::integer{}) ||
       m.contains(numsim::cas::rational{}) ||
       m.contains(numsim::cas::irrational{}))
     m.insert(numsim::cas::real_tag{});
-  // Concrete numeric constants are real by construction. #261 will
-  // pre-annotate these, but until then we promote try_numeric() success
-  // to real_tag here. Sound because complex constants are rejected at
-  // scalar_constant construction (scalar_constant.h), so try_numeric()
-  // can only return a real value.
+  // Numeric constants are real (complex is rejected at construction).
   if (!m.contains(numsim::cas::real_tag{})) {
     using traits = numsim::cas::domain_traits<tensor_to_scalar_expression>;
     if (traits::try_numeric(e))

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -60,15 +60,14 @@ template <tensor_to_scalar_expr_holder ExprLHS,
 
   // #260 — capture sign tags on base and exponent BEFORE forwarding;
   // the visitor may consume the holders as rvalues.
-  const auto base_view = tensor_to_scalar_detail::positivity::read(expr_lhs);
-  const auto exp_view = tensor_to_scalar_detail::positivity::read(expr_rhs);
+  const auto base_view = positivity::read(expr_lhs);
+  const auto exp_view = positivity::read(expr_rhs);
   // Full simplification via visitor dispatch
   auto &_lhs{expr_lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::pow_base visitor(
       std::forward<ExprLHS>(expr_lhs), std::forward<ExprRHS>(expr_rhs));
   auto result = _lhs.accept(visitor);
-  tensor_to_scalar_detail::positivity::propagate_pow_from_views(
-      base_view, exp_view, result);
+  positivity::propagate_pow_from_views(base_view, exp_view, result);
   return result;
 }
 

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -58,8 +58,7 @@ template <tensor_to_scalar_expr_holder ExprLHS,
       return make_expression<tensor_to_scalar_one>();
   }
 
-  // #260 — capture sign tags on base and exponent BEFORE forwarding;
-  // the visitor may consume the holders as rvalues.
+  // #260 — snapshot sign tags before forwarding (visitor may move them).
   const auto base_tags = positivity::read(expr_lhs);
   const auto exp_tags = positivity::read(expr_rhs);
   // Full simplification via visitor dispatch

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -60,14 +60,14 @@ template <tensor_to_scalar_expr_holder ExprLHS,
 
   // #260 — capture sign tags on base and exponent BEFORE forwarding;
   // the visitor may consume the holders as rvalues.
-  const auto base_view = positivity::read(expr_lhs);
-  const auto exp_view = positivity::read(expr_rhs);
+  const auto base_tags = positivity::read(expr_lhs);
+  const auto exp_tags = positivity::read(expr_rhs);
   // Full simplification via visitor dispatch
   auto &_lhs{expr_lhs.template get<tensor_to_scalar_visitable_t>()};
   tensor_to_scalar_detail::simplifier::pow_base visitor(
       std::forward<ExprLHS>(expr_lhs), std::forward<ExprRHS>(expr_rhs));
   auto result = _lhs.accept(visitor);
-  positivity::propagate_pow_from_views(base_view, exp_view, result);
+  positivity::propagate_pow(base_tags, exp_tags, result);
   return result;
 }
 

--- a/src/numsim_cas/scalar/scalar_expression.cpp
+++ b/src/numsim_cas/scalar/scalar_expression.cpp
@@ -25,9 +25,9 @@ tag_invoke(detail::neg_fn, std::type_identity<scalar_expression>,
 
   // #305 — capture operand sign BEFORE building the negative node so
   // the propagation step can flip pos→neg / nonneg→nonpos / etc.
-  const auto operand_view = scalar_detail::positivity::read(e);
+  const auto operand_view = positivity::read(e);
   auto result = make_expression<scalar_negative>(e);
-  scalar_detail::positivity::propagate_neg_from_view(operand_view, result);
+  positivity::propagate_neg_from_view(operand_view, result);
   return result;
 }
 

--- a/src/numsim_cas/scalar/scalar_expression.cpp
+++ b/src/numsim_cas/scalar/scalar_expression.cpp
@@ -23,8 +23,7 @@ tag_invoke(detail::neg_fn, std::type_identity<scalar_expression>,
     return e.get<scalar_negative>().expr();
   }
 
-  // #305 — capture operand sign BEFORE building the negative node so
-  // the propagation step can flip pos→neg / nonneg→nonpos / etc.
+  // #305 — capture operand sign before building the node, then flip it.
   const auto operand_tags = positivity::read(e);
   auto result = make_expression<scalar_negative>(e);
   positivity::propagate_neg(operand_tags, result);

--- a/src/numsim_cas/scalar/scalar_expression.cpp
+++ b/src/numsim_cas/scalar/scalar_expression.cpp
@@ -25,9 +25,9 @@ tag_invoke(detail::neg_fn, std::type_identity<scalar_expression>,
 
   // #305 — capture operand sign BEFORE building the negative node so
   // the propagation step can flip pos→neg / nonneg→nonpos / etc.
-  const auto operand_view = positivity::read(e);
+  const auto operand_tags = positivity::read(e);
   auto result = make_expression<scalar_negative>(e);
-  positivity::propagate_neg_from_view(operand_view, result);
+  positivity::propagate_neg(operand_tags, result);
   return result;
 }
 

--- a/src/numsim_cas/scalar/visitors/scalar_assumption_propagator.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_assumption_propagator.cpp
@@ -224,10 +224,8 @@ void scalar_assumption_propagator::operator()(scalar_pow const &v) {
   // recognised. The bare `is_same<scalar_constant>` check this
   // replaced missed pow(x, 0) (scalar_zero, even) and would have
   // mis-classified pow(x, -2) (scalar_negative(scalar_constant{2})).
-  // No complex guard needed: complex constants are rejected at
-  // scalar_constant construction and symbols cannot be assumed complex,
-  // so every base/exponent reaching here is real. base^even ≥ 0 and
-  // positive^real > 0 hold unconditionally over the real numbers.
+  // No complex guard needed: complex is rejected at construction, so
+  // every base/exponent here is real (base^even ≥ 0, positive^real > 0).
   bool exp_even = false;
   if (auto iv = try_int_constant(v.expr_rhs())) {
     exp_even = (*iv % 2 == 0);
@@ -688,10 +686,8 @@ public:
     auto const &base_a = ensure_assumptions(v.expr_lhs());
     auto const &exp_a = ensure_assumptions(v.expr_rhs());
     m_result = {};
-    // No complex guard needed: complex constants are rejected at
-    // scalar_constant construction and symbols cannot be assumed
-    // complex, so every base/exponent reaching here is real (see the
-    // equivalent rule in scalar_assumption_propagator::operator()).
+    // No complex guard needed: complex is rejected at construction, so
+    // every base/exponent here is real (see the sibling pow rule above).
     bool exp_even = false;
     // try_int_constant (#284 architectural rule); see the equivalent
     // call in the earlier pow handler above for the singleton context.

--- a/src/numsim_cas/scalar/visitors/scalar_assumption_propagator.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_assumption_propagator.cpp
@@ -224,6 +224,10 @@ void scalar_assumption_propagator::operator()(scalar_pow const &v) {
   // recognised. The bare `is_same<scalar_constant>` check this
   // replaced missed pow(x, 0) (scalar_zero, even) and would have
   // mis-classified pow(x, -2) (scalar_negative(scalar_constant{2})).
+  // No complex guard needed: complex constants are rejected at
+  // scalar_constant construction and symbols cannot be assumed complex,
+  // so every base/exponent reaching here is real. base^even ≥ 0 and
+  // positive^real > 0 hold unconditionally over the real numbers.
   bool exp_even = false;
   if (auto iv = try_int_constant(v.expr_rhs())) {
     exp_even = (*iv % 2 == 0);
@@ -684,6 +688,10 @@ public:
     auto const &base_a = ensure_assumptions(v.expr_lhs());
     auto const &exp_a = ensure_assumptions(v.expr_rhs());
     m_result = {};
+    // No complex guard needed: complex constants are rejected at
+    // scalar_constant construction and symbols cannot be assumed
+    // complex, so every base/exponent reaching here is real (see the
+    // equivalent rule in scalar_assumption_propagator::operator()).
     bool exp_even = false;
     // try_int_constant (#284 architectural rule); see the equivalent
     // call in the earlier pow handler above for the singleton context.

--- a/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
@@ -19,9 +19,20 @@ void scalar_differentiation::operator()(
 }
 
 void scalar_differentiation::operator()(scalar_mul const &visitable) {
-  expr_holder_t expr_result;
+  // Initialize accumulators to identity elements so the first iteration's
+  // `+=` / `*=` doesn't operate on an invalid holder. Previously these
+  // were default-constructed (invalid) and relied on
+  // expression_holder's operator+= safety net (which converts
+  // `invalid += x` to `*this = x`). That safety net is real but it
+  // means CALLERS who read `data()->...` directly on the accumulator
+  // before the first iteration null-deref — surfaced as a segfault
+  // in #305 when the positivity-propagation read() call landed in the
+  // mul instrumentation. The is_valid() guard in read() is still
+  // belt-and-suspenders, but eliminating the invalid intermediate
+  // here is the principled fix.
+  expr_holder_t expr_result = get_scalar_zero();
   for (auto &expr_out : visitable.symbol_map() | std::views::values) {
-    expr_holder_t expr_result_in;
+    expr_holder_t expr_result_in = get_scalar_one();
     for (auto &expr_in : visitable.symbol_map() | std::views::values) {
       if (expr_out == expr_in) {
         scalar_differentiation d(m_arg);
@@ -42,7 +53,8 @@ void scalar_differentiation::operator()(scalar_mul const &visitable) {
 }
 
 void scalar_differentiation::operator()(scalar_add const &visitable) {
-  expr_holder_t expr_result;
+  // Identity-init: see scalar_mul comment above.
+  expr_holder_t expr_result = get_scalar_zero();
   for (auto &child : visitable.symbol_map() | std::views::values) {
     scalar_differentiation d(m_arg);
     expr_result += d.apply(child);

--- a/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
@@ -64,14 +64,12 @@ void scalar_differentiation::operator()(scalar_add const &visitable) {
 
 void scalar_differentiation::operator()(scalar_negative const &visitable) {
   scalar_differentiation d(m_arg);
-  auto diff_expr{d.apply(visitable.expr())};
-  // d.apply always returns valid (apply_imp converts invalid m_result
-  // to scalar_zero at the boundary). Skipping the assignment when
-  // diff_expr is zero leaves m_result invalid, which then surfaces
-  // as scalar_zero via apply_imp's same fallback — identical
-  // observable behavior, but more explicit to assign directly.
-  if (!is_same<scalar_zero>(diff_expr))
-    m_result = -diff_expr;
+  // d.apply() is guaranteed valid (see apply() contract in header).
+  // -scalar_zero short-circuits to scalar_zero in tag_invoke(neg_fn),
+  // so the assignment is correct unconditionally — no need to
+  // special-case zero. Also preserves the "visitor sets m_result to
+  // a valid expression" invariant called out in the apply contract.
+  m_result = -d.apply(visitable.expr());
 }
 
 void scalar_differentiation::operator()(scalar_pow const &visitable) {

--- a/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
@@ -65,9 +65,13 @@ void scalar_differentiation::operator()(scalar_add const &visitable) {
 void scalar_differentiation::operator()(scalar_negative const &visitable) {
   scalar_differentiation d(m_arg);
   auto diff_expr{d.apply(visitable.expr())};
-  if (diff_expr.is_valid() && !is_same<scalar_zero>(diff_expr)) {
+  // d.apply always returns valid (apply_imp converts invalid m_result
+  // to scalar_zero at the boundary). Skipping the assignment when
+  // diff_expr is zero leaves m_result invalid, which then surfaces
+  // as scalar_zero via apply_imp's same fallback — identical
+  // observable behavior, but more explicit to assign directly.
+  if (!is_same<scalar_zero>(diff_expr))
     m_result = -diff_expr;
-  }
 }
 
 void scalar_differentiation::operator()(scalar_pow const &visitable) {

--- a/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_differentiation.cpp
@@ -19,17 +19,10 @@ void scalar_differentiation::operator()(
 }
 
 void scalar_differentiation::operator()(scalar_mul const &visitable) {
-  // Initialize accumulators to identity elements so the first iteration's
-  // `+=` / `*=` doesn't operate on an invalid holder. Previously these
-  // were default-constructed (invalid) and relied on
-  // expression_holder's operator+= safety net (which converts
-  // `invalid += x` to `*this = x`). That safety net is real but it
-  // means CALLERS who read `data()->...` directly on the accumulator
-  // before the first iteration null-deref — surfaced as a segfault
-  // in #305 when the positivity-propagation read() call landed in the
-  // mul instrumentation. The is_valid() guard in read() is still
-  // belt-and-suspenders, but eliminating the invalid intermediate
-  // here is the principled fix.
+  // Identity-init so the first += / *= never hits an invalid holder —
+  // default-construction relied on the += safety net, which left the
+  // accumulator invalid for a mid-iteration reader (the #305 positivity
+  // read() null-deref / segfault).
   expr_holder_t expr_result = get_scalar_zero();
   for (auto &expr_out : visitable.symbol_map() | std::views::values) {
     expr_holder_t expr_result_in = get_scalar_one();
@@ -64,11 +57,8 @@ void scalar_differentiation::operator()(scalar_add const &visitable) {
 
 void scalar_differentiation::operator()(scalar_negative const &visitable) {
   scalar_differentiation d(m_arg);
-  // d.apply() is guaranteed valid (see apply() contract in header).
-  // -scalar_zero short-circuits to scalar_zero in tag_invoke(neg_fn),
-  // so the assignment is correct unconditionally — no need to
-  // special-case zero. Also preserves the "visitor sets m_result to
-  // a valid expression" invariant called out in the apply contract.
+  // d.apply() is always valid and -scalar_zero folds to scalar_zero, so
+  // no zero special-case needed.
   m_result = -d.apply(visitable.expr());
 }
 

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -24,8 +24,7 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
   // the propagation step can flip pos→neg / nonneg→nonpos / etc.
   const auto operand_view = positivity::read(e);
   auto result = make_expression<tensor_to_scalar_negative>(e);
-  positivity::propagate_neg_from_view(operand_view,
-                                                               result);
+  positivity::propagate_neg_from_view(operand_view, result);
   return result;
 }
 

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -22,9 +22,9 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
 
   // #260 — capture operand sign BEFORE building the negative node so
   // the propagation step can flip pos→neg / nonneg→nonpos / etc.
-  const auto operand_view = tensor_to_scalar_detail::positivity::read(e);
+  const auto operand_view = positivity::read(e);
   auto result = make_expression<tensor_to_scalar_negative>(e);
-  tensor_to_scalar_detail::positivity::propagate_neg_from_view(operand_view,
+  positivity::propagate_neg_from_view(operand_view,
                                                                result);
   return result;
 }

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -22,9 +22,9 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
 
   // #260 — capture operand sign BEFORE building the negative node so
   // the propagation step can flip pos→neg / nonneg→nonpos / etc.
-  const auto operand_view = positivity::read(e);
+  const auto operand_tags = positivity::read(e);
   auto result = make_expression<tensor_to_scalar_negative>(e);
-  positivity::propagate_neg_from_view(operand_view, result);
+  positivity::propagate_neg(operand_tags, result);
   return result;
 }
 

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -20,8 +20,7 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
     return e.get<tensor_to_scalar_negative>().expr();
   }
 
-  // #260 — capture operand sign BEFORE building the negative node so
-  // the propagation step can flip pos→neg / nonneg→nonpos / etc.
+  // #260 — capture operand sign before building the node, then flip it.
   const auto operand_tags = positivity::read(e);
   auto result = make_expression<tensor_to_scalar_negative>(e);
   positivity::propagate_neg(operand_tags, result);

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -54,8 +54,7 @@ void tensor_to_scalar_differentiation::operator()(
   // natural fit. Both patterns produce the same observable
   // behavior; the asymmetry is intentional.
   //
-  // Audit (June 2026): all tensor-domain diff accumulators use
-  // this pattern —
+  // All tensor-domain diff accumulators use this pattern —
   //   * tensor_differentiation::operator()(tensor_add)
   //   * tensor_differentiation::operator()(tensor_mul)
   //   * tensor_differentiation::operator()(tensor_inner_product…)

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -45,15 +45,18 @@ void tensor_to_scalar_differentiation::operator()(
 // coeff is constant offset -> derivative is zero
 void tensor_to_scalar_differentiation::operator()(
     tensor_to_scalar_add const &visitable) {
-  // Mirror the explicit `is_valid()` accumulation pattern used in
-  // tensor_to_scalar_differentiation_wrt_scalar (cpp:82-90 there).
-  // Previously `sum` was default-constructed (invalid) and `sum += d`
-  // ran on the first iteration with an invalid lhs. The
-  // expression_holder operator+= safety net converts that to
-  // assignment, so the code worked — but any caller that reads
-  // `sum.data()->...` between iterations null-derefs. Surfaced on
-  // scalar in #305 (FuzzyScalarDiff seed 35); applying the symmetric
-  // fix here so the same latent UB doesn't trip a future t2s seed.
+  // Explicit `is_valid()` accumulation pattern. This is the
+  // tensor-domain convention (used by all sibling visitors:
+  // tensor_to_scalar_differentiation_wrt_scalar cpp:82-90,
+  // tensor_differentiation cpp:57-67, etc.). The scalar diff
+  // visitor uses identity-init (`expr_result = scalar_zero`)
+  // instead — that's available there because scalar has cheap
+  // singleton identities (get_scalar_zero/one). Tensor doesn't
+  // have a global zero (rank/dim vary with m_arg), so explicit
+  // check is the natural fit. Both patterns produce the same
+  // observable behavior; the asymmetry is intentional, not an
+  // oversight. PR #309 added the audit confirming all other
+  // tensor diff visitors use this pattern.
   tensor_holder_t sum;
   for (auto &child : visitable.symbol_map() | std::views::values) {
     auto d = diff(child, m_arg);

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -45,18 +45,28 @@ void tensor_to_scalar_differentiation::operator()(
 // coeff is constant offset -> derivative is zero
 void tensor_to_scalar_differentiation::operator()(
     tensor_to_scalar_add const &visitable) {
-  // Explicit `is_valid()` accumulation pattern. This is the
-  // tensor-domain convention (used by all sibling visitors:
-  // tensor_to_scalar_differentiation_wrt_scalar cpp:82-90,
-  // tensor_differentiation cpp:57-67, etc.). The scalar diff
-  // visitor uses identity-init (`expr_result = scalar_zero`)
-  // instead — that's available there because scalar has cheap
-  // singleton identities (get_scalar_zero/one). Tensor doesn't
-  // have a global zero (rank/dim vary with m_arg), so explicit
-  // check is the natural fit. Both patterns produce the same
-  // observable behavior; the asymmetry is intentional, not an
-  // oversight. PR #309 added the audit confirming all other
-  // tensor diff visitors use this pattern.
+  // Explicit `is_valid()` accumulation pattern: the tensor-domain
+  // convention. The scalar diff visitor uses identity-init
+  // (`expr_result = scalar_zero`) instead — that's available there
+  // because scalar has cheap singleton identities (get_scalar_zero
+  // and get_scalar_one). Tensor doesn't have a global zero
+  // (rank/dim vary with m_arg), so the explicit check is the
+  // natural fit. Both patterns produce the same observable
+  // behavior; the asymmetry is intentional.
+  //
+  // Audit (June 2026): all tensor-domain diff accumulators use
+  // this pattern —
+  //   * tensor_differentiation::operator()(tensor_add)
+  //   * tensor_differentiation::operator()(tensor_mul)
+  //   * tensor_differentiation::operator()(tensor_inner_product…)
+  //   * tensor_differentiation_wrt_scalar::operator()(tensor_add)
+  //   * tensor_differentiation_wrt_scalar::operator()(tensor_mul)
+  //   * tensor_to_scalar_differentiation_wrt_scalar::operator()(
+  //       tensor_to_scalar_add)
+  //   * tensor_to_scalar_differentiation_wrt_scalar::operator()(
+  //       tensor_to_scalar_mul)
+  // Keep this t2s_add consistent with the family when adding new
+  // accumulator-bearing visitors.
   tensor_holder_t sum;
   for (auto &child : visitable.symbol_map() | std::views::values) {
     auto d = diff(child, m_arg);

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -45,12 +45,24 @@ void tensor_to_scalar_differentiation::operator()(
 // coeff is constant offset -> derivative is zero
 void tensor_to_scalar_differentiation::operator()(
     tensor_to_scalar_add const &visitable) {
+  // Mirror the explicit `is_valid()` accumulation pattern used in
+  // tensor_to_scalar_differentiation_wrt_scalar (cpp:82-90 there).
+  // Previously `sum` was default-constructed (invalid) and `sum += d`
+  // ran on the first iteration with an invalid lhs. The
+  // expression_holder operator+= safety net converts that to
+  // assignment, so the code worked — but any caller that reads
+  // `sum.data()->...` between iterations null-derefs. Surfaced on
+  // scalar in #305 (FuzzyScalarDiff seed 35); applying the symmetric
+  // fix here so the same latent UB doesn't trip a future t2s seed.
   tensor_holder_t sum;
   for (auto &child : visitable.symbol_map() | std::views::values) {
     auto d = diff(child, m_arg);
-    if (!is_same<tensor_zero>(d)) {
-      sum += d;
-    }
+    if (is_same<tensor_zero>(d))
+      continue;
+    if (sum.is_valid())
+      sum += std::move(d);
+    else
+      sum = std::move(d);
   }
   m_result = std::move(sum);
 }

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -45,27 +45,9 @@ void tensor_to_scalar_differentiation::operator()(
 // coeff is constant offset -> derivative is zero
 void tensor_to_scalar_differentiation::operator()(
     tensor_to_scalar_add const &visitable) {
-  // Explicit `is_valid()` accumulation pattern: the tensor-domain
-  // convention. The scalar diff visitor uses identity-init
-  // (`expr_result = scalar_zero`) instead — that's available there
-  // because scalar has cheap singleton identities (get_scalar_zero
-  // and get_scalar_one). Tensor doesn't have a global zero
-  // (rank/dim vary with m_arg), so the explicit check is the
-  // natural fit. Both patterns produce the same observable
-  // behavior; the asymmetry is intentional.
-  //
-  // All tensor-domain diff accumulators use this pattern —
-  //   * tensor_differentiation::operator()(tensor_add)
-  //   * tensor_differentiation::operator()(tensor_mul)
-  //   * tensor_differentiation::operator()(tensor_inner_product…)
-  //   * tensor_differentiation_wrt_scalar::operator()(tensor_add)
-  //   * tensor_differentiation_wrt_scalar::operator()(tensor_mul)
-  //   * tensor_to_scalar_differentiation_wrt_scalar::operator()(
-  //       tensor_to_scalar_add)
-  //   * tensor_to_scalar_differentiation_wrt_scalar::operator()(
-  //       tensor_to_scalar_mul)
-  // Keep this t2s_add consistent with the family when adding new
-  // accumulator-bearing visitors.
+  // Explicit is_valid() accumulation — the tensor-domain convention
+  // (no global zero, since rank/dim vary with m_arg; scalar diff
+  // identity-inits instead). Keep new tensor accumulators consistent.
   tensor_holder_t sum;
   for (auto &child : visitable.symbol_map() | std::views::values) {
     auto d = diff(child, m_arg);

--- a/tests/ScalarAssumptionTest.h
+++ b/tests/ScalarAssumptionTest.h
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <complex>
 
 // ─── Fixture ─────────────────────────────────────────────────────────
 
@@ -154,6 +155,40 @@ TEST_F(AssumptionFixture, PropagatePowZeroSingletonAsEvenExp) {
   auto a = numsim::cas::propagate_assumptions(e);
   EXPECT_TRUE(a.contains(numsim::cas::nonnegative{}))
       << "Expected nonnegative for x^0 (even exponent zero singleton)";
+}
+
+// Complex constants are not representable: numsim-cas is a real-valued
+// CAS, so scalar_constant construction rejects complex values. This is
+// the single boundary that keeps complex out of every expression and
+// lets the positivity rules treat every base/exponent as real (which is
+// why pow(positive, exp) → positive needs no real-exponent guard). Once
+// a complex value can't enter, pow(positive, 2i) / pow(i, 2) can't be
+// built at all — the unsoundness becomes unrepresentable rather than
+// merely guarded.
+TEST_F(AssumptionFixture, ComplexConstantRejectedAtConstruction) {
+  EXPECT_THROW(numsim::cas::make_scalar_constant(
+                   numsim::cas::scalar_number{std::complex<double>{0.0, 2.0}}),
+               numsim::cas::invalid_expression_error);
+  // The low-level make_expression path is the same chokepoint.
+  EXPECT_THROW(
+      {
+        auto h = numsim::cas::make_expression<numsim::cas::scalar_constant>(
+            numsim::cas::scalar_number{std::complex<double>{1.0, 1.0}});
+        (void)h;
+      },
+      numsim::cas::invalid_expression_error);
+}
+
+// Regression guard for the real-by-default convention that the
+// no-complex-guard pow rules rely on: pow(x, 2) for unassumed x stays
+// nonnegative, and pow(positive, integer) stays positive.
+TEST_F(AssumptionFixture, PowRealByDefaultConventionPreserved) {
+  numsim::cas::assume(y, numsim::cas::positive{});
+  EXPECT_TRUE(numsim::cas::propagate_assumptions(pow(x, 2)).contains(
+      numsim::cas::nonnegative{}))
+      << "pow(unassumed, 2) must remain nonnegative (real-by-default)";
+  EXPECT_TRUE(numsim::cas::is_positive(pow(y, 3)))
+      << "pow(positive, 3) must remain positive";
 }
 
 TEST_F(AssumptionFixture, PropagateSqrt) {
@@ -583,25 +618,21 @@ TEST(ScalarConstantValueAssumptions,
   EXPECT_FALSE(numsim::cas::is_integer(c));
 }
 
-TEST(ScalarConstantValueAssumptions, ComplexCarriesNoSignOrRealPredicates) {
-  // QA Q3d: complex values get NO sign predicates AND NO real_tag. This
-  // branch is purely negative (asserts nothing inserted) — the riskiest
-  // case because a future edit that adds real_tag for complex would be
-  // silently invisible without this test. Includes is_nonnegative /
-  // is_even as the most-plausible accidental insertions (e.g. if someone
-  // misused magnitude or even-bit logic on a complex value). The
-  // !is_rational assertion is the false-path lock-in for the
-  // is_rational query helper (QA fifth-round gap).
-  auto c = numsim::cas::make_expression<numsim::cas::scalar_constant>(
-      std::complex<double>{1.0, 1.0});
-  EXPECT_FALSE(numsim::cas::is_positive(c));
-  EXPECT_FALSE(numsim::cas::is_negative(c));
-  EXPECT_FALSE(numsim::cas::is_nonzero(c));
-  EXPECT_FALSE(numsim::cas::is_nonnegative(c));
-  EXPECT_FALSE(numsim::cas::is_real(c));
-  EXPECT_FALSE(numsim::cas::is_integer(c));
-  EXPECT_FALSE(numsim::cas::is_rational(c));
-  EXPECT_FALSE(numsim::cas::is_even(c));
+TEST(ScalarConstantValueAssumptions, ComplexValueRejectedAtConstruction) {
+  // numsim-cas is a real-valued CAS: complex values are never needed in
+  // constitutive modelling, symbols cannot be assumed complex, and no
+  // operation folds to a complex constant. scalar_constant construction
+  // therefore rejects complex outright — the previous behaviour (build a
+  // tag-less complex constant) was an attractive nuisance that left an
+  // unsound corner for the positivity rules. This pins the rejection so a
+  // future edit that re-admits complex constants must be deliberate.
+  EXPECT_THROW(
+      {
+        auto c = numsim::cas::make_expression<numsim::cas::scalar_constant>(
+            std::complex<double>{1.0, 1.0});
+        (void)c;
+      },
+      numsim::cas::invalid_expression_error);
 }
 
 // ─── Step 5: expression_holder::assumption() variadic API ─────────────

--- a/tests/ScalarAssumptionTest.h
+++ b/tests/ScalarAssumptionTest.h
@@ -157,14 +157,9 @@ TEST_F(AssumptionFixture, PropagatePowZeroSingletonAsEvenExp) {
       << "Expected nonnegative for x^0 (even exponent zero singleton)";
 }
 
-// Complex constants are not representable: numsim-cas is a real-valued
-// CAS, so scalar_constant construction rejects complex values. This is
-// the single boundary that keeps complex out of every expression and
-// lets the positivity rules treat every base/exponent as real (which is
-// why pow(positive, exp) → positive needs no real-exponent guard). Once
-// a complex value can't enter, pow(positive, 2i) / pow(i, 2) can't be
-// built at all — the unsoundness becomes unrepresentable rather than
-// merely guarded.
+// Complex is rejected at scalar_constant construction — the single
+// boundary that keeps it out of every expression, so pow(positive, 2i)
+// can't be built at all (the unsoundness is unrepresentable, not guarded).
 TEST_F(AssumptionFixture, ComplexConstantRejectedAtConstruction) {
   EXPECT_THROW(numsim::cas::make_scalar_constant(
                    numsim::cas::scalar_number{std::complex<double>{0.0, 2.0}}),
@@ -619,13 +614,8 @@ TEST(ScalarConstantValueAssumptions,
 }
 
 TEST(ScalarConstantValueAssumptions, ComplexValueRejectedAtConstruction) {
-  // numsim-cas is a real-valued CAS: complex values are never needed in
-  // constitutive modelling, symbols cannot be assumed complex, and no
-  // operation folds to a complex constant. scalar_constant construction
-  // therefore rejects complex outright — the previous behaviour (build a
-  // tag-less complex constant) was an attractive nuisance that left an
-  // unsound corner for the positivity rules. This pins the rejection so a
-  // future edit that re-admits complex constants must be deliberate.
+  // Real-valued CAS: scalar_constant rejects complex. Pins the rejection
+  // so re-admitting complex must be deliberate (#267).
   EXPECT_THROW(
       {
         auto c = numsim::cas::make_expression<numsim::cas::scalar_constant>(

--- a/tests/ScalarComparisonTest.h
+++ b/tests/ScalarComparisonTest.h
@@ -129,20 +129,17 @@ TEST(ScalarComparison, EdgeCase_NaN_StructuralIdentity) {
   EXPECT_TRUE(is_same<scalar_zero>(ne(nan_const, nan_const)));
 }
 
-// Complex constants are not representable in the CAS: numsim-cas is a
-// real-valued system, so building a complex scalar_constant throws.
-// Complex comparison-folding is therefore unreachable through the
-// expression layer.
+// Real-valued CAS: building a complex scalar_constant throws, so complex
+// comparison-folding is unreachable through the expression layer.
 TEST(ScalarComparison, EdgeCase_Complex_RejectedAtBoundary) {
   EXPECT_THROW(
       make_scalar_constant(scalar_number{std::complex<double>{1.0, 5.0}}),
       invalid_expression_error);
 }
 
-// Locks in #144 at the type level: `scalar_number` still provides a
-// total order over complex values (real-then-imag tiebreak), needed for
-// variant comparison even though complex constants can't enter an
-// expression. Documents the choice so any future change is deliberate.
+// Locks in #144 at the type level: scalar_number keeps a total order
+// over complex values (real-then-imag), needed for variant comparison
+// even though complex constants can't enter an expression.
 TEST(ScalarComparison, EdgeCase_Complex_ScalarNumberTotalOrder) {
   scalar_number const c_1_5{std::complex<double>{1.0, 5.0}};
   scalar_number const c_1_3{std::complex<double>{1.0, 3.0}};

--- a/tests/ScalarComparisonTest.h
+++ b/tests/ScalarComparisonTest.h
@@ -129,23 +129,29 @@ TEST(ScalarComparison, EdgeCase_NaN_StructuralIdentity) {
   EXPECT_TRUE(is_same<scalar_zero>(ne(nan_const, nan_const)));
 }
 
-// Locks in #144: complex ordering. `numeric_less` uses real-then-imag
-// tiebreak for complex values — a total order needed by sort
-// containers, but not a mathematically meaningful ordering. Documents
-// the choice so any future change is deliberate.
-TEST(ScalarComparison, EdgeCase_Complex_RealThenImagOrdering) {
-  using namespace std::complex_literals;
-  auto c_1_5 =
-      make_scalar_constant(scalar_number{std::complex<double>{1.0, 5.0}});
-  auto c_1_3 =
-      make_scalar_constant(scalar_number{std::complex<double>{1.0, 3.0}});
-  auto c_2_0 =
-      make_scalar_constant(scalar_number{std::complex<double>{2.0, 0.0}});
-  // Same real component → imag breaks the tie: 5 > 3 so c_1_5 > c_1_3
-  EXPECT_TRUE(is_same<scalar_one>(gt(c_1_5, c_1_3)));
-  EXPECT_TRUE(is_same<scalar_zero>(lt(c_1_5, c_1_3)));
-  // Different real components → real wins regardless of imag: 1 < 2
-  EXPECT_TRUE(is_same<scalar_one>(lt(c_1_5, c_2_0)));
+// Complex constants are not representable in the CAS: numsim-cas is a
+// real-valued system, so building a complex scalar_constant throws.
+// Complex comparison-folding is therefore unreachable through the
+// expression layer.
+TEST(ScalarComparison, EdgeCase_Complex_RejectedAtBoundary) {
+  EXPECT_THROW(
+      make_scalar_constant(scalar_number{std::complex<double>{1.0, 5.0}}),
+      invalid_expression_error);
+}
+
+// Locks in #144 at the type level: `scalar_number` still provides a
+// total order over complex values (real-then-imag tiebreak), needed for
+// variant comparison even though complex constants can't enter an
+// expression. Documents the choice so any future change is deliberate.
+TEST(ScalarComparison, EdgeCase_Complex_ScalarNumberTotalOrder) {
+  scalar_number const c_1_5{std::complex<double>{1.0, 5.0}};
+  scalar_number const c_1_3{std::complex<double>{1.0, 3.0}};
+  scalar_number const c_2_0{std::complex<double>{2.0, 0.0}};
+  // Same real component → imag breaks the tie: 3 < 5.
+  EXPECT_TRUE(numeric_less(c_1_3, c_1_5));
+  EXPECT_FALSE(numeric_less(c_1_5, c_1_3));
+  // Different real components → real wins regardless of imag: 1 < 2.
+  EXPECT_TRUE(numeric_less(c_1_5, c_2_0));
 }
 
 // Locks in #142: rational cross-multiplication must actually overflow.

--- a/tests/ScalarDifferentiationTest.h
+++ b/tests/ScalarDifferentiationTest.h
@@ -221,6 +221,49 @@ TEST(ScalarDifferentiationAudit, PowVariableBaseVariableExponent) {
   expect_is_zero(d - expected);
 }
 
+// ─── Accumulator-init regression (follow-up to #305) ───────────────
+// scalar_differentiation's scalar_mul / scalar_add visitors previously
+// default-constructed the accumulator (invalid holder) and relied on
+// expression_holder::operator+=/*='s "invalid lhs → assign rhs"
+// safety net. That worked for the visitor itself but left an invalid
+// intermediate visible to any code that read `accumulator.data()->...`
+// directly — surfaced as a segfault when the #305 positivity-
+// propagation read() landed in the mul instrumentation (FuzzyScalar
+// Depth3 seed 35). Lock-in tests ensure the accumulator is initialized
+// to the identity element (scalar_zero for additive, scalar_one for
+// multiplicative) so any future read() in the visitor stays valid.
+
+TEST(ScalarDifferentiationAudit, MulAccumulatorReturnsScalarZeroForConstant) {
+  // d(c1·c2)/dx = 0. The mul visitor's outer accumulator is a
+  // sum; if not initialized to scalar_zero, the result could be
+  // invalid (and apply_imp's fallback would handle it). With the
+  // identity-init, the result is structurally scalar_zero already.
+  auto x = make_expression<scalar>("x");
+  auto y = make_expression<scalar>("y");
+  auto z = make_expression<scalar>("z");
+  auto d = diff(y * z, x);
+  EXPECT_TRUE(is_same<scalar_zero>(d));
+}
+
+TEST(ScalarDifferentiationAudit, AddAccumulatorReturnsScalarZeroForConstant) {
+  // Same shape for scalar_add.
+  auto x = make_expression<scalar>("x");
+  auto y = make_expression<scalar>("y");
+  auto z = make_expression<scalar>("z");
+  auto d = diff(y + z, x);
+  EXPECT_TRUE(is_same<scalar_zero>(d));
+}
+
+TEST(ScalarDifferentiationAudit, MulAccumulatorProductRuleStillWorks) {
+  // Sanity that initializing the inner accumulator to scalar_one
+  // doesn't bloat the product rule output. d/dx(x * y) = y.
+  auto x = make_expression<scalar>("x");
+  auto y = make_expression<scalar>("y");
+  auto d = diff(x * y, x);
+  // After folding scalar_one * y = y.
+  EXPECT_EQ(d, y);
+}
+
 } // namespace numsim::cas
 
 #endif // SCALARDIFFERENTIATIONTEST_H

--- a/tests/ScalarDifferentiationTest.h
+++ b/tests/ScalarDifferentiationTest.h
@@ -222,22 +222,12 @@ TEST(ScalarDifferentiationAudit, PowVariableBaseVariableExponent) {
 }
 
 // ─── Accumulator-init regression (follow-up to #305) ───────────────
-// scalar_differentiation's scalar_mul / scalar_add visitors previously
-// default-constructed the accumulator (invalid holder) and relied on
-// expression_holder::operator+=/*='s "invalid lhs → assign rhs"
-// safety net. That worked for the visitor itself but left an invalid
-// intermediate visible to any code that read `accumulator.data()->...`
-// directly — surfaced as a segfault when the #305 positivity-
-// propagation read() landed in the mul instrumentation (FuzzyScalar
-// Depth3 seed 35). Lock-in tests ensure the accumulator is initialized
-// to the identity element (scalar_zero for additive, scalar_one for
-// multiplicative) so any future read() in the visitor stays valid.
+// The scalar_mul/add visitors identity-init their accumulators
+// (scalar_zero/one) so no invalid intermediate is visible to a reader
+// like the #305 positivity read() (segfaulted on FuzzyScalar seed 35).
 
 TEST(ScalarDifferentiationAudit, MulAccumulatorReturnsScalarZeroForConstant) {
-  // d(c1·c2)/dx = 0. The mul visitor's outer accumulator is a
-  // sum; if not initialized to scalar_zero, the result could be
-  // invalid (and apply_imp's fallback would handle it). With the
-  // identity-init, the result is structurally scalar_zero already.
+  // d(c1·c2)/dx = 0, structurally scalar_zero via identity-init.
   auto x = make_expression<scalar>("x");
   auto y = make_expression<scalar>("y");
   auto z = make_expression<scalar>("z");

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -661,7 +661,7 @@ TEST(TensorAlgebraOperatorPropagation, NegOfDoubleNegativeFoldsToOperand) {
   // -(-x) → x at the construction-time fold in the t2s_negative
   // factory. Tests an INTERACTION between the fold and the
   // propagation helper rather than the helper alone: the fold
-  // short-circuits before propagate_neg_from_view runs, so the
+  // short-circuits before propagate_neg runs, so the
   // helper never executes — but the user-visible contract
   // (-(-positive) is positive) is what we care about. The
   // operand's tags survive the round-trip because the fold
@@ -685,7 +685,7 @@ TEST(TensorAlgebraOperatorPropagation,
      PosTagOnlyTimesNonnegTagOnlyExercisesHardening) {
   // Direct-manager construction: insert `positive{}` alone (no joint
   // `nonnegative{}`) into lhs, and `nonnegative{}` alone into rhs.
-  // This is the exact brittle shape the at_least_nonneg_tag()
+  // This is the exact brittle shape the at_least_nonneg()
   // hardening was added for — joint-insertion paths (assume_positive_*)
   // can't produce this state, so the public API never reaches it
   // through the normal flow. This test pins the rule's behavior on
@@ -694,7 +694,7 @@ TEST(TensorAlgebraOperatorPropagation,
   // Without the hardening, the mul rule would test
   // `lhs.nonnegative && rhs.nonnegative` and skip — lhs.nonnegative
   // is false here (only positive was inserted). The hardening's
-  // `at_least_nonneg_tag()` reads "positive OR nonnegative", so the
+  // `at_least_nonneg()` reads "positive OR nonnegative", so the
   // rule still fires correctly.
   auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
   auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
@@ -708,7 +708,7 @@ TEST(TensorAlgebraOperatorPropagation,
   auto p = d1 * d2;
   auto const &a = p.data()->assumptions();
   EXPECT_TRUE(a.contains(nonnegative{}))
-      << "Hardening should fire: at_least_nonneg_tag covers the "
+      << "Hardening should fire: at_least_nonneg covers the "
          "pos-only × nonneg-only case";
   EXPECT_TRUE(a.contains(real_tag{}));
   // Can't conclude positive (rhs is only nonneg, may be zero) nor


### PR DESCRIPTION
## Scope

This PR started as the diff-accumulator-init fix but grew during review into four related changes to the scalar/t2s assumption + positivity machinery. Flagging the full scope here since the title only names the first part.

### 1. Diff-visitor accumulator init (original purpose)
`scalar_differentiation`'s `scalar_mul`/`scalar_add` visitors now identity-init their accumulators (`scalar_zero`/`scalar_one`) instead of default-constructing an invalid holder and leaning on the `+=`/`*=` safety net. The invalid intermediate was visible to instrumentation reading `accumulator.data()` directly and segfaulted once the positivity `read()` landed in the mul path (FuzzyScalar seed 35). `apply_inner_unary` also drops its `if (inner.is_valid())` skip (which produced silently-wrong derivatives for constant inner) now that `apply()` guarantees a valid result.

### 2. Lift positivity propagation into `core/`
The parallel scalar (#305) and t2s (#260) positivity helpers are unified into `core/positivity_propagation.h` (shared `mark_*`/`propagate_*`); each domain keeps only its `read()` adapter. Call sites migrated to the canonical `positivity::` namespace.

### 3. Reject complex constants at construction
`scalar_constant`'s ctor throws `invalid_expression_error` on a complex value — the single boundary that keeps complex out of every expression (numsim-cas is a real-valued CAS; symbols already can't be assumed complex and nothing folds to complex). This supersedes an interim set of scattered complex-guards in the pow rules. Decision recorded on #267.

### 4. Remove the `positivity::view` struct
`read()` now returns a normalized `numeric_assumption_manager` snapshot and `propagate_*` query the typed tags directly, instead of a bespoke 6-bool mirror.

## Notes
- No correctness regressions: **1548 main + 783 fuzz** pass.
- The eager propagation here is redundant with the lazy `shallow_inference_visitor` for queries — tracked in **#310** (which would delete most of parts 2-4).
- The duplicated scalar pow inference rule is tracked in **#311**.
- Base should be retargeted to `main` before merge.
