### PR TITLE
Fix installable-package export + restore package smoke test (#293)

### DIFF
--- a/.github/workflows/package-smoke-test.yml
+++ b/.github/workflows/package-smoke-test.yml
@@ -1,0 +1,24 @@
+name: Package Smoke Test
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+# Verifies the installable package (#84/#293): install NumSim_CAS, then
+# consume it from a fresh project via find_package(NumSim_CAS).
+jobs:
+  smoke:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        parser: [ "OFF", "ON" ]
+    env:
+      CC: gcc-14
+      CXX: g++-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Installable-package smoke test (parser=${{ matrix.parser }})
+        run: ./cmake/package_smoke_test.sh ${{ matrix.parser }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,11 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
-    tmech::tmech
+    # tmech is a FetchContent build target — usable for our own build but
+    # not in any export set, so it can't appear in the installed
+    # interface. Link it BUILD-only; the installed package re-attaches the
+    # consumer's find_dependency(tmech) target in NumSim_CASConfig.cmake.in.
+    $<BUILD_INTERFACE:tmech::tmech>
 )
 
 target_compile_definitions(${PROJECT_NAME}
@@ -285,12 +289,14 @@ if(NUMSIM_CAS_INSTALL_LIBRARY AND NUMSIM_CAS_ENABLE_PACKAGE_SMOKE_TEST)
   set(NUMSIM_CAS_INSTALL_CMAKEDIR
       "${CMAKE_INSTALL_LIBDIR}/cmake/NumSim_CAS")
 
+  # No INCLUDES DESTINATION here: target_include_directories already sets
+  # the $<INSTALL_INTERFACE:> include dir; adding it again duplicates it in
+  # the exported target.
   install(TARGETS ${PROJECT_NAME}
     EXPORT NumSim_CASTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 
   # Install headers preserving directory structure
@@ -311,7 +317,6 @@ if(NUMSIM_CAS_INSTALL_LIBRARY AND NUMSIM_CAS_ENABLE_PACKAGE_SMOKE_TEST)
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/numsim_cas/parser/"
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/numsim_cas/parser"
@@ -329,6 +334,15 @@ if(NUMSIM_CAS_INSTALL_LIBRARY AND NUMSIM_CAS_ENABLE_PACKAGE_SMOKE_TEST)
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
   )
+
+  # The parser lib links taocpp::pegtl; a consumer therefore needs it via
+  # find_dependency (PRIVATE static-lib deps propagate as LINK_ONLY). Only
+  # emit the line when the parser is part of this package.
+  if(NUMSIM_CAS_BUILD_PARSER)
+    set(NUMSIM_CAS_CONFIG_PARSER_DEP "find_dependency(pegtl REQUIRED)")
+  else()
+    set(NUMSIM_CAS_CONFIG_PARSER_DEP "")
+  endif()
 
   configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/NumSim_CASConfig.cmake.in"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ ctest --test-dir build
 - [tmech](https://github.com/petlenz/tmech) -- fetched automatically via CMake FetchContent
 - [GoogleTest](https://github.com/google/googletest) -- fetched automatically for tests
 
+### Consuming an installed package
+
+The build always uses the pinned tmech (`GIT_TAG d03f2c2`), but an installed
+`find_package(NumSim_CAS)` resolves tmech via `find_dependency(tmech)` from the
+consumer's environment. tmech carries no version, so this cannot be enforced:
+**you must provide tmech at commit `d03f2c2` or newer** -- an older tmech
+satisfies the dependency but silently reintroduces the rank-4 `tmech::inv` NaN
+bug (#283/#248). Packaging is supported for the default (parser-off) build;
+enabling `NUMSIM_CAS_BUILD_PARSER` additionally requires a findable
+`taocpp::pegtl`.
+
 ## Architecture
 
 ```

--- a/cmake/NumSim_CASConfig.cmake.in
+++ b/cmake/NumSim_CASConfig.cmake.in
@@ -1,8 +1,29 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+
+# NumSim_CAS is built against a pinned tmech (FetchContent GIT_TAG). tmech
+# declares no version, so find_dependency cannot enforce a floor here — the
+# consumer MUST provide a tmech at or newer than that pin. An older tmech
+# satisfies this dependency but silently reintroduces the rank-4 tmech::inv
+# NaN bug (#283/#248). See the project README for the required tmech.
 find_dependency(tmech REQUIRED)
+@NUMSIM_CAS_CONFIG_PARSER_DEP@
 
 include("${CMAKE_CURRENT_LIST_DIR}/NumSim_CASTargets.cmake")
+
+# tmech is linked BUILD-only in our tree (FetchContent target, not
+# exportable); re-attach the consumer-found tmech::tmech to the imported
+# targets so downstream code gets tmech's headers transitively. Idempotent
+# so repeated find_package(NumSim_CAS) calls don't duplicate the entry.
+foreach(_ncas_tgt NumSim_CAS::NumSim_CAS NumSim_CAS::NumSim_CAS_Parser)
+  if(TARGET ${_ncas_tgt} AND TARGET tmech::tmech)
+    get_target_property(_ncas_links ${_ncas_tgt} INTERFACE_LINK_LIBRARIES)
+    if(NOT _ncas_links OR NOT "tmech::tmech" IN_LIST _ncas_links)
+      set_property(TARGET ${_ncas_tgt} APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES tmech::tmech)
+    endif()
+  endif()
+endforeach()
 
 check_required_components(NumSim_CAS)

--- a/cmake/package_smoke_test.sh
+++ b/cmake/package_smoke_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Installable-package smoke test (#84/#293). Installs the pinned tmech
+# (and pegtl when the parser is on), installs NumSim_CAS, then builds and
+# runs a throwaway downstream project that consumes it via
+# find_package(NumSim_CAS). Exits non-zero on any failure.
+#
+# Usage: cmake/package_smoke_test.sh [ON|OFF]   # parser (default OFF)
+set -euo pipefail
+
+PARSER="${1:-OFF}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PREFIX="$WORK/prefix"
+JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
+
+echo "== smoke test (parser=$PARSER) : root=$ROOT =="
+
+# 1. Configure once to populate the FetchContent deps (tmech, pegtl).
+cmake -S "$ROOT" -B "$WORK/seed" \
+  -DNUMSIM_CAS_BUILD_TESTS=OFF -DNUMSIM_CAS_BUILD_PARSER="$PARSER" >/dev/null
+
+# 2. Install the pinned tmech from the fetched source (tests/examples off
+#    so it doesn't drag in googletest at install time).
+cmake -S "$WORK/seed/_deps/tmech-src" -B "$WORK/tmech" \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DTMECH_INSTALL_LIBRARY=ON -DTMECH_BUILD_TESTS=OFF \
+  -DTMECH_BUILD_EXAMPLES=OFF >/dev/null
+cmake --install "$WORK/tmech" >/dev/null
+
+# 3. Parser needs pegtl findable by the consumer too.
+if [ "$PARSER" = "ON" ]; then
+  cmake -S "$WORK/seed/_deps/pegtl-src" -B "$WORK/pegtl" \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DPEGTL_BUILD_TESTS=OFF -DPEGTL_BUILD_EXAMPLES=OFF >/dev/null
+  cmake --install "$WORK/pegtl" >/dev/null
+fi
+
+# 4. Configure + build + install NumSim_CAS with the export rules on.
+cmake -S "$ROOT" -B "$WORK/ncas" \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" \
+  -DNUMSIM_CAS_INSTALL_LIBRARY=ON -DNUMSIM_CAS_ENABLE_PACKAGE_SMOKE_TEST=ON \
+  -DNUMSIM_CAS_BUILD_PARSER="$PARSER" -DNUMSIM_CAS_BUILD_TESTS=OFF >/dev/null
+cmake --build "$WORK/ncas" --parallel "$JOBS" >/dev/null
+cmake --install "$WORK/ncas" >/dev/null
+
+# 5. Downstream consumer: only knows the install prefix.
+CONS="$WORK/consumer"
+mkdir -p "$CONS"
+if [ "$PARSER" = "ON" ]; then
+  LINK_TGT="NumSim_CAS::NumSim_CAS_Parser"
+  cat > "$CONS/main.cpp" <<'EOF'
+#include <numsim_cas/numsim_cas.h>
+#include <numsim_cas/parser/parser.h>
+#include <cstdio>
+int main() {
+  using namespace numsim::cas;
+  parser::symbol_table syms;
+  auto e = parser::parse_scalar("sin(x)^2 + cos(x)^2", syms);
+  std::printf("consumer OK (parser): %s\n", to_string(e).c_str());
+  return 0;
+}
+EOF
+else
+  LINK_TGT="NumSim_CAS::NumSim_CAS"
+  cat > "$CONS/main.cpp" <<'EOF'
+#include <numsim_cas/numsim_cas.h>
+#include <cstdio>
+int main() {
+  using namespace numsim::cas;
+  auto x = make_expression<scalar>("x");
+  auto d = diff(pow(x, 3), x);
+  std::printf("consumer OK: %s\n", to_string(d).c_str());
+  return 0;
+}
+EOF
+fi
+cat > "$CONS/CMakeLists.txt" <<EOF
+cmake_minimum_required(VERSION 3.22)
+project(ncas_smoke_consumer CXX)
+set(CMAKE_CXX_STANDARD 23)
+find_package(NumSim_CAS REQUIRED)
+add_executable(consumer main.cpp)
+target_link_libraries(consumer PRIVATE $LINK_TGT)
+EOF
+
+cmake -S "$CONS" -B "$WORK/consumer-build" -DCMAKE_PREFIX_PATH="$PREFIX" >/dev/null
+cmake --build "$WORK/consumer-build" --parallel "$JOBS" >/dev/null
+"$WORK/consumer-build/consumer"
+
+echo "== packaging smoke test (parser=$PARSER) PASSED =="


### PR DESCRIPTION
## Problem

`install(EXPORT)` was broken: `NumSim_CAS` PUBLIC-linked the FetchContent `tmech` target, which isn't in any export set, so `find_package(NumSim_CAS)` couldn't even be generated. The smoke test that would have caught this had been disabled (#293, after the FetchContent-always swap in #84).

## Fixes

- **tmech export:** link tmech build-only (`$<BUILD_INTERFACE:tmech::tmech>`); the installed `NumSim_CASConfig.cmake` re-attaches the consumer's `find_dependency(tmech)` target to the imported targets (idempotently).
- **parser packaging:** emit `find_dependency(pegtl)` in the config when the parser is built (its PRIVATE static-lib dep propagates as `LINK_ONLY`, so a downstream parser consumer needs pegtl findable).
- **dedup:** drop the redundant `INCLUDES DESTINATION` (the exported include dir was listed twice).
- **tmech version caveat:** tmech carries no version, so `find_dependency` can't enforce a floor — a stale tmech reintroduces the rank-4 `inv` NaN (#283/#248). Documented in the config + README.

## Smoke test restored

`cmake/package_smoke_test.sh` installs the pinned tmech (and pegtl for parser=ON), installs NumSim_CAS, then builds + runs a `find_package(NumSim_CAS)` consumer. A new **Package Smoke Test** workflow runs it for parser `OFF` and `ON`.

## Verification (local)

| Config | Result |
|---|---|
| parser=OFF | consumer builds + runs → `3*pow(x,2)`; export is leak-free (`${_IMPORT_PREFIX}/include`) |
| parser=ON | consumer builds + runs → `1` (`sin²+cos²`); config carries `find_dependency(pegtl)` |

Normal build/tests unaffected (1548 pass). Closes the packaging half of #293; the CI-restoration half is this PR's new workflow.