### PR TITLE
Preserve tensor space() annotations through rebuild + copy (#93)

### DIFF
--- a/include/numsim_cas/tensor/operators/tensor/tensor_mul.h
+++ b/include/numsim_cas/tensor/operators/tensor/tensor_mul.h
@@ -10,9 +10,8 @@ class tensor_mul final : public n_ary_vector<tensor_node_base_t<tensor_mul>> {
 public:
   using base = n_ary_vector<tensor_node_base_t<tensor_mul>>;
   tensor_mul(std::size_t dim, std::size_t rank) : base(dim, rank) {}
-  // #93 — the (data, dim, rank) base ctor deliberately does NOT copy
-  // space(); restore it here (as tensor_add already does) so a node's
-  // annotation survives copy/move reconstruction in the simplifier.
+  // #93 — restore space(): the (data,dim,rank) base ctor drops it,
+  // unlike tensor_add.
   tensor_mul(tensor_mul const &add)
       : base(static_cast<const base &>(add), add.dim(), add.rank()) {
     if (auto const &sp = add.space())

--- a/include/numsim_cas/tensor/operators/tensor/tensor_mul.h
+++ b/include/numsim_cas/tensor/operators/tensor/tensor_mul.h
@@ -10,10 +10,19 @@ class tensor_mul final : public n_ary_vector<tensor_node_base_t<tensor_mul>> {
 public:
   using base = n_ary_vector<tensor_node_base_t<tensor_mul>>;
   tensor_mul(std::size_t dim, std::size_t rank) : base(dim, rank) {}
+  // #93 — the (data, dim, rank) base ctor deliberately does NOT copy
+  // space(); restore it here (as tensor_add already does) so a node's
+  // annotation survives copy/move reconstruction in the simplifier.
   tensor_mul(tensor_mul const &add)
-      : base(static_cast<const base &>(add), add.dim(), add.rank()) {}
+      : base(static_cast<const base &>(add), add.dim(), add.rank()) {
+    if (auto const &sp = add.space())
+      this->set_space(*sp);
+  }
   tensor_mul(tensor_mul &&add) noexcept
-      : base(static_cast<base &&>(add), add.dim(), add.rank()) {}
+      : base(static_cast<base &&>(add), add.dim(), add.rank()) {
+    if (auto const &sp = add.space())
+      this->set_space(*sp);
+  }
   ~tensor_mul() override = default;
   const tensor_mul &operator=(tensor_mul &&) = delete;
 };

--- a/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
+++ b/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
@@ -22,12 +22,9 @@ public:
     if (expr.is_valid()) {
       m_current = expr;
       expr.get<tensor_visitable_t>().accept(*this);
-      // #93 — the per-node reconstructions below build fresh nodes via
-      // their variadic ctors, which don't carry over a post-construction
-      // space() annotation (e.g. the Skew set on skew(A)). Restore it
-      // from the source so annotations survive substitution/diff
-      // rebuilds. Only when the result has none — don't clobber a
-      // self-computed space (e.g. tensor_add's child-join).
+      // #93 — reconstructions below build fresh nodes (variadic ctors)
+      // that drop post-construction space(). Restore from source, but not
+      // over a self-computed space (e.g. tensor_add's child-join).
       if (m_result.is_valid() && !m_result.get().space()) {
         if (auto const &sp = expr.get().space())
           m_result.data()->set_space(*sp);

--- a/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
+++ b/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
@@ -22,6 +22,16 @@ public:
     if (expr.is_valid()) {
       m_current = expr;
       expr.get<tensor_visitable_t>().accept(*this);
+      // #93 — the per-node reconstructions below build fresh nodes via
+      // their variadic ctors, which don't carry over a post-construction
+      // space() annotation (e.g. the Skew set on skew(A)). Restore it
+      // from the source so annotations survive substitution/diff
+      // rebuilds. Only when the result has none — don't clobber a
+      // self-computed space (e.g. tensor_add's child-join).
+      if (m_result.is_valid() && !m_result.get().space()) {
+        if (auto const &sp = expr.get().space())
+          m_result.data()->set_space(*sp);
+      }
       return std::move(m_result);
     }
     return expr;

--- a/include/numsim_cas/tensor/wrappers/simple_outer_product.h
+++ b/include/numsim_cas/tensor/wrappers/simple_outer_product.h
@@ -12,10 +12,18 @@ public:
   using base = n_ary_vector<tensor_node_base_t<simple_outer_product>>;
 
   simple_outer_product(std::size_t dim, std::size_t rank) : base(dim, rank) {}
+  // #93 — restore space() after the (data, dim, rank) base ctor, which
+  // deliberately drops it (matches tensor_add / tensor_mul).
   simple_outer_product(simple_outer_product const &add)
-      : base(static_cast<const base &>(add), add.dim(), add.rank()) {}
+      : base(static_cast<const base &>(add), add.dim(), add.rank()) {
+    if (auto const &sp = add.space())
+      this->set_space(*sp);
+  }
   simple_outer_product(simple_outer_product &&add) noexcept
-      : base(static_cast<base &&>(add), add.dim(), add.rank()) {}
+      : base(static_cast<base &&>(add), add.dim(), add.rank()) {
+    if (auto const &sp = add.space())
+      this->set_space(*sp);
+  }
   ~simple_outer_product() override = default;
   const simple_outer_product &operator=(simple_outer_product &&) = delete;
 };

--- a/include/numsim_cas/tensor/wrappers/simple_outer_product.h
+++ b/include/numsim_cas/tensor/wrappers/simple_outer_product.h
@@ -12,8 +12,7 @@ public:
   using base = n_ary_vector<tensor_node_base_t<simple_outer_product>>;
 
   simple_outer_product(std::size_t dim, std::size_t rank) : base(dim, rank) {}
-  // #93 — restore space() after the (data, dim, rank) base ctor, which
-  // deliberately drops it (matches tensor_add / tensor_mul).
+  // #93 — restore space() (base ctor drops it; matches tensor_add/mul).
   simple_outer_product(simple_outer_product const &add)
       : base(static_cast<const base &>(add), add.dim(), add.rank()) {
     if (auto const &sp = add.space())

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -671,10 +671,9 @@ TEST(CoreBugFix, SkewSpacePreservedAsTensorMulChild) {
 }
 
 TEST(CoreBugFix, SkewSpacePreservedThroughRebuild) {
-  // #93 real mechanism (deterministic, unlike the platform-dependent
-  // mul-child case above): the rebuild visitor reconstructs annotated
-  // nodes via their variadic ctors, which drop the post-construction
-  // Skew space. Substituting a leaf inside skew(A) must keep it Skew.
+  // #93 — rebuild reconstructs nodes via variadic ctors, dropping
+  // post-construction space(); substituting a leaf inside skew(A) must
+  // keep it Skew (deterministic reproducer).
   auto [A, B] =
       make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}},
                            std::tuple{"B", std::size_t{3}, std::size_t{2}});
@@ -930,10 +929,8 @@ TEST(CoreBugFix, Issue184_DoublePathAndConstantPathMatch) {
   }
 }
 
-// #93 — a tensor_mul node's space() annotation must survive copy/move
-// reconstruction (the simplifier rebuilds mul nodes via the copy ctor).
-// tensor_add already did this; tensor_mul silently dropped it, which is
-// the platform-dependent Skew-loss root cause.
+// #93 — a tensor_mul's space() must survive copy reconstruction
+// (tensor_add did this; mul dropped it).
 TEST(CoreBugFix, TensorMulCopyPreservesSpaceAnnotation) {
   auto A = make_expression<tensor>("A", 3, 2);
   auto B = make_expression<tensor>("B", 3, 2);

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -4,6 +4,8 @@
 #include "numsim_cas/numsim_cas.h"
 #include "gtest/gtest.h"
 #include <cmath>
+#include <numsim_cas/core/substitute.h>
+#include <numsim_cas/tensor/visitors/tensor_substitution.h>
 
 namespace numsim::cas {
 
@@ -666,6 +668,21 @@ TEST(CoreBugFix, SkewSpacePreservedAsTensorMulChild) {
   }
   EXPECT_TRUE(found_skew_child)
       << "skew(A) child of tensor_mul lost its Skew annotation on this build";
+}
+
+TEST(CoreBugFix, SkewSpacePreservedThroughRebuild) {
+  // #93 real mechanism (deterministic, unlike the platform-dependent
+  // mul-child case above): the rebuild visitor reconstructs annotated
+  // nodes via their variadic ctors, which drop the post-construction
+  // Skew space. Substituting a leaf inside skew(A) must keep it Skew.
+  auto [A, B] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}},
+                           std::tuple{"B", std::size_t{3}, std::size_t{2}});
+  auto sA = skew(A);
+  ASSERT_TRUE(is_skew_annotated(sA));
+  auto rebuilt = substitute(sA, A, B);
+  EXPECT_TRUE(is_skew_annotated(rebuilt))
+      << "Skew annotation lost through rebuild (#93)";
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -913,6 +913,23 @@ TEST(CoreBugFix, Issue184_DoublePathAndConstantPathMatch) {
   }
 }
 
+// #93 — a tensor_mul node's space() annotation must survive copy/move
+// reconstruction (the simplifier rebuilds mul nodes via the copy ctor).
+// tensor_add already did this; tensor_mul silently dropped it, which is
+// the platform-dependent Skew-loss root cause.
+TEST(CoreBugFix, TensorMulCopyPreservesSpaceAnnotation) {
+  auto A = make_expression<tensor>("A", 3, 2);
+  auto B = make_expression<tensor>("B", 3, 2);
+  auto prod = A * B;
+  ASSERT_TRUE(is_same<tensor_mul>(prod));
+  prod.data()->set_space({Skew{}, AnyTraceTag{}});
+
+  auto copy = make_expression<tensor_mul>(prod.get<tensor_mul>());
+  ASSERT_TRUE(copy.get().space().has_value())
+      << "tensor_mul copy ctor dropped space() (#93)";
+  EXPECT_TRUE(std::holds_alternative<Skew>(copy.get().space()->perm));
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H


### PR DESCRIPTION
Fixes the platform-dependent Skew-annotation loss in #93. Split out of #313 (pre-release batch) because it touches a core dispatch path (`tensor_rebuild_visitor::apply()`) and warrants isolated review.

## Root cause
`tensor_rebuild_visitor` reconstructs annotated nodes (`inner_product`, `outer_product`, …) via their **variadic ctors**, which don't carry over the `space()` annotation set post-construction by `skew()` / `sym()` / `assume_*`. So any substitution or differentiation rebuild silently dropped the annotation — and which rebuilds fire depends on stdlib hash-iteration order, which is what made it platform-dependent.

## Fix
1. **Rebuild (`3b4a4e7`)** — restore the source node's `space()` onto the freshly-built result in `apply()`, only when the result has none (so a self-computed space like `tensor_add`'s child-join isn't clobbered). One generic point, covers all node types.
2. **Copy-ctor (`aab65a9`, complementary)** — `tensor_mul` / `simple_outer_product` copy/move ctors now restore `space()` (they used the `(data,dim,rank)` base ctor that drops it, unlike `tensor_add`).

## Verification
- **Deterministic reproducer**: substitute a leaf inside `skew(A)` → assert the Skew annotation survives. Confirmed it **FAILS without the rebuild fix, PASSES with it**.
- Full suite green; structural skew classifier kept as belt-and-braces.