### PR TITLE
Un-skip fuzz seed 10034 via 4th-order finite differences (#303)

### DIFF
--- a/tests/FuzzyDiffBase.h
+++ b/tests/FuzzyDiffBase.h
@@ -154,6 +154,26 @@ template <std::size_t N> auto fuzzy_num_diff(auto &&fn, auto &&val) {
                              std::make_index_sequence<N>{});
 }
 
+// 4th-order central difference via Richardson extrapolation of tmech's
+// 2-point num_diff_central: D4 = (4*D(h/2) - D(h)) / 3, O(h^4). Needed
+// because 2-point O(h^2) can't validate high-degree derivatives to the
+// per-element tolerance (#303, seed 10034). h = 1e-4 is the center of a
+// verified-robust plateau: the full fuzz suite passes for h in [1e-5,
+// 1e-3]. Interim until tmech gains a stencil-order parameter (tmech#27),
+// after which this collapses to num_diff_central<seq, k>.
+template <std::size_t... Is>
+auto fuzzy_num_diff_impl_h(auto const &fn, auto const &val, double h,
+                           std::index_sequence<Is...>) {
+  return tmech::num_diff_central<tmech::sequence<(Is + 1)...>>(fn, val, h);
+}
+template <std::size_t N>
+auto fuzzy_num_diff_ho(auto const &fn, auto const &val, double h = 1e-4) {
+  auto d_h = fuzzy_num_diff_impl_h(fn, val, h, std::make_index_sequence<N>{});
+  auto d_h2 =
+      fuzzy_num_diff_impl_h(fn, val, h * 0.5, std::make_index_sequence<N>{});
+  return tmech::eval((4.0 * d_h2 - d_h) * (1.0 / 3.0));
+}
+
 inline std::string
 tensor_expr_string(expression_holder<tensor_expression> const &e) {
   if (!e.is_valid())

--- a/tests/FuzzyTensorDiffTest.h
+++ b/tests/FuzzyTensorDiffTest.h
@@ -139,7 +139,7 @@ tensor_verify_impl(unsigned seed, std::vector<TensorVarEntry> const &vars,
       static_cast<tensor_data<double, FDIM, VarRank> &>(*diff_var_ptr).data();
   auto var_original = var_tmech;
 
-  auto numdiff = fuzzy_num_diff<DiffRank>(
+  auto numdiff = fuzzy_num_diff_ho<DiffRank>(
       [&](auto const &x) {
         var_tmech = x;
         if (var.project)
@@ -731,34 +731,13 @@ namespace {
 // ===========================================================================
 class FuzzyTensorDiffTest : public ::testing::TestWithParam<unsigned> {};
 
-inline bool is_flaky_tensor_seed(unsigned seed) {
-  // Seed 10034 (Depth4, all platforms): max_err ≈ 3e-5,
-  // rel_err ≈ 1e-5. No inv() in the expression — pure-algebra
-  // rank-2 (pow + permute + outer + inner). The small absolute
-  // error trips compare_arrays's per-element check because the
-  // noise floor is scaled from the aggregate max_abs (O(1)) while
-  // some elements live at much smaller magnitudes. Likely FD
-  // step-size precision or a symbolic fold losing a few ulps.
-  // Tracked separately from the inv-conditioning issue.
-  //
-  // Previously also skipped seeds 10 (Depth3, macOS) and 10009
-  // (Depth4, Linux/Windows). Both were the same root cause:
-  // the fuzz inv operator generated `inv(composite)` forms that
-  // evaluate to outer-product matrices — rank-1 as a rank-2
-  // matrix → singular. E.g. seed 10009 produced
-  //   inv(inner(-a, outer(b, D), {3})) = inv(-b ⊗ (D·a))
-  // which is always singular regardless of leaf conditioning.
-  // Fixed at the fuzz generator by restricting inv to leaf inputs
-  // at rank 2 — the restriction already existed at rank 4 for
-  // the analogous `inv(outer(X, Y))` case.
-  return seed == 10034u;
-}
+// No flaky-seed skip list: seed 10034 (the last entry, an FD-precision
+// artifact) is resolved by the 4th-order fuzzy_num_diff_ho (#303). The
+// earlier singular-inv seeds (10, 10009) were fixed at the generator.
 
 #define FUZZY_TENSOR_DIFF_TEST_P(TestClass, TestName, SeedOffset, Depth)       \
   TEST_P(TestClass, TestName) {                                                \
     unsigned const seed = GetParam() + SeedOffset##u;                          \
-    if (is_flaky_tensor_seed(seed))                                            \
-      GTEST_SKIP() << "Flaky seed " << seed;                                   \
     try {                                                                      \
       numsim::cas::fuzzy_detail::FuzzyTensorMachine machine(seed, Depth);      \
       auto result = machine.run_one_test();                                    \


### PR DESCRIPTION
Resolves #303 for real (was documented-as-skipped in #313; split out here).

## Finding
Seed 10034's ~3e-5 symbolic-vs-numerical mismatch was **truncation-limited in the numerical reference, not a symbolic-derivative bug**. The 2-point central FD (`tmech::num_diff_central`, O(h²)) can't validate the expression's degree-6 term to the per-element tolerance — the symbolic derivative is correct.

## Fix
- `fuzzy_num_diff_ho<N>` — 4th-order central difference via Richardson extrapolation of two `num_diff_central` calls: `D4 = (4·D(h/2) − D(h))/3`, O(h⁴). Reuses tmech's tested per-component machinery.
- Route tensor fuzz through it; **remove the flaky-seed skip** (10034 was the only entry).

## Robustness
`h = 1e-4` is the **center of a verified plateau** — I swept `h` and the full fuzz suite passes with 0 failures for `h ∈ [1e-5, 1e-3]` (two decades), so it's not a lucky point.

## Verification
- Seed 10034 passes; **full fuzz suite 784 passed, 0 failed** (was 783 + 1 skipped).
- Interim: once tmech gains a stencil-order parameter (**petlenz/tmech#27**), this collapses to `num_diff_central<seq, k>`.