### PR TITLE
Fold contraction indices into inner_product hash (#266)

### DIFF
--- a/include/numsim_cas/tensor/wrappers/inner_product_wrapper.h
+++ b/include/numsim_cas/tensor/wrappers/inner_product_wrapper.h
@@ -52,6 +52,20 @@ public:
     return m_rhs_indices;
   }
 
+  // #266 — fold the contraction indices into the hash (mirrors
+  // outer_product_wrapper). Without this, the default binary_op hash
+  // ignores them, so two inner_products differing only in their
+  // contraction sequences hash-collide (cache aliasing + blind lock-ins).
+  void update_hash_value() const noexcept override {
+    hash_combine(base::m_hash_value, base::get_id());
+    numsim::cas::hash_combine(base::m_hash_value,
+                              base::expr_lhs().get().hash_value());
+    numsim::cas::hash_combine(base::m_hash_value,
+                              base::expr_rhs().get().hash_value());
+    numsim::cas::hash_combine(base::m_hash_value, indices_lhs());
+    numsim::cas::hash_combine(base::m_hash_value, indices_rhs());
+  }
+
 protected:
   sequence m_lhs_indices;
   sequence m_rhs_indices;

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -944,6 +944,18 @@ TEST(CoreBugFix, TensorMulCopyPreservesSpaceAnnotation) {
   EXPECT_TRUE(std::holds_alternative<Skew>(copy.get().space()->perm));
 }
 
+// #266 — inner_product's hash must include its contraction indices; two
+// products differing only in their contraction sequences must hash
+// differently (the default binary_op hash ignored them, causing cache
+// aliasing and structural lock-ins that couldn't see the difference).
+TEST(InnerProductHash, ContractionIndicesAffectHash) {
+  auto A = make_expression<tensor>("A", 3, 2);
+  auto B = make_expression<tensor>("B", 3, 2);
+  auto e1 = inner_product(A, sequence{2}, B, sequence{1});
+  auto e2 = inner_product(A, sequence{1}, B, sequence{2});
+  EXPECT_NE(e1.get().hash_value(), e2.get().hash_value());
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H


### PR DESCRIPTION
Fixes #266. `inner_product_wrapper` inherited the default `binary_op` hash (id + lhs + rhs), ignoring its contraction index sequences — so two inner_products differing only in their contractions hash-collided (cache aliasing; structural lock-ins couldn't see the difference). Adds the `update_hash_value` override that folds `indices_lhs()`/`indices_rhs()` in, mirroring `outer_product_wrapper`.

Lock-in test verified to **fail without the fix**; full main suite + 784 fuzz unaffected (no dedup ripple).

Follow-up: `SkewRank2Dim4StructuralLockIn` (deleted in #265) can be revived now — left separate.

Closes #266.