### PR TITLE
Propagate PD/PSD through tensor_scalar_mul for positive scalars (#256)

### DIFF
--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -6,6 +6,7 @@
 #include <numsim_cas/core/operators.h>
 #include <numsim_cas/core/promote_expr.h>
 
+#include <numsim_cas/scalar/scalar_assume.h>
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/operators/tensor/tensor_add.h>
@@ -172,6 +173,21 @@ tag_invoke(mul_fn, L &&lhs, [[maybe_unused]] R &&rhs) {
   return _lhs.accept(visitor);
 }
 
+// #256 — a positive scalar preserves PD/PSD: pos·PD → PD, pos·PSD → PSD.
+// A negative scalar flips to negative-definite (not modelled) and
+// unknown-sign destroys the annotation. Orthogonality needs |α| = 1,
+// which isn't symbolically checkable, so it is NOT propagated.
+inline void propagate_pd_psd_scalar_mul(
+    bool scalar_positive, bool tensor_pd, bool tensor_psd,
+    expression_holder<tensor_expression> const &result) {
+  if (!scalar_positive || !tensor_psd)
+    return;
+  auto &out = result.data()->tensor_algebra_assumptions();
+  if (tensor_pd)
+    out.insert(positive_definite{});
+  out.insert(positive_semidefinite{}); // PD ⇒ PSD (#245 convention)
+}
+
 template <class L, class R>
 requires std::same_as<std::remove_cvref_t<L>,
                       expression_holder<tensor_expression>> &&
@@ -192,9 +208,17 @@ inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
   }
 
   auto &_lhs{lhs.template get<tensor_visitable_t>()};
+  // #256 — capture positivity/PD BEFORE forwarding consumes the operands.
+  const bool sp = is_positive(rhs);
+  const bool t_pd =
+      lhs.get().tensor_algebra_assumptions().contains(positive_definite{});
+  const bool t_psd = t_pd || lhs.get().tensor_algebra_assumptions().contains(
+                                 positive_semidefinite{});
   tensor_with_scalar_detail::simplifier::mul_base visitor(std::forward<R>(rhs),
                                                           std::forward<L>(lhs));
-  return _lhs.accept(visitor);
+  auto result = _lhs.accept(visitor);
+  propagate_pd_psd_scalar_mul(sp, t_pd, t_psd, result);
+  return result;
 }
 
 template <class L, class R>
@@ -217,9 +241,17 @@ inline expression_holder<tensor_expression> tag_invoke(mul_fn, L &&lhs,
   }
 
   auto &_rhs{rhs.template get<tensor_visitable_t>()};
+  // #256 — capture positivity/PD BEFORE forwarding consumes the operands.
+  const bool sp = is_positive(lhs);
+  const bool t_pd =
+      rhs.get().tensor_algebra_assumptions().contains(positive_definite{});
+  const bool t_psd = t_pd || rhs.get().tensor_algebra_assumptions().contains(
+                                 positive_semidefinite{});
   tensor_with_scalar_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                                           std::forward<R>(rhs));
-  return _rhs.accept(visitor);
+  auto result = _rhs.accept(visitor);
+  propagate_pd_psd_scalar_mul(sp, t_pd, t_psd, result);
+  return result;
 }
 
 // tensor × tensor_to_scalar — produces a tensor result via the

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -1878,6 +1878,34 @@ TEST(TensorAlgebraStep6, ClosedFormConstantQueryConsistency) {
   EXPECT_FALSE(is_orthogonal(P));
 }
 
+// #256 — a positive scalar preserves PD/PSD through tensor_scalar_mul,
+// so positive · PD stays PD (both operand orders) and inv(2·mu·C) is PD.
+TEST(TensorAlgebraScalarMul, PositiveScalarPreservesPD) {
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto [mu] = make_scalar_variable("mu");
+  assume_positive_definite(C);
+  assume(mu, positive{});
+  EXPECT_TRUE(is_positive_definite(mu * C));
+  EXPECT_TRUE(is_positive_definite(C * mu));
+  EXPECT_TRUE(is_positive_definite(inv(2 * mu * C)));
+}
+
+TEST(TensorAlgebraScalarMul, PositiveScalarPreservesPSD) {
+  auto H = std::get<0>(make_tensor_variable(std::tuple{"H", 3, 2}));
+  auto [mu] = make_scalar_variable("mu");
+  assume_positive_semidefinite(H);
+  assume(mu, positive{});
+  EXPECT_TRUE(is_positive_semidefinite(mu * H));
+  EXPECT_FALSE(is_positive_definite(mu * H)); // PSD, not PD
+}
+
+TEST(TensorAlgebraScalarMul, UnknownSignScalarDropsPD) {
+  auto C = std::get<0>(make_tensor_variable(std::tuple{"C", 3, 2}));
+  auto [a] = make_scalar_variable("a"); // no sign assumption
+  assume_positive_definite(C);
+  EXPECT_FALSE(is_positive_definite(a * C));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORALGEBRAASSUMETEST_H


### PR DESCRIPTION
Fixes #256. `tensor_scalar_mul(α, T)` now propagates `positive_definite`/`positive_semidefinite` from `T` when `α` is positive (both operand orders). Uses `is_positive`, so inferred positivity (e.g. `1/(2·mu)`) counts, and captures PD/PSD before the operands are forwarded.

Closes the gap from #255/#246: the scalar-pullout fold `inv(α·A) → inv(A)/α` wrapped the PD result in a `tensor_scalar_mul` that stripped the annotation, so `is_positive_definite(inv(2·mu·C))` was false. Now true.

- Negative / unknown-sign scalars don't propagate (negative → ND, not modelled).
- Orthogonality needs |α|=1 (not symbolically checkable) → intentionally excluded.
- The `tensor / pos_scalar` div path routes through `mul · pow(pos,-1)` and is covered for free.

3 lock-ins (the `inv(2·mu·C)` example, PSD, unknown-sign negative case); full suite green (1561).

Closes #256.