### PR TITLE
Add symbolic eigenvalue node for symmetric rank-2 tensors (#226)

### DIFF
--- a/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
@@ -4,6 +4,9 @@
 #include "tensor_data.h"
 #include <numsim_cas/core/cas_error.h>
 
+#include <algorithm>
+#include <array>
+
 namespace numsim::cas {
 
 // ─── Generic unary wrapper: dispatches runtime (dim,rank) to tmech Op
@@ -82,6 +85,55 @@ public:
 private:
   tensor_data_base<ValueType> const &m_lhs;
   tensor_data_base<ValueType> const &m_rhs;
+};
+
+// ─── Eigenvalue wrapper: dispatches runtime (dim,rank), computes the
+//     ascending-sorted eigenvalues of a symmetric rank-2 tensor and
+//     returns the index-th one (#226) ────────────────────────────────────
+//
+template <typename ValueType>
+class tensor_data_eigenvalue_wrapper final
+    : public tensor_data_eval_up_unary<
+          tensor_data_eigenvalue_wrapper<ValueType>, ValueType> {
+public:
+  tensor_data_eigenvalue_wrapper(tensor_data_base<ValueType> const &input,
+                                 std::size_t index)
+      : m_input(input), m_index(index) {}
+
+  template <std::size_t Dim, std::size_t Rank> ValueType evaluate_imp() {
+    if constexpr (Rank == 2 && (Dim == 2 || Dim == 3)) {
+      if (m_index >= Dim)
+        throw evaluation_error(
+            "tensor_data_eigenvalue_wrapper: eigenvalue index out of range");
+      using Tensor = tensor_data<ValueType, Dim, Rank>;
+      auto const &in = static_cast<const Tensor &>(m_input).data();
+      auto decomp = tmech::eigen_decomposition(tmech::sym(in));
+      decomp.decompose();
+      auto const values = decomp.eigenvalues();
+      std::array<ValueType, Dim> sorted{};
+      for (std::size_t i{0}; i < Dim; ++i)
+        sorted[i] = values[i];
+      std::sort(sorted.begin(), sorted.end());
+      return sorted[m_index];
+    } else {
+      throw evaluation_error("tensor_data_eigenvalue_wrapper: requires a "
+                             "rank-2 tensor of dim 2 or 3");
+    }
+  }
+
+  ValueType mismatch(std::size_t dim, std::size_t rank) {
+    if (dim > this->MaxDim_ || dim == 0)
+      throw evaluation_error(
+          "tensor_data_eigenvalue_wrapper: dim > MaxDim || dim == 0");
+    if (rank > this->MaxRank_ || rank == 0)
+      throw evaluation_error(
+          "tensor_data_eigenvalue_wrapper: rank > MaxRank || rank == 0");
+    return ValueType{};
+  }
+
+private:
+  tensor_data_base<ValueType> const &m_input;
+  std::size_t m_index;
 };
 
 // ─── tmech scalar-returning operation policies ──────────────────────────

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h
@@ -5,6 +5,7 @@
 #include <numsim_cas/tensor_to_scalar/tensor_dot.h>
 #include <numsim_cas/tensor_to_scalar/tensor_inner_product_to_scalar.h>
 #include <numsim_cas/tensor_to_scalar/tensor_norm.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_eigenvalue.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_exp.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_log.h>

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_eigenvalue.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_eigenvalue.h
@@ -1,0 +1,56 @@
+#ifndef TENSOR_TO_SCALAR_EIGENVALUE_H
+#define TENSOR_TO_SCALAR_EIGENVALUE_H
+
+#include <cstddef>
+
+#include <numsim_cas/core/unary_op.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+
+namespace numsim::cas {
+
+// #226 — the i-th eigenvalue of a symmetric rank-2 tensor A. Stays an
+// opaque scalar at the AST level (materialised only at evaluation, via
+// tmech's eigendecomposition), so the symbolic chain rule survives.
+// `index` is 0-based into the ascending-sorted eigenvalues.
+class tensor_to_scalar_eigenvalue final
+    : public unary_op<tensor_to_scalar_node_base_t<tensor_to_scalar_eigenvalue>,
+                      tensor_expression> {
+public:
+  using base =
+      unary_op<tensor_to_scalar_node_base_t<tensor_to_scalar_eigenvalue>,
+               tensor_expression>;
+
+  template <typename E>
+  tensor_to_scalar_eigenvalue(E &&e, std::size_t index)
+      : base(std::forward<E>(e)), m_index(index) {}
+
+  tensor_to_scalar_eigenvalue(tensor_to_scalar_eigenvalue const &e)
+      : base(static_cast<base const &>(e)), m_index(e.m_index) {}
+  tensor_to_scalar_eigenvalue(tensor_to_scalar_eigenvalue &&e) noexcept
+      : base(std::move(static_cast<base &&>(e))), m_index(e.m_index) {}
+  tensor_to_scalar_eigenvalue() = delete;
+  ~tensor_to_scalar_eigenvalue() override = default;
+  const tensor_to_scalar_eigenvalue &
+  operator=(tensor_to_scalar_eigenvalue &&) = delete;
+
+  [[nodiscard]] std::size_t index() const noexcept { return m_index; }
+
+protected:
+  // Fold the index in (mirrors inner_product_wrapper #266): two
+  // eigenvalues of the same tensor differ only by index.
+  void update_hash_value() const noexcept override {
+    this->m_hash_value = 0;
+    hash_combine(this->m_hash_value, this->get_id());
+    if (this->expr().is_valid())
+      hash_combine(this->m_hash_value, this->expr().get().hash_value());
+    hash_combine(this->m_hash_value, m_index);
+  }
+
+private:
+  std::size_t m_index;
+};
+
+} // namespace numsim::cas
+
+#endif // TENSOR_TO_SCALAR_EIGENVALUE_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h
@@ -44,6 +44,13 @@ second_invariant(expression_holder<tensor_expression> const &expr);
 [[nodiscard]] expression_holder<tensor_to_scalar_expression>
 third_invariant(expression_holder<tensor_expression> const &expr);
 
+// The `index`-th eigenvalue of a symmetric rank-2 tensor (#226), ordered
+// ascending. Stays symbolic (an opaque scalar node) until evaluation, so
+// the chain rule composes over it. `index` is 0-based and must be less
+// than the tensor's dimension.
+[[nodiscard]] expression_holder<tensor_to_scalar_expression>
+eigenvalue(expression_holder<tensor_expression> const &expr, std::size_t index);
+
 } // namespace numsim::cas
 
 #endif // TENSOR_TO_SCALAR_FUNCTIONS_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_node_list.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_node_list.h
@@ -16,6 +16,7 @@
   NEXT(tensor_to_scalar_log)                                                   \
   NEXT(tensor_to_scalar_exp)                                                   \
   NEXT(tensor_to_scalar_sqrt)                                                  \
+  NEXT(tensor_to_scalar_eigenvalue)                                            \
   NEXT(tensor_to_scalar_scalar_wrapper)                                        \
   NEXT(tensor_to_scalar_if_then_else)
 

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.h
@@ -74,6 +74,7 @@ public:
   void operator()(tensor_dot const &visitable) override;
   void operator()(tensor_norm const &visitable) override;
   void operator()(tensor_det const &visitable) override;
+  void operator()(tensor_to_scalar_eigenvalue const &visitable) override;
   void operator()(tensor_inner_product_to_scalar const &visitable) override;
 
   // ─── if_then_else (#135 / #210) ─────────────────────────────────

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.h
@@ -70,6 +70,7 @@ public:
   void operator()(tensor_dot const &visitable) override;
   void operator()(tensor_norm const &visitable) override;
   void operator()(tensor_det const &visitable) override;
+  void operator()(tensor_to_scalar_eigenvalue const &visitable) override;
   void operator()(tensor_inner_product_to_scalar const &visitable) override;
   void operator()(tensor_to_scalar_if_then_else const &visitable) override;
 

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
@@ -137,6 +137,14 @@ public:
     m_result = eval_tensor_to_scalar<tmech_ops::dcontract_self_op>(v.expr());
   }
 
+  void operator()(tensor_to_scalar_eigenvalue const &v) override {
+    auto data = m_tensor_eval.apply(v.expr());
+    const auto dim = data->dim();
+    const auto rank = data->rank();
+    tensor_data_eigenvalue_wrapper<ValueType> op(*data, v.index());
+    m_result = op.evaluate(dim, rank);
+  }
+
   void operator()(tensor_inner_product_to_scalar const &v) override {
     auto lhs_data = m_tensor_eval.apply(v.expr_lhs());
     auto rhs_data = m_tensor_eval.apply(v.expr_rhs());

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_latex_printer.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_latex_printer.h
@@ -70,6 +70,12 @@ public:
     print_unary("\\det", visitable);
   }
 
+  void operator()(tensor_to_scalar_eigenvalue const &visitable) override {
+    m_out << "\\lambda_{" << visitable.index() << "}\\left(";
+    apply(visitable.expr());
+    m_out << "\\right)";
+  }
+
   void operator()(tensor_to_scalar_negative const &visitable) override {
     constexpr auto precedence{Precedence::Unary};
     m_out << "-";

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.h
@@ -33,6 +33,7 @@ public:
   void operator()(tensor_dot const &) override;
   void operator()(tensor_det const &) override;
   void operator()(tensor_norm const &) override;
+  void operator()(tensor_to_scalar_eigenvalue const &) override;
   void operator()(tensor_inner_product_to_scalar const &) override;
 
   // Arithmetic

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
@@ -85,6 +85,12 @@ public:
     print_unary("det", visitable);
   }
 
+  void operator()(tensor_to_scalar_eigenvalue const &visitable) override {
+    m_out << "eig_" << visitable.index() << "(";
+    apply(visitable.expr());
+    m_out << ")";
+  }
+
   void operator()(tensor_to_scalar_negative const &visitable) override {
     constexpr auto precedence{Precedence::Unary};
     m_out << "-";

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
@@ -92,6 +92,10 @@ public:
     m_result = norm(apply_tensor(v.expr()));
   }
 
+  void operator()(tensor_to_scalar_eigenvalue const &v) override {
+    m_result = eigenvalue(apply_tensor(v.expr()), v.index());
+  }
+
   // Binary t2s x t2s -> t2s
   void operator()(tensor_to_scalar_pow const &v) override {
     m_result = pow(apply(v.expr_lhs()), apply(v.expr_rhs()));

--- a/src/numsim_cas/core/contains_expression.cpp
+++ b/src/numsim_cas/core/contains_expression.cpp
@@ -244,6 +244,9 @@ public:
   void operator()(tensor_trace const &v) override { check_tensor(v.expr()); }
   void operator()(tensor_det const &v) override { check_tensor(v.expr()); }
   void operator()(tensor_norm const &v) override { check_tensor(v.expr()); }
+  void operator()(tensor_to_scalar_eigenvalue const &v) override {
+    check_tensor(v.expr());
+  }
   void operator()(tensor_dot const &v) override { check_tensor(v.expr()); }
   void operator()(tensor_inner_product_to_scalar const &v) override {
     check_tensor(v.expr_lhs());

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -3,6 +3,7 @@
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
 
 #include <numsim_cas/basic_functions.h>
+#include <numsim_cas/core/cas_error.h>
 #include <numsim_cas/scalar/scalar_std.h>
 #include <numsim_cas/tensor/tensor_assume.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
@@ -220,6 +221,19 @@ second_invariant(expression_holder<tensor_expression> const &expr) {
 expression_holder<tensor_to_scalar_expression>
 third_invariant(expression_holder<tensor_expression> const &expr) {
   return det(expr);
+}
+
+// ─── Eigenvalue (#226) ─────────────────────────────────────────────────
+
+expression_holder<tensor_to_scalar_expression>
+eigenvalue(expression_holder<tensor_expression> const &expr,
+           std::size_t index) {
+  assert(expr.get().rank() == 2);
+  if (index >= expr.get().dim())
+    throw invalid_expression_error(
+        "eigenvalue: index out of range for tensor dimension");
+
+  return make_expression<tensor_to_scalar_eigenvalue>(expr, index);
 }
 
 } // namespace numsim::cas

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -261,6 +261,16 @@ void tensor_to_scalar_differentiation::operator()(tensor_det const &visitable) {
       std::move(contracted), m_expr);
 }
 
+// Eigenvalue: d(λ_i(A))/dA = n_i ⊗ n_i (the eigenprojection), which needs
+// symbolic eigenvectors — deferred until the eigenvector node lands (#226
+// follow-up). Evaluation of λ_i itself already works.
+void tensor_to_scalar_differentiation::operator()(
+    tensor_to_scalar_eigenvalue const & /*visitable*/) {
+  throw not_implemented_error(
+      "tensor_to_scalar_differentiation: d/dA of an eigenvalue needs the "
+      "eigenvector node (not yet implemented)");
+}
+
 // Inner product to scalar: product rule
 // d(inner(A, idx_a, B, idx_b))/dX
 // = inner(dA, idx_a, B, idx_b) + inner(A, idx_a, dB, idx_b)

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
@@ -272,6 +272,15 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   m_result = m_expr * std::move(contracted);
 }
 
+// λ_i(A): d/ds = n_i ⊗ n_i : dA/ds, needs symbolic eigenvectors — deferred
+// until the eigenvector node lands (#226 follow-up).
+void tensor_to_scalar_differentiation_wrt_scalar::operator()(
+    tensor_to_scalar_eigenvalue const & /*visitable*/) {
+  throw not_implemented_error(
+      "tensor_to_scalar_differentiation_wrt_scalar: d/ds of an eigenvalue "
+      "needs the eigenvector node (not yet implemented)");
+}
+
 // inner_product_to_scalar(A, idxA, B, idxB): product rule, t2s-valued.
 // d/ds = inner(dA, idxA, B, idxB) + inner(A, idxA, dB, idxB)
 void tensor_to_scalar_differentiation_wrt_scalar::operator()(

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_limit_visitor.cpp
@@ -122,6 +122,18 @@ void tensor_to_scalar_limit_visitor::operator()(
 }
 
 void tensor_to_scalar_limit_visitor::operator()(
+    [[maybe_unused]] tensor_to_scalar_eigenvalue const &v) {
+  // An eigenvalue's sign and magnitude aren't recoverable from the AST
+  // generically (unlike norm/det), so any tensor dependency is unknown.
+  if (m_mode == dependency_mode::tensor_dependency &&
+      contains_expression(v.expr(), m_tensor_var)) {
+    m_result = {dir::unknown};
+    return;
+  }
+  m_result = {dir::finite_positive};
+}
+
+void tensor_to_scalar_limit_visitor::operator()(
     tensor_inner_product_to_scalar const &v) {
   if (m_mode == dependency_mode::tensor_dependency) {
     bool lhs_dep = contains_expression(v.expr_lhs(), m_tensor_var);

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <numsim_cas/basic_functions.h>
+#include <numsim_cas/core/cas_error.h>
 #include <numsim_cas/scalar/scalar_all.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/scalar/scalar_std.h>
@@ -386,6 +387,61 @@ TEST(T2sEval, IfThenElseLazyOnUnselectedBranch) {
   ev.set_scalar(x, 0.0);
   auto expr_else_safe = if_then_else(cond, unsafe, safe);
   EXPECT_NEAR(ev.apply(expr_else_safe), 42.0, t2s_tol);
+}
+
+// ─── Eigenvalue (#226) ────────────────────────────────────────────────
+
+TEST(T2sEval, EigenvalueDiagonal3x3Ascending) {
+  // diag(5,3,2): eigenvalues are the diagonal entries. The node returns
+  // them ascending regardless of input order, so eig_0=2, eig_1=3, eig_2=5.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({5.0, 0.0, 0.0,
+                                   0.0, 3.0, 0.0,
+                                   0.0, 0.0, 2.0}));
+  // clang-format on
+  EXPECT_NEAR(ev.apply(eigenvalue(A, 0)), 2.0, t2s_tol);
+  EXPECT_NEAR(ev.apply(eigenvalue(A, 1)), 3.0, t2s_tol);
+  EXPECT_NEAR(ev.apply(eigenvalue(A, 2)), 5.0, t2s_tol);
+}
+
+TEST(T2sEval, EigenvalueSumEqualsTraceProductEqualsDet) {
+  // Cross-check on a non-diagonal symmetric matrix without hardcoding the
+  // (irrational) eigenvalues: Σλ_i = tr(A), Πλ_i = det(A).
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 1.0, 0.0,
+                                   1.0, 3.0, 1.0,
+                                   0.0, 1.0, 2.0}));
+  // clang-format on
+  auto const l0 = ev.apply(eigenvalue(A, 0));
+  auto const l1 = ev.apply(eigenvalue(A, 1));
+  auto const l2 = ev.apply(eigenvalue(A, 2));
+  EXPECT_LE(l0, l1);
+  EXPECT_LE(l1, l2);
+  // Symbolic composition: eigenvalues are opaque atoms that flow through
+  // the t2s add/mul simplifiers like any other scalar node.
+  auto sum = eigenvalue(A, 0) + eigenvalue(A, 1) + eigenvalue(A, 2);
+  auto prod = eigenvalue(A, 0) * eigenvalue(A, 1) * eigenvalue(A, 2);
+  EXPECT_NEAR(ev.apply(sum), ev.apply(trace(A)), 1e-10);
+  EXPECT_NEAR(ev.apply(prod), ev.apply(det(A)), 1e-10);
+}
+
+TEST(T2sEval, Eigenvalue2x2) {
+  // A = [[2,1],[1,2]] has eigenvalues 1 and 3.
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 2, 2);
+  ev.set(A, make_test_data<2, 2>({2.0, 1.0, 1.0, 2.0}));
+  EXPECT_NEAR(ev.apply(eigenvalue(A, 0)), 1.0, 1e-10);
+  EXPECT_NEAR(ev.apply(eigenvalue(A, 1)), 3.0, 1e-10);
+}
+
+TEST(T2sEval, EigenvalueIndexOutOfRangeThrows) {
+  // index must be < dim; the factory rejects it at construction.
+  auto A = make_expression<tensor>("A", 3, 2);
+  EXPECT_THROW((void)eigenvalue(A, 3), invalid_expression_error);
 }
 
 } // namespace numsim::cas

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -648,6 +648,29 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_NormSimplification) {
   EXPECT_PRINT(norm(X), "norm(X)");
 }
 
+// ---------- eigenvalue() (#226) ----------
+TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_Eigenvalue) {
+  auto &X = this->X;
+  constexpr auto Dim = TestFixture::Dim;
+
+  using numsim::cas::eigenvalue;
+
+  // Prints as eig_<index>(A).
+  EXPECT_PRINT(eigenvalue(X, 0), "eig_0(X)");
+
+  // Same tensor + same index → identical expression (equal hash).
+  EXPECT_EQ(eigenvalue(X, 0).get().hash_value(),
+            eigenvalue(X, 0).get().hash_value());
+
+  // Index is folded into the hash: different eigenvalues of the same
+  // tensor are distinct expressions (#266-style disambiguation).
+  if constexpr (Dim >= 2) {
+    EXPECT_PRINT(eigenvalue(X, 1), "eig_1(X)");
+    EXPECT_NE(eigenvalue(X, 0).get().hash_value(),
+              eigenvalue(X, 1).get().hash_value());
+  }
+}
+
 // ---------- trace() linearity ----------
 TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_TraceLinearity) {
   auto &X = this->X;

--- a/tests/TensorToScalarSubstitutionTest.h
+++ b/tests/TensorToScalarSubstitutionTest.h
@@ -85,4 +85,16 @@ TYPED_TEST(TensorToScalarSubstitutionTest, TensorInT2s) {
       << "Expected " << testcas::S(expected) << ", got: " << testcas::S(result);
 }
 
+// Substitution rebuilds through the eigenvalue node, preserving the index.
+TYPED_TEST(TensorToScalarSubstitutionTest, EigenvalueTensorSub) {
+  auto &X = this->X;
+  auto &Y = this->Y;
+
+  auto expr = numsim::cas::eigenvalue(X, 0);
+  auto result = numsim::cas::substitute(expr, X, Y);
+  auto expected = numsim::cas::eigenvalue(Y, 0);
+  EXPECT_TRUE(result == expected)
+      << "Expected " << testcas::S(expected) << ", got: " << testcas::S(result);
+}
+
 #endif // TENSORTOSCALARSUBSTITUTIONTEST_H


### PR DESCRIPTION
## Summary

First PR of the eigenvalue/eigenvector half of #226 (principal invariants already landed). Adds a **symbolic eigenvalue node** for symmetric rank-2 tensors.

`eigenvalue(A, i)` is the `i`-th eigenvalue of `A`, ordered **ascending**. It stays opaque in the AST — an atom in the tensor→scalar domain — and is materialised only at evaluation via tmech's eigendecomposition. That keeps the symbolic chain rule intact: `eigenvalue` composes through the t2s add/mul/pow simplifiers like any other scalar.

## What's included

- **Node** `tensor_to_scalar_eigenvalue`: `unary_op` over a tensor plus a 0-based `index`, folded into the hash (mirrors the #266 inner-product hashing) so distinct eigenvalues of the same tensor are distinct expressions.
- **Factory** `eigenvalue(A, i)`; rejects out-of-range `index` at construction (`invalid_expression_error`).
- **Every t2s visitor wired**: text printer (`eig_i(A)`), LaTeX (`\lambda_i(A)`), rebuild/substitution, `contains`, evaluator (ascending-sorted tmech eigenvalues, dim 2/3; input symmetrised for robustness), and the limit visitor.
- **Evaluation wrapper** `tensor_data_eigenvalue_wrapper` with the usual runtime `(dim,rank)` dispatch.

## Deferred (tracked follow-up)

Differentiation — both `d/dA` and `d/ds` — throws `not_implemented_error`. The derivative is the eigenprojection `n_i ⊗ n_i`, which needs the **eigenvector node**. That's the next PR in #226; evaluation of the eigenvalue itself already works.

## Tests

- Evaluation: diagonal ascending order (unsorted input), `Σλ = tr` / `Πλ = det` via **symbolic** add/mul composition, 2×2, out-of-range throw.
- Printing + hash disambiguation across dims 1/2/3.
- Substitution rebuild preserves the index.

All 1576 tests pass locally.
