### PR TITLE
Add eigenprojection node; wire eigenvalue differentiation (#226)

### DIFF
--- a/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
@@ -4,6 +4,9 @@
 #include "tensor_data.h"
 #include <numsim_cas/core/cas_error.h>
 
+#include <algorithm>
+#include <array>
+
 namespace numsim::cas {
 
 // ─── Generic unary wrapper: dispatches runtime (dim,rank) to tmech Op ────────
@@ -43,6 +46,60 @@ public:
 private:
   tensor_data_base<ValueType> &m_result;
   tensor_data_base<ValueType> const &m_input;
+};
+
+// ─── Eigenprojection wrapper: E_i = n_i ⊗ n_i of a symmetric rank-2 tensor
+//     (#226). Runtime index selects the i-th (ascending-eigenvalue)
+//     eigenpair, so E_index pairs with the eigenvalue node's λ_index. ─────
+//
+template <typename ValueType>
+class tensor_data_eigenprojection_wrapper final
+    : public tensor_data_eval_up_unary<
+          tensor_data_eigenprojection_wrapper<ValueType>, ValueType> {
+public:
+  tensor_data_eigenprojection_wrapper(tensor_data_base<ValueType> &result,
+                                      tensor_data_base<ValueType> const &input,
+                                      std::size_t index)
+      : m_result(result), m_input(input), m_index(index) {}
+
+  template <std::size_t Dim, std::size_t Rank> void evaluate_imp() {
+    if constexpr (Rank == 2 && (Dim == 2 || Dim == 3)) {
+      if (m_index >= Dim)
+        throw evaluation_error(
+            "tensor_data_eigenprojection_wrapper: index out of range");
+      using Tensor = tensor_data<ValueType, Dim, Rank>;
+      auto const &in = static_cast<const Tensor &>(m_input).data();
+      auto decomp = tmech::eigen_decomposition(tmech::sym(in));
+      auto const [eigvals, eigvecs] = decomp.decompose();
+      // Sort eigenpair indices by eigenvalue ascending so this E_index
+      // corresponds to the eigenvalue node's λ_index.
+      std::array<std::size_t, Dim> order{};
+      for (std::size_t i{0}; i < Dim; ++i)
+        order[i] = i;
+      std::sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) {
+        return eigvals[a] < eigvals[b];
+      });
+      auto const &n = eigvecs[order[m_index]];
+      static_cast<Tensor &>(m_result).data() = tmech::otimes(n, n);
+    } else {
+      throw evaluation_error("tensor_data_eigenprojection_wrapper: requires a "
+                             "rank-2 tensor of dim 2 or 3");
+    }
+  }
+
+  void mismatch(std::size_t dim, std::size_t rank) {
+    if (dim > this->MaxDim_ || dim == 0)
+      throw evaluation_error(
+          "tensor_data_eigenprojection_wrapper: dim > MaxDim || dim == 0");
+    if (rank > this->MaxRank_ || rank == 0)
+      throw evaluation_error(
+          "tensor_data_eigenprojection_wrapper: rank > MaxRank || rank == 0");
+  }
+
+private:
+  tensor_data_base<ValueType> &m_result;
+  tensor_data_base<ValueType> const &m_input;
+  std::size_t m_index;
 };
 
 // ─── Identity tensor creation via tmech::eye ─────────────────────────────────

--- a/include/numsim_cas/tensor/tensor_definitions.h
+++ b/include/numsim_cas/tensor/tensor_definitions.h
@@ -17,6 +17,7 @@
 #include <numsim_cas/tensor/wrappers/outer_product_wrapper.h>
 #include <numsim_cas/tensor/wrappers/permute_indices_wrapper.h>
 #include <numsim_cas/tensor/wrappers/simple_outer_product.h>
+#include <numsim_cas/tensor/wrappers/tensor_eigenprojection.h>
 #include <numsim_cas/tensor/wrappers/tensor_inv.h>
 #include <numsim_cas/tensor/wrappers/tensor_pow.h>
 

--- a/include/numsim_cas/tensor/tensor_functions.h
+++ b/include/numsim_cas/tensor/tensor_functions.h
@@ -507,6 +507,23 @@ template <tensor_expr_holder Expr>
   return make_expression<tensor_inv>(std::forward<Expr>(expr));
 }
 
+// The i-th eigenprojection E_i(A) = n_i ⊗ n_i of a symmetric rank-2 tensor
+// (#226) — a rank-2 symmetric tensor, ordered so E_i pairs with the i-th
+// ascending eigenvalue. Stays symbolic until evaluation; the spectral
+// derivative dλ_i/dA = E_i and isotropic functions f(A) = Σ f(λ_i) E_i
+// (#227) consume it. `index` is 0-based and must be less than dim.
+template <tensor_expr_holder Expr>
+[[nodiscard]] inline auto eigenprojection(Expr &&expr, std::size_t index) {
+  if (expr.get().rank() != 2)
+    throw invalid_expression_error(
+        "eigenprojection: input must be a rank-2 tensor");
+  if (index >= expr.get().dim())
+    throw invalid_expression_error(
+        "eigenprojection: index out of range for tensor dimension");
+  return make_expression<tensor_eigenprojection>(std::forward<Expr>(expr),
+                                                 index);
+}
+
 } // namespace numsim::cas
 
 #endif // NUMSIM_CAS_TENSOR_FUNCTIONS_H

--- a/include/numsim_cas/tensor/tensor_node_list.h
+++ b/include/numsim_cas/tensor/tensor_node_list.h
@@ -19,6 +19,7 @@
   NEXT(outer_product_wrapper)                                                  \
   NEXT(simple_outer_product)                                                   \
   NEXT(tensor_inv)                                                             \
+  NEXT(tensor_eigenprojection)                                                 \
   NEXT(tensor_zero)                                                            \
   NEXT(tensor_projector)                                                       \
   NEXT(identity_tensor)                                                        \

--- a/include/numsim_cas/tensor/visitors/tensor_differentiation.h
+++ b/include/numsim_cas/tensor/visitors/tensor_differentiation.h
@@ -204,6 +204,7 @@ public:
   void operator()(tensor_mul const &visitable) override;
   void operator()(simple_outer_product const &visitable) override;
   void operator()(tensor_inv const &visitable) override;
+  void operator()(tensor_eigenprojection const &visitable) override;
   void operator()(inner_product_wrapper const &visitable) override;
   void operator()(permute_indices_wrapper const &visitable) override;
   void operator()(outer_product_wrapper const &visitable) override;

--- a/include/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.h
+++ b/include/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.h
@@ -161,6 +161,7 @@ public:
   void operator()(tensor_mul const &visitable) override;
   void operator()(simple_outer_product const &visitable) override;
   void operator()(tensor_inv const &visitable) override;
+  void operator()(tensor_eigenprojection const &visitable) override;
   void operator()(inner_product_wrapper const &visitable) override;
   void operator()(outer_product_wrapper const &visitable) override;
   void operator()(tensor_to_scalar_with_tensor_mul const &visitable) override;

--- a/include/numsim_cas/tensor/visitors/tensor_evaluator.h
+++ b/include/numsim_cas/tensor/visitors/tensor_evaluator.h
@@ -341,6 +341,15 @@ public:
     proj.evaluate(d, r);
   }
 
+  void operator()(tensor_eigenprojection const &v) override {
+    auto temp = apply(v.expr());
+    const auto dim = v.dim();
+    m_result = make_tensor_data<ValueType>(dim, 2);
+    tensor_data_eigenprojection_wrapper<ValueType> op(*m_result, *temp,
+                                                      v.index());
+    op.evaluate(dim, 2);
+  }
+
   // ─── Cross-domain ────────────────────────────────────────────
 
   // f * A where f is tensor_to_scalar (scalar-valued), A is tensor

--- a/include/numsim_cas/tensor/visitors/tensor_latex_printer.h
+++ b/include/numsim_cas/tensor/visitors/tensor_latex_printer.h
@@ -368,6 +368,12 @@ public:
     m_out << "}^{-1}";
   }
 
+  void operator()(tensor_eigenprojection const &visitable) override {
+    m_out << "\\mathbf{E}_{" << visitable.index() << "}\\left(";
+    apply(visitable.expr(), Precedence::None);
+    m_out << "\\right)";
+  }
+
   void operator()([[maybe_unused]] tensor_zero const &visitable) override {
     m_out << "0";
   }

--- a/include/numsim_cas/tensor/visitors/tensor_printer.h
+++ b/include/numsim_cas/tensor/visitors/tensor_printer.h
@@ -498,6 +498,12 @@ public:
     print_unary("inv", visitable);
   }
 
+  void operator()(tensor_eigenprojection const &visitable) override {
+    m_out << "E_" << visitable.index() << "(";
+    apply(visitable.expr(), Precedence::None);
+    m_out << ")";
+  }
+
   /**
    * @brief Prints a zero tensor.
    *

--- a/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
+++ b/include/numsim_cas/tensor/visitors/tensor_rebuild_visitor.h
@@ -72,6 +72,10 @@ public:
     m_result = inv(apply(v.expr()));
   }
 
+  void operator()(tensor_eigenprojection const &v) override {
+    m_result = eigenprojection(apply(v.expr()), v.index());
+  }
+
   void operator()(permute_indices_wrapper const &v) override {
     m_result =
         make_expression<permute_indices_wrapper>(apply(v.expr()), v.indices());

--- a/include/numsim_cas/tensor/wrappers/tensor_eigenprojection.h
+++ b/include/numsim_cas/tensor/wrappers/tensor_eigenprojection.h
@@ -1,0 +1,65 @@
+#ifndef TENSOR_EIGENPROJECTION_H
+#define TENSOR_EIGENPROJECTION_H
+
+#include <cstddef>
+
+#include <numsim_cas/core/cas_error.h>
+#include <numsim_cas/core/unary_op.h>
+#include <numsim_cas/tensor/tensor_assume.h>
+#include <numsim_cas/tensor/tensor_expression.h>
+
+namespace numsim::cas {
+
+// #226 — the i-th eigenprojection E_i(A) = n_i ⊗ n_i of a symmetric rank-2
+// tensor A, where n_i is the i-th (ascending) eigenvector. A rank-2
+// symmetric tensor, kept opaque at the AST level and materialised at
+// evaluation via tmech's eigenbasis. Unlike raw eigenvectors, E_i is
+// unique (no ± sign freedom), which is exactly what the spectral
+// derivative dλ_i/dA = E_i and isotropic functions f(A) = Σ f(λ_i) E_i
+// (#227) consume. `index` is 0-based into the ascending eigenvalues.
+class tensor_eigenprojection final
+    : public unary_op<tensor_node_base_t<tensor_eigenprojection>> {
+public:
+  using base = unary_op<tensor_node_base_t<tensor_eigenprojection>>;
+
+  template <typename Expr>
+  tensor_eigenprojection(Expr &&_expr, std::size_t index)
+      // Output is always rank 2 (E_i lives in the same space as A), with
+      // the dimension of the input.
+      : base(std::forward<Expr>(_expr), _expr.get().dim(), std::size_t{2}),
+        m_index(index) {
+    if (this->expr().get().rank() != 2)
+      throw invalid_expression_error(
+          "tensor_eigenprojection: input must be a rank-2 tensor");
+    // E_i = n_i ⊗ n_i is symmetric by construction.
+    this->set_space({Symmetric{}, AnyTraceTag{}});
+  }
+
+  tensor_eigenprojection(tensor_eigenprojection const &e)
+      : base(static_cast<base const &>(e)), m_index(e.m_index) {}
+  tensor_eigenprojection(tensor_eigenprojection &&e) noexcept
+      : base(std::move(static_cast<base &&>(e))), m_index(e.m_index) {}
+  tensor_eigenprojection() = delete;
+  ~tensor_eigenprojection() override = default;
+  const tensor_eigenprojection &operator=(tensor_eigenprojection &&) = delete;
+
+  [[nodiscard]] std::size_t index() const noexcept { return m_index; }
+
+protected:
+  // Fold the index in: two eigenprojections of the same tensor differ
+  // only by index (mirrors tensor_to_scalar_eigenvalue).
+  void update_hash_value() const noexcept override {
+    this->m_hash_value = 0;
+    hash_combine(this->m_hash_value, this->get_id());
+    if (this->expr().is_valid())
+      hash_combine(this->m_hash_value, this->expr().get().hash_value());
+    hash_combine(this->m_hash_value, m_index);
+  }
+
+private:
+  std::size_t m_index;
+};
+
+} // namespace numsim::cas
+
+#endif // TENSOR_EIGENPROJECTION_H

--- a/src/numsim_cas/core/contains_expression.cpp
+++ b/src/numsim_cas/core/contains_expression.cpp
@@ -161,6 +161,7 @@ public:
   void operator()(tensor_negative const &v) override { check(v.expr()); }
   void operator()(tensor_pow const &v) override { check(v.expr_lhs()); }
   void operator()(tensor_inv const &v) override { check(v.expr()); }
+  void operator()(tensor_eigenprojection const &v) override { check(v.expr()); }
 
   void operator()(inner_product_wrapper const &v) override {
     check(v.expr_lhs());

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -305,6 +305,17 @@ void tensor_differentiation::operator()(simple_outer_product const &visitable) {
 // space() is cleared but the algebra tag remains. Vol/Dev inputs route
 // through the sym branch too (their space()->perm is Symmetric{}).
 // Closes #250.
+// dE_i/dA is the fourth-order spectral derivative (Miehe/Simo), which
+// needs the full eigenvalue/eigenvector set and the degenerate-eigenvalue
+// limit — deferred to a #226 follow-up. Evaluation of E_i already works,
+// and dλ_i/dA = E_i is handled directly in the eigenvalue diff visitor.
+void tensor_differentiation::operator()(
+    tensor_eigenprojection const & /*visitable*/) {
+  throw not_implemented_error(
+      "tensor_differentiation: d/dA of an eigenprojection (the 4th-order "
+      "spectral derivative) is not yet implemented");
+}
+
 void tensor_differentiation::operator()(tensor_inv const &visitable) {
   auto const &A = visitable.expr();
   auto dA = diff(A, m_arg);

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.cpp
@@ -257,6 +257,15 @@ void tensor_differentiation_wrt_scalar::operator()(
 // std::unreachable()` pins that contract — the trailing
 // `std::unreachable` catches drift if a future wrapper relaxation
 // admits a higher rank without updating this visitor.
+// dE_i/ds needs the 4th-order spectral derivative contracted with dA/ds —
+// deferred to a #226 follow-up alongside dE_i/dA.
+void tensor_differentiation_wrt_scalar::operator()(
+    tensor_eigenprojection const & /*visitable*/) {
+  throw not_implemented_error(
+      "tensor_differentiation_wrt_scalar: d/ds of an eigenprojection is not "
+      "yet implemented");
+}
+
 void tensor_differentiation_wrt_scalar::operator()(
     tensor_inv const &visitable) {
   auto const &A = visitable.expr();

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation.cpp
@@ -261,14 +261,22 @@ void tensor_to_scalar_differentiation::operator()(tensor_det const &visitable) {
       std::move(contracted), m_expr);
 }
 
-// Eigenvalue: d(λ_i(A))/dA = n_i ⊗ n_i (the eigenprojection), which needs
-// symbolic eigenvectors — deferred until the eigenvector node lands (#226
-// follow-up). Evaluation of λ_i itself already works.
+// Eigenvalue: d(λ_i(B))/dX = E_i(B) : dB/dX, where E_i = n_i ⊗ n_i is the
+// eigenprojection (∂λ_i/∂B). Chain rule over the inner tensor B.
 void tensor_to_scalar_differentiation::operator()(
-    tensor_to_scalar_eigenvalue const & /*visitable*/) {
-  throw not_implemented_error(
-      "tensor_to_scalar_differentiation: d/dA of an eigenvalue needs the "
-      "eigenvector node (not yet implemented)");
+    tensor_to_scalar_eigenvalue const &visitable) {
+  auto dB = diff(visitable.expr(), m_arg);
+  if (is_same<tensor_zero>(dB)) {
+    return;
+  }
+  auto Ei = eigenprojection(visitable.expr(), visitable.index());
+  // dB = I{4} (differentiating w.r.t. B itself) ⇒ E_i : I{4} = E_i.
+  if (is_same<identity_tensor>(dB)) {
+    m_result = std::move(Ei);
+    return;
+  }
+  m_result = inner_product(std::move(Ei), sequence{1, 2}, std::move(dB),
+                           sequence{1, 2});
 }
 
 // Inner product to scalar: product rule

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
@@ -272,13 +272,17 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   m_result = m_expr * std::move(contracted);
 }
 
-// λ_i(A): d/ds = n_i ⊗ n_i : dA/ds, needs symbolic eigenvectors — deferred
-// until the eigenvector node lands (#226 follow-up).
+// λ_i(B): d/ds = E_i(B) : dB/ds, where E_i = n_i ⊗ n_i is the
+// eigenprojection (∂λ_i/∂B).
 void tensor_to_scalar_differentiation_wrt_scalar::operator()(
-    tensor_to_scalar_eigenvalue const & /*visitable*/) {
-  throw not_implemented_error(
-      "tensor_to_scalar_differentiation_wrt_scalar: d/ds of an eigenvalue "
-      "needs the eigenvector node (not yet implemented)");
+    tensor_to_scalar_eigenvalue const &visitable) {
+  auto dB = diff(visitable.expr(), m_arg);
+  if (!dB.is_valid() || is_same<tensor_zero>(dB)) {
+    return;
+  }
+  auto Ei = eigenprojection(visitable.expr(), visitable.index());
+  m_result =
+      dot_product(std::move(Ei), sequence{1, 2}, std::move(dB), sequence{1, 2});
 }
 
 // inner_product_to_scalar(A, idxA, B, idxB): product rule, t2s-valued.

--- a/tests/TensorEvaluatorTest.h
+++ b/tests/TensorEvaluatorTest.h
@@ -1156,6 +1156,55 @@ TEST(TensorEval, IfThenElseLazyOnUnselectedBranch) {
   EXPECT_TRUE(tmech::almost_equal(as_tmech<2, 2>(*result2), expected, tol));
 }
 
+// ─── Eigenprojection E_i = n_i ⊗ n_i (#226) ───────────────────────────
+
+TEST(TensorEval, EigenprojectionDiagonal3x3) {
+  // diag(5,3,2): eigenpairs sorted ascending are (2,ẑ),(3,ŷ),(5,x̂), so
+  // E_0 = diag(0,0,1), E_1 = diag(0,1,0), E_2 = diag(1,0,0).
+  tensor_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({5.0, 0.0, 0.0,
+                                   0.0, 3.0, 0.0,
+                                   0.0, 0.0, 2.0}));
+  // clang-format on
+  auto E0 = ev.apply(eigenprojection(A, 0));
+  auto E1 = ev.apply(eigenprojection(A, 1));
+  auto E2 = ev.apply(eigenprojection(A, 2));
+  ASSERT_NE(E0, nullptr);
+  EXPECT_TRUE(tmech::almost_equal(
+      as_tmech<3, 2>(*E0), make_tmech<3, 2>({0, 0, 0, 0, 0, 0, 0, 0, 1}), tol));
+  EXPECT_TRUE(tmech::almost_equal(
+      as_tmech<3, 2>(*E1), make_tmech<3, 2>({0, 0, 0, 0, 1, 0, 0, 0, 0}), tol));
+  EXPECT_TRUE(tmech::almost_equal(
+      as_tmech<3, 2>(*E2), make_tmech<3, 2>({1, 0, 0, 0, 0, 0, 0, 0, 0}), tol));
+}
+
+TEST(TensorEval, EigenprojectionCompletenessAndReconstruction) {
+  // Non-diagonal symmetric A: Σ E_i = I, and A = Σ λ_i E_i (spectral thm).
+  tensor_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  // clang-format off
+  ev.set(A, make_test_data<3, 2>({2.0, 1.0, 0.0,
+                                   1.0, 3.0, 1.0,
+                                   0.0, 1.0, 2.0}));
+  // clang-format on
+  auto E0 = as_tmech<3, 2>(*ev.apply(eigenprojection(A, 0)));
+  auto E1 = as_tmech<3, 2>(*ev.apply(eigenprojection(A, 1)));
+  auto E2 = as_tmech<3, 2>(*ev.apply(eigenprojection(A, 2)));
+
+  auto I = tmech::eval(tmech::eye<double, 3, 2>());
+  EXPECT_TRUE(tmech::almost_equal(tmech::eval(E0 + E1 + E2), I, tol));
+
+  // λ_i = A : E_i (double contraction), so A = Σ λ_i E_i must recover A.
+  auto A_val = make_tmech<3, 2>({2, 1, 0, 1, 3, 1, 0, 1, 2});
+  double l0 = tmech::dcontract(A_val, E0);
+  double l1 = tmech::dcontract(A_val, E1);
+  double l2 = tmech::dcontract(A_val, E2);
+  EXPECT_TRUE(tmech::almost_equal(tmech::eval(l0 * E0 + l1 * E1 + l2 * E2),
+                                  A_val, tol));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSOREVALUATORTEST_H

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -98,6 +98,32 @@ TYPED_TEST(TensorExpressionTest, TensorExpressionTestPrint) {
   EXPECT_PRINT((X * X) * X, "pow(X,3)");
 }
 
+// Eigenprojection E_i(A) = n_i ⊗ n_i (#226).
+TYPED_TEST(TensorExpressionTest, EigenprojectionNode) {
+  auto &X = this->X;
+  constexpr auto Dim = TestFixture::Dim;
+
+  using numsim::cas::eigenprojection;
+  using numsim::cas::is_symmetric;
+
+  // Prints as E_<index>(A).
+  EXPECT_PRINT(eigenprojection(X, 0), "E_0(X)");
+
+  // E_i is a rank-2 symmetric tensor by construction.
+  auto E0 = eigenprojection(X, 0);
+  EXPECT_EQ(E0.get().rank(), std::size_t{2});
+  EXPECT_TRUE(is_symmetric(E0));
+
+  // Same tensor + index → equal hash; index folded in → distinct.
+  EXPECT_EQ(eigenprojection(X, 0).get().hash_value(),
+            eigenprojection(X, 0).get().hash_value());
+  if constexpr (Dim >= 2) {
+    EXPECT_PRINT(eigenprojection(X, 1), "E_1(X)");
+    EXPECT_NE(eigenprojection(X, 0).get().hash_value(),
+              eigenprojection(X, 1).get().hash_value());
+  }
+}
+
 TYPED_TEST(TensorExpressionTest, TensorScalarExpressionTestPrint) {
   auto &X = this->X;
   auto &Y = this->Y;

--- a/tests/TensorToScalarDifferentiationTest.h
+++ b/tests/TensorToScalarDifferentiationTest.h
@@ -53,6 +53,20 @@ TEST_F(TensorToScalarDifferentiationTest, Node_Trace_NonDependencyGivesZero) {
   EXPECT_SAME_PRINT(d, Zero);
 }
 
+// d(λ_i(Y))/d(Y) = E_i(Y) (the eigenprojection). Differentiating w.r.t.
+// Y itself makes dY/dY the 4th-order identity, so E_i : I{4} = E_i.
+TEST_F(TensorToScalarDifferentiationTest, Node_Eigenvalue) {
+  auto d = diff(eigenvalue(Y, 0), Y);
+  EXPECT_TRUE(d.is_valid()) << "Expected valid result for eigenvalue diff";
+  EXPECT_SAME_PRINT(d, eigenprojection(Y, 0));
+}
+
+// d(λ_i(X))/d(Y) = zero (no dependency).
+TEST_F(TensorToScalarDifferentiationTest, Node_Eigenvalue_NonDependencyZero) {
+  auto d = diff(eigenvalue(X, 0), Y);
+  EXPECT_SAME_PRINT(d, Zero);
+}
+
 // d(-tr(Y))/d(Y) should be -I
 TEST_F(TensorToScalarDifferentiationTest, Node_Negative) {
   auto f = -trY;


### PR DESCRIPTION
## Summary

Second PR of the spectral half of #226 (stacked on #322, the eigenvalue node). Adds the **eigenprojection node** `E_i(A) = n_i ⊗ n_i` and uses it to **complete eigenvalue differentiation**.

Per the design choice to build the projection first: `E_i` is the unique rank-2 symmetric tensor `n_i ⊗ n_i` (no ± sign ambiguity, unlike raw eigenvectors), ordered so `E_i` pairs with the eigenvalue node's ascending `λ_i`. It's exactly what both the spectral derivative and #227 isotropic functions consume.

## What's included

- **Node** `tensor_eigenprojection`: `unary_op` over a tensor + 0-based `index` (folded into the hash), symmetric-space annotated. Factory `eigenprojection(A, i)` rejects non-rank-2 input and out-of-range index at construction.
- **Every tensor-domain visitor wired**: text printer (`E_i(A)`), LaTeX (`\mathbf{E}_i(A)`), rebuild/substitution, `contains`, evaluator (tmech eigenbasis, ascending-sorted, dim 2/3).
- **Eigenvalue differentiation now works** (previously threw `not_implemented`):
  - `d(λ_i(B))/dX = E_i(B) : dB/dX`  (tensor→scalar differentiated w.r.t. a tensor)
  - `d(λ_i(B))/ds = E_i(B) : dB/ds`  (differentiated w.r.t. a scalar)

## Deferred (tracked follow-up)

`dE_i/dA` — the 4th-order spectral derivative (Miehe/Simo), which needs the degenerate-eigenvalue limit — throws `not_implemented`. Evaluation of `E_i` works; only its *own* derivative is deferred.

## Tests

- Evaluation: exact `E_i` for a diagonal tensor, completeness `Σ E_i = I`, spectral reconstruction `A = Σ λ_i E_i` (with `λ_i = A : E_i`).
- Symbolic `d(λ_i)/dA = E_i` and non-dependency → 0.
- Printing + hash disambiguation across dims 1/2/3, symmetric annotation, rank-2 output.

All 1583 tests pass locally.

## Stacking

Based on `226-eigenvalue-node` (#322). Retarget to `main` before merge.
