### PR TITLE
Isotropic tensor functions exp/log/sqrt by spectral composition (#227)

### DIFF
--- a/include/numsim_cas/tensor/tensor_isotropic_functions.h
+++ b/include/numsim_cas/tensor/tensor_isotropic_functions.h
@@ -1,0 +1,39 @@
+#ifndef NUMSIM_CAS_TENSOR_ISOTROPIC_FUNCTIONS_H
+#define NUMSIM_CAS_TENSOR_ISOTROPIC_FUNCTIONS_H
+
+#include <numsim_cas/tensor/tensor_expression.h>
+
+namespace numsim::cas {
+
+// Isotropic tensor functions of a symmetric rank-2 tensor A (#227): the
+// scalar function is applied to each eigenvalue and recombined on the
+// eigenprojections,
+//
+//   f(A) = Σ_i f(λ_i) E_i,
+//
+// built purely by composition on the eigen_decomposition facade (#226) —
+// no dedicated AST nodes. Differentiation therefore comes for free from
+// the generic chain rule, and yields the exact Daleckii–Krein tangent.
+//
+// A must be a symmetric rank-2 tensor of dimension 2 or 3 (enforced by
+// eigen_decomposition). These overload the scalar/t2s exp/log/sqrt, which
+// are concept-constrained to their own domains, so a tensor argument
+// dispatches here unambiguously.
+//
+// pow(A, p) is intentionally NOT provided here: pow(tensor, scalar)
+// already means the integer matrix power (tensor_pow). The real-exponent
+// isotropic power needs that overload reconciled first — tracked
+// separately.
+
+[[nodiscard]] expression_holder<tensor_expression>
+exp(expression_holder<tensor_expression> const &A);
+
+[[nodiscard]] expression_holder<tensor_expression>
+log(expression_holder<tensor_expression> const &A);
+
+[[nodiscard]] expression_holder<tensor_expression>
+sqrt(expression_holder<tensor_expression> const &A);
+
+} // namespace numsim::cas
+
+#endif // NUMSIM_CAS_TENSOR_ISOTROPIC_FUNCTIONS_H

--- a/src/numsim_cas/tensor/tensor_isotropic_functions.cpp
+++ b/src/numsim_cas/tensor/tensor_isotropic_functions.cpp
@@ -1,0 +1,49 @@
+#include <numsim_cas/tensor/tensor_isotropic_functions.h>
+
+#include <cstddef>
+
+#include <numsim_cas/eigen_decomposition.h>
+#include <numsim_cas/tensor/tensor_definitions.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h>
+
+namespace numsim::cas {
+
+namespace {
+
+// f(A) = Σ_i f(λ_i) E_i. `scalar_fn` maps the i-th eigenvalue node (a
+// tensor_to_scalar scalar) to f(λ_i); the term f(λ_i)·E_i is a
+// tensor × tensor_to_scalar product (→ tensor), summed over the spectrum.
+template <typename ScalarFn>
+expression_holder<tensor_expression>
+spectral_compose(expression_holder<tensor_expression> const &A,
+                 ScalarFn scalar_fn) {
+  eigen_decomposition eig(A);
+  const std::size_t dim = A.get().dim();
+  expression_holder<tensor_expression> result;
+  for (std::size_t i = 0; i < dim; ++i) {
+    auto term = eig.basis(i) * scalar_fn(eig.value(i));
+    result = result.is_valid() ? result + term : term;
+  }
+  return result;
+}
+
+} // namespace
+
+expression_holder<tensor_expression>
+exp(expression_holder<tensor_expression> const &A) {
+  return spectral_compose(A, [](auto const &lambda) { return exp(lambda); });
+}
+
+expression_holder<tensor_expression>
+log(expression_holder<tensor_expression> const &A) {
+  return spectral_compose(A, [](auto const &lambda) { return log(lambda); });
+}
+
+expression_holder<tensor_expression>
+sqrt(expression_holder<tensor_expression> const &A) {
+  return spectral_compose(A, [](auto const &lambda) { return sqrt(lambda); });
+}
+
+} // namespace numsim::cas

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_numsim_cas_test(numsim_cas_test
     CoreBugFixTest.h
     SolveTest.h
     LeviCivitaTest.h
+    IsotropicTensorFunctionTest.h
     LimitVisitorTest.h
     NumericalDiffHelpers.h
     NumericalDiffTest.h

--- a/tests/IsotropicTensorFunctionTest.h
+++ b/tests/IsotropicTensorFunctionTest.h
@@ -1,0 +1,122 @@
+#ifndef ISOTROPICTENSORFUNCTIONTEST_H
+#define ISOTROPICTENSORFUNCTIONTEST_H
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <numsim_cas/core/diff.h>
+#include <numsim_cas/eigen_decomposition.h>
+#include <numsim_cas/scalar/scalar_all.h>
+#include <numsim_cas/tensor/tensor_definitions.h>
+#include <numsim_cas/tensor/tensor_diff.h>
+#include <numsim_cas/tensor/tensor_functions.h>
+#include <numsim_cas/tensor/tensor_isotropic_functions.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+#include <numsim_cas/tensor/tensor_std.h>
+#include <numsim_cas/tensor/visitors/tensor_evaluator.h>
+
+namespace numsim::cas {
+
+namespace iso_detail {
+
+constexpr double iso_tol = 1e-10;
+
+using T2 = tmech::tensor<double, 3, 2>;
+
+inline std::shared_ptr<tensor_data<double, 3, 2>> data_from(T2 const &t) {
+  auto ptr = std::make_shared<tensor_data<double, 3, 2>>();
+  auto *dst = ptr->raw_data();
+  auto const *src = t.raw_data();
+  for (std::size_t i = 0; i < 9; ++i)
+    dst[i] = src[i];
+  return ptr;
+}
+
+template <std::size_t Dim, std::size_t Rank>
+auto const &as_t(tensor_data_base<double> const &d) {
+  return static_cast<tensor_data<double, Dim, Rank> const &>(d).data();
+}
+
+} // namespace iso_detail
+
+// ─── Value: diagonal is exact ──────────────────────────────────────────
+TEST(IsotropicFn, DiagonalValues) {
+  using namespace iso_detail;
+  tensor_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  T2 A_val;
+  A_val = {4.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 9.0};
+  ev.set(A, data_from(A_val));
+
+  auto s = ev.apply(sqrt(A));
+  EXPECT_TRUE(tmech::almost_equal(
+      as_t<3, 2>(*s), T2{2.0, 0, 0, 0, 1.0, 0, 0, 0, 3.0}, iso_tol));
+
+  auto l = ev.apply(log(A));
+  EXPECT_TRUE(tmech::almost_equal(
+      as_t<3, 2>(*l), T2{std::log(4.0), 0, 0, 0, 0.0, 0, 0, 0, std::log(9.0)},
+      iso_tol));
+
+  auto e = ev.apply(exp(A));
+  EXPECT_TRUE(tmech::almost_equal(
+      as_t<3, 2>(*e),
+      T2{std::exp(4.0), 0, 0, 0, std::exp(1.0), 0, 0, 0, std::exp(9.0)},
+      iso_tol));
+}
+
+// ─── Value: round-trips on a non-diagonal SPD tensor ───────────────────
+TEST(IsotropicFn, RoundTripsNonDiagonal) {
+  using namespace iso_detail;
+  tensor_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  T2 A_val; // SPD, eigenvalues {2, 2.382, 4.618}
+  A_val = {4.0, 1.0, 0.0, 1.0, 3.0, 0.0, 0.0, 0.0, 2.0};
+  ev.set(A, data_from(A_val));
+
+  // exp(log(A)) == A
+  auto explog = ev.apply(exp(log(A)));
+  EXPECT_TRUE(tmech::almost_equal(as_t<3, 2>(*explog), A_val, 1e-9));
+
+  // sqrt(A) * sqrt(A) == A  (matrix product of the isotropic square root)
+  auto S = sqrt(A);
+  auto sq = ev.apply(inner_product(S, sequence{2}, S, sequence{1}));
+  EXPECT_TRUE(tmech::almost_equal(as_t<3, 2>(*sq), A_val, 1e-9));
+}
+
+// ─── Tangent for free: d log(A)/dA matches finite differences ──────────
+TEST(IsotropicFn, LogTangentMatchesFiniteDiff) {
+  using namespace iso_detail;
+  tensor_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  T2 A_val;
+  A_val = {4.0, 1.0, 0.0, 1.0, 3.0, 0.0, 0.0, 0.0, 2.0}; // SPD
+  T2 H;
+  H = {0.1, 0.2, 0.0, 0.2, 0.3, 0.1, 0.0, 0.1, 0.15}; // symmetric direction
+
+  auto dL = diff(log(A), A); // rank-4, produced purely by the generic
+                             // chain rule — no isotropic-function diff code
+  ASSERT_TRUE(dL.is_valid());
+  EXPECT_EQ(dL.get().rank(), std::size_t{4});
+
+  ev.set(A, data_from(A_val));
+  auto D_data = ev.apply(dL);
+  auto const &D = as_t<3, 4>(*D_data);
+  auto analytic = tmech::eval(tmech::dcontract(D, H));
+
+  const double t = 1e-6;
+  ev.set(A, data_from(T2{tmech::eval(A_val + t * H)}));
+  auto Lp_data = ev.apply(log(A));
+  auto const &Lp = as_t<3, 2>(*Lp_data);
+  ev.set(A, data_from(T2{tmech::eval(A_val - t * H)}));
+  auto Lm_data = ev.apply(log(A));
+  auto const &Lm = as_t<3, 2>(*Lm_data);
+  auto fd = tmech::eval((Lp - Lm) / (2.0 * t));
+
+  EXPECT_TRUE(tmech::almost_equal(analytic, fd, 1e-6))
+      << "d log(A)/dA : H disagrees with finite difference";
+}
+
+} // namespace numsim::cas
+
+#endif // ISOTROPICTENSORFUNCTIONTEST_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,4 +1,5 @@
 #include "CoreBugFixTest.h"
+#include "IsotropicTensorFunctionTest.h"
 #include "LeviCivitaTest.h"
 #include "LimitVisitorTest.h"
 #include "NumericalDiffTest.h"


### PR DESCRIPTION
## Summary

Phase 1 of #227: isotropic tensor functions `exp`/`log`/`sqrt` of a symmetric rank-2 tensor, built **by composition** on the `eigen_decomposition` facade (#226):

```cpp
exp(A) = Σ exp(value(i)) · basis(i)
log(A) = Σ log(value(i)) · basis(i)
sqrt(A)= Σ sqrt(value(i))· basis(i)
```

The headline: **no dedicated AST nodes, no visitor wiring, and no isotropic-function differentiation code.** The generic chain/product/sum rules differentiate the composition into the exact Daleckii–Krein tangent for free — the whole feature (value + consistent tangent) is a ~50-line factory.

## Details

- Tensor overloads of `exp`/`log`/`sqrt` are unambiguous with the scalar/t2s versions, which are concept-constrained (`tensor_to_scalar_expr_holder`, etc.) to their own domains.
- `A` must be symmetric rank-2, dim 2/3 (enforced by `eigen_decomposition`).
- `pow(A, p)` is **deferred**: `pow(tensor, scalar)` already means the integer matrix power (`tensor_pow` node). The real-exponent isotropic power needs that overload reconciled — #227 follow-up.

## Tests

- `DiagonalValues` — `sqrt`/`log`/`exp` of a diagonal tensor are exact.
- `RoundTripsNonDiagonal` — `exp(log(A)) == A` and `sqrt(A)² == A` on a non-diagonal SPD tensor.
- `LogTangentMatchesFiniteDiff` — `d log(A)/dA : H` matches a central finite difference. This is the tangent that cost **zero** extra code.

All 1593 tests pass locally.

## Scope / follow-ups

- Correct for **distinct** eigenvalues. The coincident-eigenvalue tangent singularity (`1/(λᵢ−λⱼ)` → `inf−inf`) is tracked in **#326** (safe divided-difference primitive).
- Decompose-once efficiency (each eig node re-decomposes today) is **#325**.
- `pow(A, real)` reconciliation with matrix power — this issue, follow-up.

Builds on the merged #226 stack (#322/#323/#324).
