### PR TITLE
Share one eigendecomposition across value/basis/normal (#325)

### DIFF
--- a/include/numsim_cas/tensor/data/spectral_decomposition_cache.h
+++ b/include/numsim_cas/tensor/data/spectral_decomposition_cache.h
@@ -1,0 +1,84 @@
+#ifndef NUMSIM_CAS_SPECTRAL_DECOMPOSITION_CACHE_H
+#define NUMSIM_CAS_SPECTRAL_DECOMPOSITION_CACHE_H
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "tensor_data.h"
+
+namespace numsim::cas::spectral {
+
+// Ascending-sorted eigenvalues and matching eigenvectors of a symmetric
+// rank-2 tensor. Populated once per distinct input and shared by the
+// eigenvalue / eigenprojection / eigenvector wrappers (#325).
+template <typename ValueType, std::size_t Dim> struct decomposition {
+  std::array<ValueType, Dim> eigenvalues{};
+  std::array<tmech::tensor<ValueType, Dim, 1>, Dim> eigenvectors{};
+};
+
+namespace detail {
+
+// FNV-1a over the tensor's raw components — a content key so the same
+// numeric tensor reuses its decomposition regardless of which node
+// requested it.
+template <typename ValueType, std::size_t Dim>
+inline std::size_t content_hash(tmech::tensor<ValueType, Dim, 2> const &t) {
+  auto const *data = t.raw_data();
+  std::uint64_t h = 1469598103934665603ULL;
+  for (std::size_t i = 0; i < Dim * Dim; ++i) {
+    std::uint64_t bits = 0;
+    std::memcpy(&bits, &data[i],
+                sizeof(ValueType) <= sizeof(bits) ? sizeof(ValueType)
+                                                  : sizeof(bits));
+    h ^= bits;
+    h *= 1099511628211ULL;
+  }
+  return static_cast<std::size_t>(h);
+}
+
+} // namespace detail
+
+// Eigendecomposition of sym(A), ascending, cached by content. A single-entry
+// thread-local cache (one per ValueType/Dim) — it collapses the repeated
+// decomposition of the *same* tensor that value(i)/basis(i)/normal(i)
+// otherwise trigger (a spectral stress decomposed A once per spectral
+// quantity before this). Correct by construction: the key is the tensor's
+// contents, so a hit returns the decomposition of exactly that tensor; a
+// changed tensor misses and recomputes. Interleaving two different tensors
+// simply thrashes the single slot — never wrong, only unshared.
+template <typename ValueType, std::size_t Dim>
+decomposition<ValueType, Dim> const &
+cached_decompose(tmech::tensor<ValueType, Dim, 2> const &in) {
+  static thread_local decomposition<ValueType, Dim> cache;
+  static thread_local std::size_t cached_key = 0;
+  static thread_local bool cached_valid = false;
+
+  const std::size_t key = detail::content_hash(in);
+  if (cached_valid && cached_key == key)
+    return cache;
+
+  auto decomp = tmech::eigen_decomposition(tmech::sym(in));
+  auto const [eigvals, eigvecs] = decomp.decompose();
+
+  std::array<std::size_t, Dim> order{};
+  for (std::size_t i = 0; i < Dim; ++i)
+    order[i] = i;
+  std::sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) {
+    return eigvals[a] < eigvals[b];
+  });
+
+  for (std::size_t i = 0; i < Dim; ++i) {
+    cache.eigenvalues[i] = eigvals[order[i]];
+    cache.eigenvectors[i] = eigvecs[order[i]];
+  }
+  cached_key = key;
+  cached_valid = true;
+  return cache;
+}
+
+} // namespace numsim::cas::spectral
+
+#endif // NUMSIM_CAS_SPECTRAL_DECOMPOSITION_CACHE_H

--- a/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
@@ -1,6 +1,7 @@
 #ifndef TENSOR_DATA_TO_SCALAR_WRAPPER_H
 #define TENSOR_DATA_TO_SCALAR_WRAPPER_H
 
+#include "spectral_decomposition_cache.h"
 #include "tensor_data.h"
 #include <numsim_cas/core/cas_error.h>
 
@@ -107,14 +108,8 @@ public:
             "tensor_data_eigenvalue_wrapper: eigenvalue index out of range");
       using Tensor = tensor_data<ValueType, Dim, Rank>;
       auto const &in = static_cast<const Tensor &>(m_input).data();
-      auto decomp = tmech::eigen_decomposition(tmech::sym(in));
-      decomp.decompose();
-      auto const values = decomp.eigenvalues();
-      std::array<ValueType, Dim> sorted{};
-      for (std::size_t i{0}; i < Dim; ++i)
-        sorted[i] = values[i];
-      std::sort(sorted.begin(), sorted.end());
-      return sorted[m_index];
+      return spectral::cached_decompose<ValueType, Dim>(in)
+          .eigenvalues[m_index];
     } else {
       throw evaluation_error("tensor_data_eigenvalue_wrapper: requires a "
                              "rank-2 tensor of dim 2 or 3");

--- a/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_unary_wrapper.h
@@ -1,6 +1,7 @@
 #ifndef TENSOR_DATA_UNARY_WRAPPER_H
 #define TENSOR_DATA_UNARY_WRAPPER_H
 
+#include "spectral_decomposition_cache.h"
 #include "tensor_data.h"
 #include <numsim_cas/core/cas_error.h>
 
@@ -69,17 +70,8 @@ public:
             "tensor_data_eigenprojection_wrapper: index out of range");
       using Tensor = tensor_data<ValueType, Dim, Rank>;
       auto const &in = static_cast<const Tensor &>(m_input).data();
-      auto decomp = tmech::eigen_decomposition(tmech::sym(in));
-      auto const [eigvals, eigvecs] = decomp.decompose();
-      // Sort eigenpair indices by eigenvalue ascending so this E_index
-      // corresponds to the eigenvalue node's λ_index.
-      std::array<std::size_t, Dim> order{};
-      for (std::size_t i{0}; i < Dim; ++i)
-        order[i] = i;
-      std::sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) {
-        return eigvals[a] < eigvals[b];
-      });
-      auto const &n = eigvecs[order[m_index]];
+      auto const &n =
+          spectral::cached_decompose<ValueType, Dim>(in).eigenvectors[m_index];
       static_cast<Tensor &>(m_result).data() = tmech::otimes(n, n);
     } else {
       throw evaluation_error("tensor_data_eigenprojection_wrapper: requires a "
@@ -126,15 +118,8 @@ public:
       using InTensor = tensor_data<ValueType, Dim, 2>;
       using OutTensor = tensor_data<ValueType, Dim, 1>;
       auto const &in = static_cast<const InTensor &>(m_input).data();
-      auto decomp = tmech::eigen_decomposition(tmech::sym(in));
-      auto const [eigvals, eigvecs] = decomp.decompose();
-      std::array<std::size_t, Dim> order{};
-      for (std::size_t i{0}; i < Dim; ++i)
-        order[i] = i;
-      std::sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) {
-        return eigvals[a] < eigvals[b];
-      });
-      static_cast<OutTensor &>(m_result).data() = eigvecs[order[m_index]];
+      static_cast<OutTensor &>(m_result).data() =
+          spectral::cached_decompose<ValueType, Dim>(in).eigenvectors[m_index];
     } else {
       throw evaluation_error("tensor_data_eigenvector_wrapper: requires a "
                              "rank-2 input of dim 2 or 3");

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -447,6 +447,39 @@ TEST(T2sEval, EigenvalueIndexOutOfRangeThrows) {
   EXPECT_THROW((void)eigen_decomposition(A).value(3), invalid_expression_error);
 }
 
+// The shared decomposition cache (#325) is content-keyed: changing the
+// tensor's value between evaluations must invalidate it (no stale result).
+TEST(T2sEval, SpectralCacheNoStaleAcrossValues) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  eigen_decomposition eig(A);
+
+  ev.set(A, make_test_data<3, 2>({4, 0, 0, 0, 1, 0, 0, 0, 9}));
+  EXPECT_NEAR(ev.apply(eig.value(0)), 1.0, t2s_tol); // smallest of {4,1,9}
+
+  ev.set(A, make_test_data<3, 2>({2, 0, 0, 0, 2, 0, 0, 0, 5})); // changed
+  EXPECT_NEAR(ev.apply(eig.value(0)), 2.0, t2s_tol); // smallest of {2,2,5}
+  EXPECT_NEAR(ev.apply(eig.value(2)), 5.0, t2s_tol);
+}
+
+// Interleaving two different tensors thrashes the single-entry cache but
+// must stay correct — each read decomposes the tensor it was given.
+TEST(T2sEval, SpectralCacheInterleavedTensors) {
+  tensor_to_scalar_evaluator<double> ev;
+  auto A = make_expression<tensor>("A", 3, 2);
+  auto B = make_expression<tensor>("B", 3, 2);
+  ev.set(A, make_test_data<3, 2>({4, 0, 0, 0, 1, 0, 0, 0, 9})); // {1,4,9}
+  ev.set(B, make_test_data<3, 2>({6, 0, 0, 0, 3, 0, 0, 0, 2})); // {2,3,6}
+  eigen_decomposition eigA(A);
+  eigen_decomposition eigB(B);
+  for (int rep = 0; rep < 3; ++rep) {
+    EXPECT_NEAR(ev.apply(eigA.value(0)), 1.0, t2s_tol);
+    EXPECT_NEAR(ev.apply(eigB.value(0)), 2.0, t2s_tol);
+    EXPECT_NEAR(ev.apply(eigA.value(2)), 9.0, t2s_tol);
+    EXPECT_NEAR(ev.apply(eigB.value(2)), 6.0, t2s_tol);
+  }
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORTOSCALAREVALUATORTEST_H


### PR DESCRIPTION
## Summary

Closes #325. The eigenvalue / eigenprojection / eigenvector evaluators each called `tmech::eigen_decomposition(sym(A))` independently, so evaluating several spectral quantities of the same `A` re-decomposed it once per node — a spectral stress `Σ ψ'(λᵢ) Eᵢ` decomposed `A` ~6×.

The evaluators can't share via a member cache: `tensor_evaluator::operator()(tensor_to_scalar_with_tensor_mul)` spins up a **fresh** `tensor_to_scalar_evaluator` per node, so the t2s eigenvalues and the tensor eigenprojections live in different evaluator instances.

## Approach

A content-keyed, single-entry, **thread-local** decomposition cache (`spectral::cached_decompose`, one instantiation per `ValueType`/`Dim`). All three wrappers route through it.

- **Shared across the fresh sub-evaluators** because it's thread-local (process/thread-wide), not tied to an evaluator instance.
- **Correct by construction** — the key is the tensor's raw contents (FNV-1a over the components): the same numeric tensor reuses its decomposition; a changed tensor misses and recomputes; interleaving two tensors thrashes the single slot but is never wrong.
- Also centralises the ascending eigenvalue sort that was duplicated in all three wrappers.

## Tests

- `SpectralCacheNoStaleAcrossValues` — changing `A`'s value between evaluations invalidates the cache (no stale result).
- `SpectralCacheInterleavedTensors` — interleaving two tensors stays correct despite single-slot thrash.
- The existing 55 spectral tests pass unchanged (correctness-preserving refactor). 1592 total.

## Notes / follow-ups

- Single-entry is deliberate (O(1) memory, catches the dominant single-tensor case). A small N-entry LRU would help expressions that interleave several distinct tensors' spectra — easy extension if profiling wants it.
- This is the interpreter-side "decompose once". The codegen-side sharing (lower eig nodes to reads of one `hash(A)`-keyed decompose) is tracked in numsim-codegen #105.

Independent of the #227 isotropic-functions work (branches off `main`).
