### PR TITLE
Bump tmech pin to v1.1.1 (fix inner_product lazy-operand zeroing)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,23 @@ set(INSTALL_GTEST OFF CACHE BOOL "Install GoogleTest" FORCE)
 # install to leak into the build.
 #
 # Bump GIT_TAG as a separate maintenance PR.
+# v1.1.1 (d7e27f3): includes tmech #29 "Fix inner_product returning zeros for a
+# lazy operand needing a basis change" — the prior pin (d03f2c2) silently
+# produced a zero rank-4 for a lazy operand feeding inner_product, which surfaced
+# as half-correct finite-strain tangents (∂(FᵀF)/∂F) downstream in numsim-codegen.
 set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+# v1.1.1 renamed these toggles to the TMECH_-prefixed form (was bare
+# BUILD_TESTS/BUILD_EXAMPLES). Set BOTH so tmech's tests/examples stay off across
+# the bump — otherwise tmech's own examples build, and `examples/symdiff/
+# system_nonlinear_equations` ICEs g++-14 in general_lu_decomposition.
+set(TMECH_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(TMECH_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(TMECH_BUILD_BENCHMARK OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   tmech
   GIT_REPOSITORY https://github.com/petlenz/tmech.git
-  GIT_TAG d03f2c2
+  GIT_TAG d7e27f30807fbd54dd7a0a0b1665a46da28d1681 # v1.1.1
 )
 FetchContent_MakeAvailable(tmech)
 # Restore so our own tests/examples are not affected.


### PR DESCRIPTION
## What

Bump the pinned tmech from `d03f2c2` to **v1.1.1** (`d7e27f3`).

v1.1.1 includes tmech PR #29 (`791c460`) — *"Fix inner_product returning zeros
for a lazy operand needing a basis change."* Before it, `tmech::inner_product`
silently produced a **zero rank-4** whenever its rank-4 operand was a *lazy*
expression template needing an internal basis change — e.g. the `otimesu(eye,eye)`
identity that `cas::diff` emits for `d(leaf)/d(leaf)`. cas's own evaluator uses
materialised buffers so it was never affected, but the bug surfaced **downstream
in numsim-codegen** as half-correct finite-strain tangents (`∂(FᵀF)/∂F` came out
`dFᵀF` alone — exactly half). This is the "separate maintenance PR" the pin
comment anticipates.

## The one gotcha (and why the extra `set()` lines)

v1.1.1 renamed tmech's CMake toggles to the `TMECH_`-prefixed form
(`TMECH_BUILD_TESTS` / `TMECH_BUILD_EXAMPLES`, was bare `BUILD_*`). Without
setting the new names, tmech's own examples build, and
`examples/symdiff/system_nonlinear_equations` **ICEs g++-14** in
`general_lu_decomposition`. This PR sets both the old and new toggles so tmech's
tests/examples stay off across the bump. The cas library itself is unaffected on
g++-14.

## Verification

`g++-14`, `NUMSIM_CAS_BUILD_TESTS=ON`: configures (`Building tmech v1.1.1`),
builds clean, **2228/2228 tests pass**.
