### PR TITLE
Remove stale TODO(#268): pow-of-pow double-negative already folds

### DIFF
--- a/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_simplifier_pow.h
@@ -50,7 +50,8 @@ public:
   pow_pow(expr_holder_t lhs, expr_holder_t rhs);
 
   /// pow(pow(x,a),b) --> pow(x,a*b)
-  /// TODO(#268): pow(pow(x,-a), -b) --> pow(x,a*b) only when x,a,b>0
+  /// (The double-negative case pow(pow(x,-a),-b) = pow(x,ab) is covered by
+  /// the a*b exponent multiply above; closed #268.)
   template <typename Expr> expr_holder_t dispatch(Expr const &);
 
   expr_holder_t dispatch(scalar_negative const &rhs);

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -13,7 +13,8 @@ pow_pow::pow_pow(expr_holder_t lhs, expr_holder_t rhs)
       m_lhs_node{base::m_lhs.template get<scalar_pow>()} {}
 
 /// pow(pow(x,a),b) --> pow(x,a*b)
-/// TODO(#268): pow(pow(x,-a), -b) --> pow(x,a*b) only when x,a,b>0
+/// (The double-negative case pow(pow(x,-a),-b) = pow(x,ab) is covered by
+/// the a*b exponent multiply above; closed #268.)
 template <typename Expr>
 pow_pow::expr_holder_t pow_pow::dispatch(Expr const &) {
   return pow(m_lhs_node.expr_lhs(), m_lhs_node.expr_rhs() * m_rhs);


### PR DESCRIPTION
Comment-only cleanup surfaced by the simplifier-issue review.

The `TODO(#268)` in `scalar_simplifier_pow` proposed folding `pow(pow(x,-a),-b) → pow(x,a*b)` *behind a positivity gate*. But the general `pow(pow(x,a),b) → pow(x, a*b)` rule already multiplies exponents **unconditionally** (`scalar_simplifier_pow.cpp:19,23`), so `(-a)(-b)=ab` already fires — and it's test-locked on an unassumed base at `ScalarExpressionTest.h:161-163` (incl. `pow(pow(y,-2),-2) → pow(y,4)`). The proposed gate is unnecessary (real-valued design, no branch cuts) and would *regress* those tests.

Replaces the misleading TODO with an accurate note. No behavior change.

Closes #268.