### PR TITLE
Review-surfaced tidy-ups: delete dead copy_expression, re-enable passing tests

### DIFF
--- a/include/numsim_cas/basic_functions.h
+++ b/include/numsim_cas/basic_functions.h
@@ -56,25 +56,6 @@ template <typename T, typename... Args>
       std::make_shared<T>(std::forward<Args>(args)...));
 }
 
-template <typename T, typename Expr>
-[[nodiscard]] auto copy_expression(expression_holder<Expr> const &expr) {
-  using ExprType = typename get_type_t<T>::expr_type;
-  using variant = typename expression_holder_data_type<ExprType, T>::data_type;
-  using variant_traits = variant_index<0, T, variant>;
-
-  if constexpr (variant_traits::value) {
-    return expression_holder<ExprType>(std::make_shared<variant>(
-        std::in_place_index<variant_traits::index>, expr.template get<T>()));
-  } else {
-    static_assert(!variant_traits::value, "Type not included in variant");
-  }
-}
-
-template <typename T, typename Expr>
-[[nodiscard]] auto copy_expression(expression_holder<Expr> &&expr) {
-  return std::move(expr);
-}
-
 template <typename... Args> auto make_scalar_variable(Args &&...args) {
   return std::make_tuple(make_expression<scalar>(std::forward<Args>(args))...);
 }

--- a/include/numsim_cas/numsim_cas_type_traits.h
+++ b/include/numsim_cas/numsim_cas_type_traits.h
@@ -127,12 +127,6 @@ class tensor_to_scalar_one;
 class tensor_to_scalar_log;
 class tensor_to_scalar_scalar_wrapper;
 
-template <typename ExprBase, typename T> struct expression_holder_data_type {
-  using data_type = ExprBase;
-};
-
-template <typename ExprBase, typename T> struct expression_holder_data_type;
-
 template <typename T> struct get_type<std::shared_ptr<T>> {
   using type = T;
 };
@@ -142,47 +136,6 @@ template <typename T> struct get_type<expression_holder<T>> {
 
 template <typename T>
 using get_type_t = typename get_type<std::remove_cvref_t<T>>::type;
-
-template <typename T>
-concept has_variant_type = requires { typename T::variant_type; };
-template <typename T>
-concept is_variant_type_index = requires { typename T::type; };
-
-template <typename T, typename Variant> struct variant_index_inner;
-
-template <typename T, typename... Types>
-struct variant_index_inner<T, std::variant<T, Types...>>
-    : std::integral_constant<std::size_t, 0> {};
-
-template <typename T, typename U, typename... Types>
-struct variant_index_inner<T, std::variant<U, Types...>>
-    : std::integral_constant<
-          std::size_t,
-          1 + variant_index_inner<T, std::variant<Types...>>::value> {};
-
-template <typename T, typename Variant> struct variant_index_outer;
-
-template <typename T, typename... SubVariants>
-struct variant_index_outer<T, std::variant<SubVariants...>> {
-private:
-  template <std::size_t Index, typename... Rest> struct helper;
-
-  template <std::size_t Index, typename First, typename... Rest>
-  struct helper<Index, First, Rest...> {
-    static constexpr bool found =
-        variant_index_inner<T, typename First::variant_type>::value <
-        std::variant_size<typename First::variant_type>::value;
-    static constexpr std::size_t value =
-        found ? Index : helper<Index + 1, Rest...>::value;
-  };
-
-  template <std::size_t Index> struct helper<Index> {
-    static constexpr std::size_t value = static_cast<std::size_t>(-1);
-  };
-
-public:
-  static constexpr std::size_t value = helper<0, SubVariants...>::value;
-};
 
 template <std::size_t Index, typename T, typename Variant> struct variant_index;
 

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -280,8 +280,8 @@ TYPED_TEST(TensorExpressionTest, TensorProductOrderAndPowersMore) {
   EXPECT_PRINT(x * y * X * Y, "x*y*X*Y");
   EXPECT_PRINT(y * x * X * Y, "x*y*X*Y");
 
-  // EXPECT_PRINT(pow(X, 2) * pow(X, 2), "pow(X,4)");
-  // EXPECT_PRINT(pow(X, 2) * X * Y, "pow(X,3)*Y");
+  EXPECT_PRINT(pow(X, 2) * pow(X, 2), "pow(X,4)");
+  EXPECT_PRINT(pow(X, 2) * X * Y, "pow(X,3)*Y");
 }
 
 TYPED_TEST(TensorExpressionTest, TensorDivisionFormattingMore) {


### PR DESCRIPTION
Two small cleanups surfaced while triaging the simplifier/architecture issues.

**Delete dead `copy_expression`** — it has zero call sites and targets the pre-`move_to_virtual` variant-based holder model (`expression_holder` now stores `shared_ptr<node_type>`, not a variant), so it wouldn't compile if instantiated. Its only-consumer traits (`expression_holder_data_type`, `variant_index_inner/outer`, and the `has_variant_type`/`is_variant_type_index` concepts) are now orphaned and removed as well. `variant_index` is **kept** — it still has live users.

**Re-enable two commented-out assertions** in `TensorExpressionTest.TensorProductOrderAndPowersMore` (`pow(X,2)*pow(X,2) → pow(X,4)`, `pow(X,2)*X*Y → pow(X,3)*Y`). They were disabled before the tensor mul×pow merge landed; both pass now.

No behavior change. 1603 tests pass.