### PR TITLE
Fix #269: chirality-aware det(orthogonal) — proper +1, improper -1, bare no-fold

### DIFF
--- a/include/numsim_cas/core/assumptions.h
+++ b/include/numsim_cas/core/assumptions.h
@@ -42,9 +42,11 @@ struct unkown {};
 // Properties of a tensor's VALUES (not projector-space classifications):
 // rotations, definiteness. Stored separately from the projector-space
 // tracking on tensor_expression — see tensor_algebra_assumption_manager.
-struct orthogonal {};            // R^T R = I
+struct orthogonal {};            // R^T R = I (chirality unspecified: det = ±1)
 struct positive_definite {};     // x^T A x > 0 for all x != 0
 struct positive_semidefinite {}; // x^T A x >= 0
+struct proper_rotation {};       // orthogonal with det = +1 (a rotation)
+struct improper_rotation {};     // orthogonal with det = -1 (a reflection)
 
 // A unified “assumption” sum type for numbers
 using numeric_assumption =
@@ -53,7 +55,8 @@ using numeric_assumption =
 
 // A unified “assumption” sum type for tensor algebra properties.
 using tensor_algebra_assumption =
-    std::variant<orthogonal, positive_definite, positive_semidefinite>;
+    std::variant<orthogonal, positive_definite, positive_semidefinite,
+                 proper_rotation, improper_rotation>;
 
 // // A unified “assumption” sum type for tensor space
 // using tensor_space =

--- a/include/numsim_cas/tensor/tensor_assume.h
+++ b/include/numsim_cas/tensor/tensor_assume.h
@@ -115,6 +115,21 @@ assume_orthogonal(expression_holder<tensor_expression> const &expr) {
   expr.data()->tensor_algebra_assumptions().insert(orthogonal{});
 }
 
+// A proper rotation (det = +1) — orthogonal with a chirality commitment (#269).
+inline void
+assume_proper_rotation(expression_holder<tensor_expression> const &expr) {
+  detail::require_symbol(expr.get(), "assume_proper_rotation");
+  expr.data()->tensor_algebra_assumptions().insert(proper_rotation{});
+}
+
+// An improper rotation / reflection (det = -1) — orthogonal with the opposite
+// chirality (#269).
+inline void
+assume_improper_rotation(expression_holder<tensor_expression> const &expr) {
+  detail::require_symbol(expr.get(), "assume_improper_rotation");
+  expr.data()->tensor_algebra_assumptions().insert(improper_rotation{});
+}
+
 [[deprecated("use expression_holder<tensor_expression>::assumption() instead")]]
 inline void
 assume_positive_definite(expression_holder<tensor_expression> const &expr) {
@@ -235,8 +250,25 @@ inline bool is_minor_major(expression_holder<tensor_expression> const &expr) {
 // Auto-implication (PD => PSD) is already baked into the set by
 // assume_positive_definite() — no special-case logic needed here.
 
+// True for any orthogonal-family annotation: a bare `orthogonal` (chirality
+// unspecified) OR a proper/improper rotation (both satisfy RᵀR = I). This is
+// what chirality-agnostic folds like inv(R) → trans(R) key on (#269).
 inline bool is_orthogonal(expression_holder<tensor_expression> const &expr) {
-  return expr.get().tensor_algebra_assumptions().contains(orthogonal{});
+  auto const &a = expr.get().tensor_algebra_assumptions();
+  return a.contains(orthogonal{}) || a.contains(proper_rotation{}) ||
+         a.contains(improper_rotation{});
+}
+
+// Chirality-specific predicates (#269). A tensor is a proper rotation iff it
+// was annotated as such; likewise improper. Bare `orthogonal` is neither.
+inline bool
+is_proper_rotation(expression_holder<tensor_expression> const &expr) {
+  return expr.get().tensor_algebra_assumptions().contains(proper_rotation{});
+}
+
+inline bool
+is_improper_rotation(expression_holder<tensor_expression> const &expr) {
+  return expr.get().tensor_algebra_assumptions().contains(improper_rotation{});
 }
 
 inline bool

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -101,15 +101,17 @@ det(expression_holder<tensor_expression> const &expr) {
   if (is_same<identity_tensor>(expr))
     return make_expression<tensor_to_scalar_one>();
 
-  // det(orthogonal R) = +1 for proper rotations. The "orthogonal"
-  // annotation in this codebase doesn't distinguish proper rotations
-  // (det = +1) from improper ones / reflections (det = -1); the
-  // common continuum-mechanics use case is proper rotation so we
-  // default to +1. TODO(#269): a `chirality` sub-tag could refine this
-  // for callers working with reflections / improper rotations.
-  // Closes one half of #246.
-  if (is_orthogonal(expr))
+  // det of an orthogonal tensor is ±1, resolved by chirality (#269):
+  //   proper rotation   → +1
+  //   improper rotation → -1  (reflection)
+  //   bare `orthogonal`  → NO fold — det could be either sign, so folding to
+  //                        +1 would be silently wrong for a reflection.
+  // (proper/improper still imply orthogonal, so inv(R) → trans(R) is
+  //  unaffected.) Closes one half of #246.
+  if (is_proper_rotation(expr))
     return make_expression<tensor_to_scalar_one>();
+  if (is_improper_rotation(expr))
+    return -make_expression<tensor_to_scalar_one>();
 
   // det(inv(A)) = 1/det(A). Routes through the t2s div operator which
   // composes via pow(rhs, -1) — produces canonical pow(det(A), -1).

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -246,15 +246,50 @@ TEST(TensorAlgebraFold, InvUnannotatedDoesNotFireFold) {
       << "inv(unannotated rank-2) should build tensor_inv as before";
 }
 
-TEST(TensorAlgebraFold, DetOrthogonalFoldsToOne) {
-  // det(R) = 1 for proper rotations (the dominant continuum-mechanics
-  // case). The annotation doesn't distinguish improper rotations (det =
-  // -1); TODO(#269) a chirality sub-tag could refine this.
+TEST(TensorAlgebraFold, DetProperRotationFoldsToOne) {
+  // det(R) = +1 for a proper rotation (#269).
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_proper_rotation(R);
+  auto d = det(R);
+  EXPECT_TRUE(is_same<tensor_to_scalar_one>(d))
+      << "det(proper rotation) should fold to tensor_to_scalar_one";
+}
+
+TEST(TensorAlgebraFold, DetImproperRotationFoldsToNegOne) {
+  // det(R) = -1 for an improper rotation / reflection (#269).
+  auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
+  assume_improper_rotation(R);
+  auto d = det(R);
+  auto neg_one = -make_expression<tensor_to_scalar_one>();
+  EXPECT_EQ(d.get().hash_value(), neg_one.get().hash_value())
+      << "det(improper rotation) should fold to -1";
+  EXPECT_FALSE(is_same<tensor_det>(d));
+}
+
+TEST(TensorAlgebraFold, DetBareOrthogonalDoesNotFold) {
+  // A bare `orthogonal` annotation leaves chirality unspecified, so det is
+  // ±1 and MUST NOT fold — folding to +1 would be silently wrong for a
+  // reflection (#269).
   auto R = std::get<0>(make_tensor_variable(std::tuple{"R", 3, 2}));
   assume_orthogonal(R);
   auto d = det(R);
-  EXPECT_TRUE(is_same<tensor_to_scalar_one>(d))
-      << "det(orthogonal) should fold to tensor_to_scalar_one";
+  EXPECT_TRUE(is_same<tensor_det>(d))
+      << "det(bare orthogonal) must not fold — chirality unknown";
+}
+
+TEST(TensorAlgebraFold, RotationChiralityImpliesOrthogonal) {
+  // proper/improper both satisfy RᵀR = I, so is_orthogonal (which chirality-
+  // agnostic folds like inv(R) → trans(R) key on) is true for both (#269).
+  auto P = std::get<0>(make_tensor_variable(std::tuple{"P", 3, 2}));
+  auto I = std::get<0>(make_tensor_variable(std::tuple{"Im", 3, 2}));
+  assume_proper_rotation(P);
+  assume_improper_rotation(I);
+  EXPECT_TRUE(is_orthogonal(P));
+  EXPECT_TRUE(is_orthogonal(I));
+  EXPECT_TRUE(is_proper_rotation(P));
+  EXPECT_FALSE(is_proper_rotation(I));
+  EXPECT_TRUE(is_improper_rotation(I));
+  EXPECT_FALSE(is_improper_rotation(P));
 }
 
 TEST(TensorAlgebraFold, DetUnannotatedDoesNotFireFold) {


### PR DESCRIPTION
`det(orthogonal R)` folded unconditionally to `+1`, which is **silently wrong for improper rotations / reflections** (`det = -1`). This teaches the assumption system to distinguish chirality.

## Changes
- New assumption tags `proper_rotation` / `improper_rotation` (siblings of `orthogonal` in the `tensor_algebra_assumption` variant), with `assume_proper_rotation` / `assume_improper_rotation` and `is_proper_rotation` / `is_improper_rotation` helpers.
- `is_orthogonal` now returns true for `orthogonal` **or** `proper_rotation` **or** `improper_rotation` (proper/improper both satisfy `RᵀR = I`), so chirality-agnostic folds like `inv(R) → trans(R)` are unaffected.
- `det` gate: proper → `+1`, improper → `-1`, **bare `orthogonal` → no fold** (chirality unknown ⇒ sign unknown; folding to `+1` was the original silent error).

## Tests
Split `DetOrthogonalFoldsToOne` into `DetProperRotationFoldsToOne`, `DetImproperRotationFoldsToNegOne`, `DetBareOrthogonalDoesNotFold`, plus `RotationChiralityImpliesOrthogonal` (predicates + that both still count as orthogonal for the inv-fold). 1606 tests pass; no existing test regressed.

Closes #269.