### PR TITLE
#262 Layer A: is_constant_one / is_constant_zero de-dup constant recognition

### DIFF
--- a/include/numsim_cas/scalar/scalar_constant_recognition.h
+++ b/include/numsim_cas/scalar/scalar_constant_recognition.h
@@ -1,0 +1,37 @@
+#ifndef NUMSIM_CAS_SCALAR_CONSTANT_RECOGNITION_H
+#define NUMSIM_CAS_SCALAR_CONSTANT_RECOGNITION_H
+
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/core/scalar_number.h>
+#include <numsim_cas/scalar/scalar_constant.h>
+#include <numsim_cas/scalar/scalar_one.h>
+#include <numsim_cas/scalar/scalar_zero.h>
+
+namespace numsim::cas {
+
+// Numeric-constant recognition (#262, Layer A). Is `e` numerically exactly
+// 1 / 0 in either representable form — the scalar_one/scalar_zero singleton, or
+// a scalar_constant carrying that value? These replace the hand-spelled idiom
+//   is_same<scalar_one>(e) || (is_same<scalar_constant>(e) && value() == 1)
+// duplicated across the scalar/tensor construction-time simplifiers. Exact
+// match to the checks they replace (no negation unwrap — same behavior as
+// before). Kept in this leaf header (constant nodes only) so consumers avoid
+// the scalar_std ↔ scalar_domain_traits include cycle that delegating to
+// domain_traits::try_numeric would introduce.
+[[nodiscard]] inline bool
+is_constant_one(expression_holder<scalar_expression> const &e) {
+  return is_same<scalar_one>(e) ||
+         (is_same<scalar_constant>(e) &&
+          e.get<scalar_constant>().value() == scalar_number{1});
+}
+
+[[nodiscard]] inline bool
+is_constant_zero(expression_holder<scalar_expression> const &e) {
+  return is_same<scalar_zero>(e) ||
+         (is_same<scalar_constant>(e) &&
+          e.get<scalar_constant>().value() == scalar_number{0});
+}
+
+} // namespace numsim::cas
+
+#endif // NUMSIM_CAS_SCALAR_CONSTANT_RECOGNITION_H

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -14,6 +14,7 @@
 #include <numsim_cas/scalar/scalar_atan.h>
 #include <numsim_cas/scalar/scalar_binary_simplify_fwd.h>
 #include <numsim_cas/scalar/scalar_constant.h>
+#include <numsim_cas/scalar/scalar_constant_recognition.h>
 #include <numsim_cas/scalar/scalar_cos.h>
 #include <numsim_cas/scalar/scalar_eq.h>
 #include <numsim_cas/scalar/scalar_exp.h>
@@ -75,22 +76,15 @@ template <scalar_expr_holder L, scalar_expr_holder R>
   assert(expr_rhs.is_valid());
   assert(expr_lhs.is_valid());
 
-  if (is_same<scalar_one>(expr_lhs) ||
-      (is_same<scalar_constant>(expr_lhs) &&
-       expr_lhs.template get<scalar_constant>().value() == 1)) {
+  if (is_constant_one(expr_lhs)) {
     return get_scalar_one();
   }
 
   if (is_same<scalar_zero>(expr_rhs))
     return get_scalar_one();
 
-  if (is_same<scalar_one>(expr_rhs))
+  if (is_constant_one(expr_rhs))
     return std::forward<L>(expr_lhs);
-
-  if (is_same<scalar_constant>(expr_rhs) &&
-      expr_rhs.template get<scalar_constant>().value() == 1) {
-    return std::forward<L>(expr_lhs);
-  }
 
   // Constant folding: pow(numeric, numeric) → numeric
   {
@@ -159,9 +153,7 @@ template <scalar_expr_holder E> [[nodiscard]] auto asin(E &&e) {
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto acos(E &&e) {
-  if (is_same<scalar_one>(e) ||
-      (is_same<scalar_constant>(e) &&
-       e.template get<scalar_constant>().value() == scalar_number{1}))
+  if (is_constant_one(e))
     return get_scalar_zero();
   return make_expression<scalar_acos>(std::forward<E>(e));
 }
@@ -191,9 +183,7 @@ template <scalar_expr_holder E> [[nodiscard]] auto abs(E &&e) {
 template <scalar_expr_holder E> [[nodiscard]] auto sqrt(E &&e) {
   if (is_same<scalar_zero>(e))
     return get_scalar_zero();
-  if (is_same<scalar_one>(e) ||
-      (is_same<scalar_constant>(e) &&
-       e.template get<scalar_constant>().value() == scalar_number{1}))
+  if (is_constant_one(e))
     return get_scalar_one();
   if (is_same<scalar_pow>(e)) {
     auto const &p = e.template get<scalar_pow>();
@@ -224,9 +214,7 @@ template <scalar_expr_holder E> [[nodiscard]] auto sign(E &&e) {
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto log(E &&e) {
-  if (is_same<scalar_one>(e) ||
-      (is_same<scalar_constant>(e) &&
-       e.template get<scalar_constant>().value() == scalar_number{1}))
+  if (is_constant_one(e))
     return get_scalar_zero();
   if (is_same<scalar_exp>(e))
     return e.template get<scalar_exp>().expr();
@@ -593,9 +581,7 @@ template <scalar_expr_holder E> [[nodiscard]] auto asinh(E const &e) {
 
 template <scalar_expr_holder E> [[nodiscard]] auto acosh(E const &e) {
   // acosh(1) = 0 — covers scalar_one and scalar_constant{1}.
-  if (is_same<scalar_one>(e) ||
-      (is_same<scalar_constant>(e) &&
-       e.template get<scalar_constant>().value() == scalar_number{1}))
+  if (is_constant_one(e))
     return get_scalar_zero();
   expression_holder<scalar_expression> one = get_scalar_one();
   return log(e + sqrt(pow(e, 2) - std::move(one)));

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -3,6 +3,7 @@
 
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/scalar/scalar_constant.h>
+#include <numsim_cas/scalar/scalar_constant_recognition.h>
 #include <numsim_cas/scalar/scalar_one.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/scalar/scalar_zero.h>
@@ -44,17 +45,13 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
     return make_expression<tensor_zero>(expr_lhs.get().dim(),
                                         expr_lhs.get().rank());
   // pow(A, 0) → identity
-  if (is_same<scalar_zero>(expr_rhs) ||
-      (is_same<scalar_constant>(expr_rhs) &&
-       expr_rhs.template get<scalar_constant>().value() == scalar_number{0})) {
+  if (is_constant_zero(expr_rhs)) {
     return make_expression<identity_tensor>(expr_lhs.get().dim(),
                                             std::size_t{2});
   }
 
   // pow(A, 1) → A
-  if (is_same<scalar_one>(expr_rhs) ||
-      (is_same<scalar_constant>(expr_rhs) &&
-       expr_rhs.template get<scalar_constant>().value() == scalar_number{1})) {
+  if (is_constant_one(expr_rhs)) {
     return std::forward<ExprLHS>(expr_lhs);
   }
 

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -1021,4 +1021,27 @@ TEST_F(ScalarFixture, SmoothedMacauleyAtEpsZeroDegeneratesToMacauleyPlus) {
   EXPECT_EQ(smoothed_macauley(x, _zero), macauley_plus(x));
 }
 
+// #262 Layer A: is_constant_one / is_constant_zero recognise the numeric
+// constant in either form (singleton or scalar_constant) and nothing else.
+TEST(ScalarConstantRecognition, OneAndZeroInBothForms) {
+  using namespace numsim::cas;
+  auto x = std::get<0>(make_scalar_variable("x"));
+  // Raw (non-canonicalised) constants exercise the scalar_constant branch —
+  // make_scalar_constant(1) would collapse to the scalar_one singleton.
+  auto raw_one = make_expression<scalar_constant>(scalar_number{1});
+  auto raw_zero = make_expression<scalar_constant>(scalar_number{0});
+  auto raw_two = make_expression<scalar_constant>(scalar_number{2});
+
+  EXPECT_TRUE(is_constant_one(get_scalar_one())); // singleton
+  EXPECT_TRUE(is_constant_one(raw_one));          // scalar_constant{1}
+  EXPECT_FALSE(is_constant_one(raw_two));
+  EXPECT_FALSE(is_constant_one(get_scalar_zero()));
+  EXPECT_FALSE(is_constant_one(x));
+
+  EXPECT_TRUE(is_constant_zero(get_scalar_zero())); // singleton
+  EXPECT_TRUE(is_constant_zero(raw_zero));          // scalar_constant{0}
+  EXPECT_FALSE(is_constant_zero(raw_one));
+  EXPECT_FALSE(is_constant_zero(x));
+}
+
 #endif // SCALAREXPRESSIONTEST_H


### PR DESCRIPTION
The `is_same<scalar_one>(e) || (is_same<scalar_constant>(e) && value()==1)` idiom (and `==0`) was hand-spelled across the scalar/tensor construction-time simplifiers. This adds `is_constant_one` / `is_constant_zero` (scalar domain) and routes the duplicated sites through them: scalar `pow` (lhs & rhs), the `acos`/`log`/`acosh`-family folds, and tensor `pow(A,0)`/`pow(A,1)`.

**Exact match** to the checks it replaces (no negation unwrap) — behavior-preserving, verified by the full suite + a new `ScalarConstantRecognition` test covering both the singleton and `scalar_constant` forms.

The helpers live in a dedicated leaf header (`scalar_constant_recognition.h`, constant nodes only) to sidestep the `scalar_std ↔ scalar_domain_traits ↔ scalar_all` include cycle that delegating to `domain_traits::try_numeric` would introduce — which is precisely why Layer B can't be reused at these sites.

## Scope (per the issue triage)
- **Layer A** (this PR): the free-function recognisers + call-site de-dup.
- **Layer B** (domain-agnostic recognition) is already largely served by `domain_traits::try_numeric`.
- **Layer C** (promote/demote across domains) is intentionally **not** done — it would blur the one-holder-per-domain invariant the visitor architecture depends on.

1612 tests pass.

Closes #262.