### PR TITLE
Fix #340, #341: replace raw hash-equality identity checks with deep comparison

### DIFF
--- a/include/numsim_cas/core/print_mul_fractions.h
+++ b/include/numsim_cas/core/print_mul_fractions.h
@@ -28,8 +28,9 @@ auto partition_mul_fractions(HashMap const &hash_map)
   for (auto const &[key, child] : hash_map) {
     if (auto pow_expr = is_same_r<pow_type>(child)) {
       auto const &exponent = pow_expr->get().expr_rhs();
+      // numeric_less, not operator< (which is rank-lexicographic order)
       if (auto num = Traits::try_numeric(exponent);
-          num && *num < scalar_number{0}) {
+          num && numeric_less(*num, scalar_number{0})) {
         denominator.push_back({pow_expr->get().expr_lhs(), -(*num)});
         continue;
       }

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -423,7 +423,12 @@ public:
       return base::m_lhs - rhs.expr();
     }
 
-    return base::get_default();
+    // non-cancelling -t: insert into a copy — get_default would nest the
+    // whole lhs add as a single child (round-9 review)
+    auto add_expr{make_expression<typename Traits::add_type>(lhs)};
+    auto &add{add_expr.template get<typename Traits::add_type>()};
+    insert_signed<Traits>(add, base::m_rhs);
+    return detail::finalize_add<Traits>(std::move(add_expr));
   }
 
 protected:
@@ -560,7 +565,7 @@ public:
     auto &add{add_expr.template get<typename Traits::add_type>()};
     // (-x) + (y - x): the map may already hold -x, so merge instead of a
     // raw push_back (which asserts on duplicates)
-    add.merge_or_insert(base::m_lhs);
+    insert_signed<Traits>(add, base::m_lhs);
     return detail::finalize_add<Traits>(std::move(add_expr));
   }
 

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -325,7 +325,11 @@ public:
                                  typename Traits::add_type &add,
                                  expr_holder_t combined) {
     if (!is_same<typename Traits::zero_type>(combined)) {
-      add.merge_or_insert(std::move(combined));
+      // signed insert: the combined term may exactly negate an existing
+      // child; a plain insert would leave a {t,-t} pair (round-8 review)
+      add_insert_signed(add, std::move(combined), [](expr_holder_t const &e) {
+        return is_same<typename Traits::zero_type>(e);
+      });
     }
     add.invalidate_hash();
     if (add.size() == 0) {

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -146,13 +146,11 @@ public:
     return get_default();
   }
 
-  // non-add + add --> swap so add is LHS (triggers n_ary_add_dispatch)
+  // non-add + add --> swap so add is LHS (triggers the n-ary dispatcher).
+  // Unconditional: the void-mul guard sent tensor A+(B+C) to get_default,
+  // which nested the rhs add as a single child (round-11 review).
   expr_holder_t dispatch(typename Traits::add_type const &) {
-    if constexpr (!std::is_void_v<typename Traits::mul_type>) {
-      return m_rhs + m_lhs;
-    } else {
-      return get_default();
-    }
+    return m_rhs + m_lhs;
   }
 
 protected:

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -196,16 +196,8 @@ public:
                          typename Traits::add_type const &rhs) {
     auto lhs_val = Traits::try_numeric(base::m_lhs);
     if (lhs_val) {
-      const auto value{get_coefficient<Traits>(rhs, 0) + *lhs_val};
-      auto add_expr{make_expression<typename Traits::add_type>(rhs)};
-      auto &add{add_expr.template get<typename Traits::add_type>()};
-      add.coeff().free();
-      if (value != 0) {
-        add.set_coeff(Traits::make_constant(value));
-      } else if (add.size() == 1) {
-        return add.symbol_map().begin()->second;
-      }
-      return add_expr;
+      return fold_constant_into_add_coeff<Traits>(
+          make_expression<typename Traits::add_type>(rhs), *lhs_val);
     }
     return base::get_default();
   }
@@ -268,16 +260,8 @@ public:
   // 1 + (coeff + x)
   expr_holder_t dispatch([[maybe_unused]]
                          typename Traits::add_type const &rhs) {
-    const auto value{get_coefficient<Traits>(rhs, 0) + 1};
-    auto add_expr{make_expression<typename Traits::add_type>(rhs)};
-    auto &add{add_expr.template get<typename Traits::add_type>()};
-    add.coeff().free();
-    if (value != 0) {
-      add.set_coeff(Traits::make_constant(value));
-    } else if (add.size() == 1) {
-      return add.symbol_map().begin()->second;
-    }
-    return add_expr;
+    return fold_constant_into_add_coeff<Traits>(
+        make_expression<typename Traits::add_type>(rhs), scalar_number{1});
   }
 
   // 1 + 1
@@ -322,28 +306,16 @@ public:
                          typename Traits::constant_type const &) {
     auto rhs_val = Traits::try_numeric(base::m_rhs);
     if (rhs_val) {
-      auto add_expr{make_expression<typename Traits::add_type>(lhs)};
-      auto &add{add_expr.template get<typename Traits::add_type>()};
-      const auto value{get_coefficient<Traits>(lhs, 0) + *rhs_val};
-      add.coeff().free();
-      if (value != 0) {
-        add.set_coeff(Traits::make_constant(value));
-      }
-      return add_expr;
+      return fold_constant_into_add_coeff<Traits>(
+          make_expression<typename Traits::add_type>(lhs), *rhs_val);
     }
     return base::get_default();
   }
 
   // (coeff + terms) + 1
   expr_holder_t dispatch([[maybe_unused]] typename Traits::one_type const &) {
-    auto add_expr{make_expression<typename Traits::add_type>(lhs)};
-    auto &add{add_expr.template get<typename Traits::add_type>()};
-    const auto value{get_coefficient<Traits>(add, 0) + 1};
-    add.coeff().free();
-    if (value != 0) {
-      add.set_coeff(Traits::make_constant(value));
-    }
-    return add_expr;
+    return fold_constant_into_add_coeff<Traits>(
+        make_expression<typename Traits::add_type>(lhs), scalar_number{1});
   }
 
   // Zero-filter + degenerate collapse after in-place mutation: a
@@ -425,14 +397,8 @@ public:
 
     auto inner_val = Traits::try_numeric(rhs.expr());
     if (inner_val) {
-      auto add_expr{make_expression<typename Traits::add_type>(lhs)};
-      auto &add{add_expr.template get<typename Traits::add_type>()};
-      const auto value{get_coefficient<Traits>(lhs, 0) - *inner_val};
-      add.coeff().free();
-      if (value != 0) {
-        add.set_coeff(Traits::make_constant(value));
-      }
-      return add_expr;
+      return fold_constant_into_add_coeff<Traits>(
+          make_expression<typename Traits::add_type>(lhs), -(*inner_val));
     }
 
     // add + (-add): route through subtraction, which cancels childwise
@@ -569,18 +535,13 @@ public:
   // -expr + (coeff + terms)
   expr_holder_t dispatch([[maybe_unused]]
                          typename Traits::add_type const &rhs) {
-    auto add_expr{make_expression<typename Traits::add_type>(rhs)};
-    auto &add{add_expr.template get<typename Traits::add_type>()};
-
     auto inner_val = Traits::try_numeric(lhs.expr());
     if (inner_val) {
-      const auto value{get_coefficient<Traits>(rhs, 0) - *inner_val};
-      add.coeff().free();
-      if (value != 0) {
-        add.set_coeff(Traits::make_constant(value));
-      }
-      return add_expr;
+      return fold_constant_into_add_coeff<Traits>(
+          make_expression<typename Traits::add_type>(rhs), -(*inner_val));
     }
+    auto add_expr{make_expression<typename Traits::add_type>(rhs)};
+    auto &add{add_expr.template get<typename Traits::add_type>()};
     // (-x) + (y - x): the map may already hold -x, so merge instead of a
     // raw push_back (which asserts on duplicates)
     add.merge_or_insert(base::m_lhs);

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -4,6 +4,7 @@
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/core/domain_traits.h>
 #include <numsim_cas/core/scalar_number.h>
+#include <numsim_cas/core/simplifier/simplifier_common.h>
 #include <numsim_cas/functions.h>
 #include <ranges>
 #include <set>
@@ -196,13 +197,15 @@ public:
     auto lhs_val = Traits::try_numeric(base::m_lhs);
     if (lhs_val) {
       const auto value{get_coefficient<Traits>(rhs, 0) + *lhs_val};
+      auto add_expr{make_expression<typename Traits::add_type>(rhs)};
+      auto &add{add_expr.template get<typename Traits::add_type>()};
+      add.coeff().free();
       if (value != 0) {
-        auto add_expr{make_expression<typename Traits::add_type>(rhs)};
-        auto &add{add_expr.template get<typename Traits::add_type>()};
         add.set_coeff(Traits::make_constant(value));
-        return add_expr;
+      } else if (add.size() == 1) {
+        return add.symbol_map().begin()->second;
       }
-      return base::m_rhs;
+      return add_expr;
     }
     return base::get_default();
   }
@@ -266,13 +269,15 @@ public:
   expr_holder_t dispatch([[maybe_unused]]
                          typename Traits::add_type const &rhs) {
     const auto value{get_coefficient<Traits>(rhs, 0) + 1};
+    auto add_expr{make_expression<typename Traits::add_type>(rhs)};
+    auto &add{add_expr.template get<typename Traits::add_type>()};
+    add.coeff().free();
     if (value != 0) {
-      auto add_expr{make_expression<typename Traits::add_type>(rhs)};
-      auto &add{add_expr.template get<typename Traits::add_type>()};
       add.set_coeff(Traits::make_constant(value));
-      return add_expr;
+    } else if (add.size() == 1) {
+      return add.symbol_map().begin()->second;
     }
-    return base::m_rhs;
+    return add_expr;
   }
 
   // 1 + 1
@@ -402,8 +407,9 @@ public:
 
   // (coeff + terms) + (-expr)
   expr_holder_t dispatch(typename Traits::negative_type const &rhs) {
+    // map keys compare by hash; confirm deep equality before cancelling
     const auto pos{lhs.symbol_map().find(rhs.expr())};
-    if (pos != lhs.symbol_map().end()) {
+    if (pos != lhs.symbol_map().end() && pos->second == rhs.expr()) {
       auto expr{make_expression<typename Traits::add_type>(lhs)};
       auto &add{expr.template get<typename Traits::add_type>()};
       add.symbol_map().erase(rhs.expr());
@@ -427,6 +433,12 @@ public:
         add.set_coeff(Traits::make_constant(value));
       }
       return add_expr;
+    }
+
+    // add + (-add): route through subtraction, which cancels childwise
+    // with deep comparison (map keys alone alias e.g. a against 1+a)
+    if (is_same<typename Traits::add_type>(rhs.expr())) {
+      return base::m_lhs - rhs.expr();
     }
 
     return base::get_default();
@@ -461,12 +473,10 @@ public:
   template <typename SymbolType = typename Traits::symbol_type>
   requires(!std::is_void_v<SymbolType>)
   expr_holder_t dispatch(SymbolType const &) {
-    const auto pos{lhs.symbol_map().find(base::m_rhs)};
-    if (pos != lhs.symbol_map().end() && lhs.symbol_map().size() == 1) {
-      auto expr{make_expression<typename Traits::mul_type>(lhs)};
-      auto &mul{expr.template get<typename Traits::mul_type>()};
-      mul.set_coeff(Traits::make_constant(get_coefficient<Traits>(lhs, 1) + 1));
-      return expr;
+    // deep single-child check: a map find would alias child x+2 against x
+    if (lhs.size() == 1 && lhs.symbol_map().begin()->second == base::m_rhs) {
+      return base::scaled_copy(
+          lhs, Traits::make_constant(get_coefficient<Traits>(lhs, 1) + 1));
     }
     return get_default();
   }
@@ -518,12 +528,10 @@ public:
 
   // x + c*x --> (c+1)*x
   expr_holder_t dispatch(typename Traits::mul_type const &rhs) {
-    const auto pos{rhs.symbol_map().find(base::m_lhs)};
-    if (pos != rhs.symbol_map().end() && rhs.symbol_map().size() == 1) {
-      auto expr{make_expression<typename Traits::mul_type>(rhs)};
-      auto &mul{expr.template get<typename Traits::mul_type>()};
-      mul.set_coeff(Traits::make_constant(get_coefficient<Traits>(rhs, 1) + 1));
-      return expr;
+    // deep single-child check: a map find would alias child x+2 against x
+    if (rhs.size() == 1 && rhs.symbol_map().begin()->second == base::m_lhs) {
+      return base::scaled_copy(
+          rhs, Traits::make_constant(get_coefficient<Traits>(rhs, 1) + 1));
     }
     return get_default();
   }
@@ -573,8 +581,10 @@ public:
       }
       return add_expr;
     }
-    add.push_back(base::m_lhs);
-    return add_expr;
+    // (-x) + (y - x): the map may already hold -x, so merge instead of a
+    // raw push_back (which asserts on duplicates)
+    add.merge_or_insert(base::m_lhs);
+    return detail::finalize_add<Traits>(std::move(add_expr));
   }
 
   // -expr + c

--- a/include/numsim_cas/core/simplifier/simplifier_add.h
+++ b/include/numsim_cas/core/simplifier/simplifier_add.h
@@ -360,6 +360,15 @@ public:
         pos = add.find_like(probe);
       }
     }
+    if (pos == add.symbol_map().end()) {
+      // negation pairs share no hash: (3-x)+x needs a -x probe; only an
+      // exact -x cancels — like-terms of -x would nest adds (round-7)
+      auto neg_probe{-base::m_rhs};
+      pos = add.find_like(neg_probe);
+      if (pos != add.symbol_map().end() && !(pos->second == neg_probe)) {
+        pos = add.symbol_map().end();
+      }
+    }
     if (pos != add.symbol_map().end()) {
       auto expr{pos->second + base::m_rhs};
       add.symbol_map().erase(pos);
@@ -369,12 +378,15 @@ public:
     return expr_add;
   }
 
-  // merge two add expressions
+  // merge two add expressions; zero-filter + collapse since childwise
+  // combines may fully cancel ((3+x)+(1-x) -> 4), round-7 review
   expr_holder_t dispatch(typename Traits::add_type const &rhs) {
     auto expr{make_expression<typename Traits::add_type>()};
     auto &add{expr.template get<typename Traits::add_type>()};
-    merge_add(lhs, rhs, add);
-    return expr;
+    merge_add(lhs, rhs, add, [](expr_holder_t const &e) {
+      return is_same<typename Traits::zero_type>(e);
+    });
+    return finalize_add<Traits>(std::move(expr));
   }
 
   // (coeff + terms) + (-expr)

--- a/include/numsim_cas/core/simplifier/simplifier_common.h
+++ b/include/numsim_cas/core/simplifier/simplifier_common.h
@@ -1,7 +1,9 @@
 #ifndef NUMSIM_CAS_CORE_SIMPLIFIER_COMMON_H
 #define NUMSIM_CAS_CORE_SIMPLIFIER_COMMON_H
 
+#include <numsim_cas/core/domain_traits.h>
 #include <numsim_cas/core/expression_holder.h>
+#include <numsim_cas/core/scalar_number.h>
 
 namespace numsim::cas::detail {
 
@@ -40,6 +42,30 @@ finalize_add(expression_holder<typename Traits::expression_type> expr) {
     return add.symbol_map().begin()->second;
   }
   return expr;
+}
+
+// Fold a numeric delta into the coefficient of `expr` (an add node).
+// A valid-but-non-numeric coefficient (symbolic, t2s) is combined as an
+// expression — get_coefficient reports 0 for it, and the old free()/
+// set_coeff pattern silently deleted it (round-6 review).
+template <typename Traits>
+[[nodiscard]] expression_holder<typename Traits::expression_type>
+fold_constant_into_add_coeff(
+    expression_holder<typename Traits::expression_type> expr,
+    scalar_number const &delta) {
+  auto &add = expr.template get<typename Traits::add_type>();
+  if (add.coeff().is_valid() && !Traits::try_numeric(add.coeff())) {
+    auto sym = add.coeff();
+    add.coeff().free();
+    add.set_coeff(sym + Traits::make_constant(delta));
+    return finalize_add<Traits>(std::move(expr));
+  }
+  const auto value{get_coefficient<Traits>(add, 0) + delta};
+  add.coeff().free();
+  if (value != 0) {
+    add.set_coeff(Traits::make_constant(value));
+  }
+  return finalize_add<Traits>(std::move(expr));
 }
 
 } // namespace numsim::cas::detail

--- a/include/numsim_cas/core/simplifier/simplifier_common.h
+++ b/include/numsim_cas/core/simplifier/simplifier_common.h
@@ -4,6 +4,7 @@
 #include <numsim_cas/core/domain_traits.h>
 #include <numsim_cas/core/expression_holder.h>
 #include <numsim_cas/core/scalar_number.h>
+#include <numsim_cas/functions.h>
 
 namespace numsim::cas::detail {
 
@@ -42,6 +43,18 @@ finalize_add(expression_holder<typename Traits::expression_type> expr) {
     return add.symbol_map().begin()->second;
   }
   return expr;
+}
+
+// merge_or_insert with exact-negation combining and zero filtering:
+// dispatcher-side child insertion must never leave a {t, -t} pair or a
+// literal zero child (round-8/9 reviews).
+template <typename Traits>
+inline void insert_signed(typename Traits::add_type &add,
+                          typename Traits::expr_holder_t entry) {
+  add_insert_signed(add, std::move(entry),
+                    [](typename Traits::expr_holder_t const &e) {
+                      return is_same<typename Traits::zero_type>(e);
+                    });
 }
 
 // Fold a numeric delta into the coefficient of `expr` (an add node).

--- a/include/numsim_cas/core/simplifier/simplifier_mul.h
+++ b/include/numsim_cas/core/simplifier/simplifier_mul.h
@@ -74,9 +74,19 @@ public:
 
   // x * (x*y*z) → push x into existing mul
   expr_holder_t dispatch(typename Traits::mul_type const &rhs) {
-    auto mul{make_expression<typename Traits::mul_type>(rhs)};
-    mul.template get<typename Traits::mul_type>().push_back(m_lhs);
-    return mul;
+    auto mul_expr{make_expression<typename Traits::mul_type>(rhs)};
+    auto &mul{mul_expr.template get<typename Traits::mul_type>()};
+    // an identical factor may already exist (sin(x) * (c*sin(x)*y)); a raw
+    // push_back would hit the no-duplicates assert — combine to a pow
+    auto pos{rhs.symbol_map().find(m_lhs)};
+    if (pos != rhs.symbol_map().end() && pos->second == m_lhs) {
+      auto combined{pos->second * m_lhs};
+      mul.symbol_map().erase(m_lhs);
+      mul.invalidate_hash();
+      return std::move(mul_expr) * combined;
+    }
+    mul.push_back(m_lhs);
+    return mul_expr;
   }
 
 protected:

--- a/include/numsim_cas/core/simplifier/simplifier_pow.h
+++ b/include/numsim_cas/core/simplifier/simplifier_pow.h
@@ -1,11 +1,29 @@
 #ifndef SIMPLIFIER_POW_H
 #define SIMPLIFIER_POW_H
 
+#include <cmath>
+#include <cstdint>
+#include <variant>
+
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/core/domain_traits.h>
+#include <numsim_cas/core/scalar_number.h>
 
 namespace numsim::cas {
 namespace detail {
+
+// -1: not a (representable) integer, 0: even, 1: odd
+inline int integer_parity(scalar_number const &n) {
+  if (auto const *i = std::get_if<std::int64_t>(&n.raw())) {
+    return static_cast<int>(*i & 1);
+  }
+  if (auto const *d = std::get_if<double>(&n.raw())) {
+    if (*d == std::floor(*d) && std::fabs(*d) < 9.0e15) {
+      return static_cast<int>(static_cast<std::int64_t>(*d) & 1);
+    }
+  }
+  return -1;
+}
 
 //==============================================================================
 // pow_dispatch<Traits, Derived> — Base algorithm for pow(A, B)
@@ -34,18 +52,31 @@ public:
       // expr*x / x --> expr; for x /= 0
       if (is_same<mul_type>(m_lhs)) {
         const auto &map{m_lhs.template get<mul_type>().symbol_map()};
+        // map keys compare by hash; confirm deep equality before erasing
         auto pos{map.find(expr)};
-        if (pos != map.end()) {
+        if (pos != map.end() && pos->second == expr) {
           auto copy{make_expression<mul_type>(m_lhs.template get<mul_type>())};
-          copy.template get<mul_type>().symbol_map().erase(expr);
+          auto &mul{copy.template get<mul_type>()};
+          mul.symbol_map().erase(expr);
+          mul.invalidate_hash();
           return copy;
         }
       }
     }
-    // pow(-expr, power) --> -pow(expr, power)
+    // pow(-expr, p): the sign survives only for odd integer p; even integer
+    // p absorbs it; unknown/non-integer p must keep the negative base.
     if (auto expr_neg{is_same_r<negative_type>(m_lhs)}) {
-      return -make_expression<pow_type>(expr_neg->get().expr(),
-                                        std::move(m_rhs));
+      if (auto num = Traits::try_numeric(m_rhs)) {
+        const int parity = integer_parity(*num);
+        if (parity == 0) {
+          return make_expression<pow_type>(expr_neg->get().expr(),
+                                           std::move(m_rhs));
+        }
+        if (parity == 1) {
+          return -make_expression<pow_type>(expr_neg->get().expr(),
+                                            std::move(m_rhs));
+        }
+      }
     }
     return make_expression<pow_type>(std::move(m_lhs), std::move(m_rhs));
   }
@@ -108,12 +139,14 @@ public:
 
   // pow(mul, -rhs)
   expr_holder_t dispatch(typename Traits::negative_type const &rhs) {
+    // map keys compare by hash; confirm deep equality before erasing
     auto pos{lhs.symbol_map().find(rhs.expr())};
     auto mul_expr{make_expression<typename Traits::mul_type>(lhs)};
     auto &mul{mul_expr.template get<typename Traits::mul_type>()};
     // x*y*z / x --> y*z
-    if (pos != lhs.symbol_map().end()) {
+    if (pos != lhs.symbol_map().end() && pos->second == rhs.expr()) {
       mul.symbol_map().erase(rhs.expr());
+      mul.invalidate_hash();
       return mul_expr;
     }
 

--- a/include/numsim_cas/core/simplifier/simplifier_sub.h
+++ b/include/numsim_cas/core/simplifier/simplifier_sub.h
@@ -52,9 +52,11 @@ public:
     if (rhs_val) {
       add.set_coeff(negate_constant(m_rhs));
     } else {
-      add.push_back(-m_rhs);
+      // -m_rhs may collapse onto m_lhs (z - (-z)); a raw push_back
+      // would hit the no-duplicates assert
+      add.merge_or_insert(-m_rhs);
     }
-    return add_new;
+    return finalize_add<Traits>(std::move(add_new));
   }
 
   template <typename Expr> expr_holder_t dispatch(Expr const &) {
@@ -336,8 +338,8 @@ public:
   requires(!std::is_void_v<SymbolType>)
   expr_holder_t dispatch(SymbolType const &) {
     if (lhs.symbol_map().size() == 1) {
-      auto pos{lhs.symbol_map().find(base::m_rhs)};
-      if (lhs.symbol_map().end() != pos) {
+      // deep-compare: a map find would alias e.g. child x+2 against x
+      if (lhs.symbol_map().begin()->second == base::m_rhs) {
         // an invalid mul coefficient means 1, not 0 (round-2 review:
         // ((x*y)*pow(x,-1)) - y evaluated to -3 via the 0 default)
         const auto value{get_coefficient<Traits>(lhs, 1) - 1};
@@ -358,18 +360,18 @@ public:
 
   /// c1*expr - c2*expr --> (c1-c2)*expr
   expr_holder_t dispatch(typename Traits::mul_type const &rhs) {
-    const auto &hash_rhs{rhs.hash_value()};
-    const auto &hash_lhs{lhs.hash_value()};
-    if (hash_rhs == hash_lhs) {
-      const auto fac_lhs{get_coefficient<Traits>(lhs, 1.0)};
-      const auto fac_rhs{get_coefficient<Traits>(rhs, 1.0)};
+    // hashes are coefficient-blind; like_term_of confirms the children match
+    if (lhs.like_term_of(rhs)) {
+      const auto fac_lhs{get_coefficient<Traits>(lhs, 1)};
+      const auto fac_rhs{get_coefficient<Traits>(rhs, 1)};
       const auto result{fac_lhs - fac_rhs};
       if (result == scalar_number{0})
         return Traits::zero();
       const auto abs_result{result.abs()};
+      const bool is_negative{numeric_less(result, scalar_number{0})};
       if (abs_result == scalar_number{1} && lhs.size() == 1) {
         auto child = lhs.symbol_map().begin()->second;
-        if (result < 0)
+        if (is_negative)
           return make_expression<typename Traits::negative_type>(
               std::move(child));
         return child;
@@ -377,7 +379,7 @@ public:
       auto expr{make_expression<typename Traits::mul_type>(lhs)};
       auto &mul{expr.template get<typename Traits::mul_type>()};
       mul.set_coeff(Traits::make_constant(abs_result));
-      if (result < 0) {
+      if (is_negative) {
         return make_expression<typename Traits::negative_type>(std::move(expr));
       }
       return expr;
@@ -420,18 +422,27 @@ public:
 
   // x - 3*x --> -(2*x)
   expr_holder_t dispatch(typename Traits::mul_type const &rhs) {
-    const auto &hash_rhs{rhs.hash_value()};
-    const auto &hash_lhs{lhs.hash_value()};
-    if (hash_rhs == hash_lhs) {
+    // c*x is a like term of x only when its single child deep-equals x
+    // (hash-based checks alias x against x+2 and never match cross-type)
+    if (rhs.size() == 1 && rhs.symbol_map().begin()->second == base::m_lhs) {
+      const auto value{scalar_number{1} - get_coefficient<Traits>(rhs, 1)};
+      if (value == scalar_number{0}) {
+        return Traits::zero();
+      }
+      const auto abs_value{value.abs()};
+      const bool is_negative{numeric_less(value, scalar_number{0})};
+      if (abs_value == scalar_number{1} && rhs.size() == 1) {
+        if (is_negative)
+          return make_expression<typename Traits::negative_type>(base::m_lhs);
+        return base::m_lhs;
+      }
       auto expr{make_expression<typename Traits::mul_type>(rhs)};
       auto &mul{expr.template get<typename Traits::mul_type>()};
-      const auto value{1.0 - get_coefficient<Traits>(rhs, 1.0)};
-      mul.set_coeff(Traits::make_constant(value.abs()));
-      if (value < 0) {
+      mul.set_coeff(Traits::make_constant(abs_value));
+      if (is_negative) {
         return make_expression<typename Traits::negative_type>(std::move(expr));
-      } else {
-        return expr;
       }
+      return expr;
     }
     return get_default();
   }

--- a/include/numsim_cas/core/simplifier/simplifier_sub.h
+++ b/include/numsim_cas/core/simplifier/simplifier_sub.h
@@ -203,28 +203,16 @@ public:
                          typename Traits::constant_type const &) {
     auto rhs_val = Traits::try_numeric(base::m_rhs);
     if (rhs_val) {
-      auto add_expr{make_expression<typename Traits::add_type>(lhs)};
-      auto &add{add_expr.template get<typename Traits::add_type>()};
-      const auto value{get_coefficient<Traits>(lhs, 0) - *rhs_val};
-      add.coeff().free();
-      if (value != 0) {
-        add.set_coeff(Traits::make_constant(value));
-      }
-      return add_expr;
+      return fold_constant_into_add_coeff<Traits>(
+          make_expression<typename Traits::add_type>(lhs), -(*rhs_val));
     }
     return base::get_default();
   }
 
   // (coeff + terms) - 1
   expr_holder_t dispatch([[maybe_unused]] typename Traits::one_type const &) {
-    auto add_expr{make_expression<typename Traits::add_type>(lhs)};
-    auto &add{add_expr.template get<typename Traits::add_type>()};
-    const auto value{get_coefficient<Traits>(add, 0) - 1};
-    add.coeff().free();
-    if (value != 0) {
-      add.set_coeff(Traits::make_constant(value));
-    }
-    return add_expr;
+    return fold_constant_into_add_coeff<Traits>(
+        make_expression<typename Traits::add_type>(lhs), scalar_number{-1});
   }
 
   // (c_l + a + b + c) - (c_r + a + d) = (c_l - c_r) + b + c - d

--- a/include/numsim_cas/core/simplifier/simplifier_sub.h
+++ b/include/numsim_cas/core/simplifier/simplifier_sub.h
@@ -24,7 +24,7 @@ public:
       : m_lhs(std::move(lhs)), m_rhs(std::move(rhs)) {}
 
   expr_holder_t get_default() {
-    if (m_lhs.get().hash_value() == m_rhs.get().hash_value()) {
+    if (m_lhs == m_rhs) {
       return Traits::zero();
     }
 

--- a/include/numsim_cas/core/simplifier/simplifier_sub.h
+++ b/include/numsim_cas/core/simplifier/simplifier_sub.h
@@ -41,6 +41,18 @@ public:
       return Traits::make_constant(result);
     }
 
+    if (is_same<add_type>(m_lhs)) {
+      // copy children — pushing the whole add would nest it (round-9)
+      auto add_expr{make_expression<add_type>(m_lhs.template get<add_type>())};
+      if (rhs_val) {
+        return fold_constant_into_add_coeff<Traits>(std::move(add_expr),
+                                                    -(*rhs_val));
+      }
+      auto &add{add_expr.template get<add_type>()};
+      insert_signed<Traits>(add, -m_rhs);
+      return finalize_add<Traits>(std::move(add_expr));
+    }
+
     auto add_new{make_expression<add_type>()};
     auto &add{add_new.template get<add_type>()};
     if (lhs_val) {
@@ -54,7 +66,7 @@ public:
     } else {
       // -m_rhs may collapse onto m_lhs (z - (-z)); a raw push_back
       // would hit the no-duplicates assert
-      add.merge_or_insert(-m_rhs);
+      insert_signed<Traits>(add, -m_rhs);
     }
     return finalize_add<Traits>(std::move(add_new));
   }
@@ -99,7 +111,7 @@ public:
   expr_holder_t dispatch(typename Traits::add_type const &rhs) {
     auto add_expr{make_expression<typename Traits::add_type>(rhs)};
     auto &add{add_expr.template get<typename Traits::add_type>()};
-    add.merge_or_insert(lhs.expr());
+    insert_signed<Traits>(add, lhs.expr());
     return make_expression<typename Traits::negative_type>(std::move(add_expr));
   }
 
@@ -145,7 +157,7 @@ public:
   // call operator- on an invalid holder and throw. Mirrors the guard
   // pattern in n_ary_sub_dispatch::dispatch(add_type) from PR #98.
   //
-  // Children are negated and pushed via merge_or_insert (not push_back)
+  // Children are negated and inserted via insert_signed (not push_back)
   // so a `-child` that collides with another entry in the result is
   // combined rather than throwing duplicate-child internal_error.
   //
@@ -163,7 +175,7 @@ public:
       add.set_coeff(base::m_lhs);
     }
     for (auto &child : rhs.symbol_map() | std::views::values) {
-      add.merge_or_insert(-child);
+      insert_signed<Traits>(add, -child);
     }
     return finalize_add<Traits>(std::move(add_expr));
   }
@@ -258,15 +270,15 @@ public:
         used_expr.insert(pos->second);
         auto combined = child - pos->second;
         if (!is_same<typename Traits::zero_type>(combined))
-          add.merge_or_insert(std::move(combined));
+          insert_signed<Traits>(add, std::move(combined));
       } else {
-        add.merge_or_insert(child);
+        insert_signed<Traits>(add, child);
       }
     }
     if (used_expr.size() != rhs.size()) {
       for (auto &child : rhs.symbol_map() | std::views::values) {
         if (!used_expr.count(child)) {
-          add.merge_or_insert(-child);
+          insert_signed<Traits>(add, -child);
         }
       }
     }
@@ -289,10 +301,10 @@ public:
       auto combined{pos->second - base::m_rhs};
       add.symbol_map().erase(pos);
       if (!is_same<typename Traits::zero_type>(combined))
-        add.merge_or_insert(std::move(combined));
+        insert_signed<Traits>(add, std::move(combined));
       return finalize_add<Traits>(std::move(expr_add));
     }
-    add.merge_or_insert(-base::m_rhs);
+    insert_signed<Traits>(add, -base::m_rhs);
     return finalize_add<Traits>(std::move(expr_add));
   }
 

--- a/include/numsim_cas/functions.h
+++ b/include/numsim_cas/functions.h
@@ -7,13 +7,13 @@
 namespace numsim::cas {
 
 /// merge two n_ary_trees
-///   --> use std::function for special handling?
 ///   --> add (x+y+z) + (x+a) --> 2*x+y+z+a --> mul
-///   --> mul (x*y*z) * (x*a) --> pow(x,2)*y*z*a --> pow
-template <typename Derived>
+/// `is_zero` filters fully-cancelled combines (x + (-x)); negation pairs
+/// share no hash, so a failed find_like retries with -child (round-7).
+template <typename Derived, typename IsZero>
 constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
                                 n_ary_tree<Derived> const &rhs,
-                                n_ary_tree<Derived> &result) {
+                                n_ary_tree<Derived> &result, IsZero &&is_zero) {
   using expr_t = typename Derived::expr_t;
 
   if (lhs.coeff().is_valid() && rhs.coeff().is_valid()) {
@@ -30,9 +30,20 @@ constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
   expr_set<expression_holder<expr_t>> used_expr;
   for (auto &child : lhs.symbol_map() | std::views::values) {
     auto pos{rhs.find_like(child)};
+    if (pos == rhs.symbol_map().end()) {
+      // only an exact -child cancels; like-terms of -child would nest adds
+      auto neg_child{-child};
+      pos = rhs.find_like(neg_child);
+      if (pos != rhs.symbol_map().end() && !(pos->second == neg_child)) {
+        pos = rhs.symbol_map().end();
+      }
+    }
     if (pos != rhs.symbol_map().end()) {
       used_expr.insert(pos->second);
-      result.merge_or_insert(child + pos->second);
+      auto combined{child + pos->second};
+      if (!is_zero(combined)) {
+        result.merge_or_insert(std::move(combined));
+      }
     } else {
       result.merge_or_insert(child);
     }
@@ -44,6 +55,13 @@ constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
       }
     }
   }
+}
+
+template <typename Derived>
+constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
+                                n_ary_tree<Derived> const &rhs,
+                                n_ary_tree<Derived> &result) {
+  merge_add(lhs, rhs, result, [](auto const &) { return false; });
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/functions.h
+++ b/include/numsim_cas/functions.h
@@ -6,10 +6,41 @@
 
 namespace numsim::cas {
 
+/// Insert `entry` into an add-semantics tree, combining with an existing
+/// exact match or exact negation until no collision remains; `is_zero`
+/// filters fully-cancelled results so {t, -t} pairs never coexist
+/// (round-8 review: such a pair downstream caused a double-consume merge).
+template <typename Derived, typename IsZero>
+constexpr inline void
+add_insert_signed(n_ary_tree<Derived> &tree,
+                  expression_holder<typename Derived::expr_t> entry,
+                  IsZero &&is_zero) {
+  while (entry.is_valid() && !is_zero(entry)) {
+    auto pos = tree.find_like(entry);
+    if (pos == tree.symbol_map().end()) {
+      auto neg{-entry};
+      pos = tree.find_like(neg);
+      if (pos != tree.symbol_map().end() && !(pos->second == neg)) {
+        pos = tree.symbol_map().end();
+      }
+    }
+    if (pos == tree.symbol_map().end()) {
+      tree.merge_or_insert(std::move(entry));
+      return;
+    }
+    auto next = pos->second + entry;
+    tree.symbol_map().erase(pos);
+    entry = std::move(next);
+  }
+}
+
 /// merge two n_ary_trees
 ///   --> add (x+y+z) + (x+a) --> 2*x+y+z+a --> mul
 /// `is_zero` filters fully-cancelled combines (x + (-x)); negation pairs
 /// share no hash, so a failed find_like retries with -child (round-7).
+/// A matched rhs child is consumed exactly once: a second lhs child must
+/// not re-match it (round-8 review: 5x and -(5x) both consuming -(5x)
+/// turned y-5x into y-10x).
 template <typename Derived, typename IsZero>
 constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
                                 n_ary_tree<Derived> const &rhs,
@@ -30,11 +61,15 @@ constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
   expr_set<expression_holder<expr_t>> used_expr;
   for (auto &child : lhs.symbol_map() | std::views::values) {
     auto pos{rhs.find_like(child)};
+    if (pos != rhs.symbol_map().end() && used_expr.count(pos->second)) {
+      pos = rhs.symbol_map().end();
+    }
     if (pos == rhs.symbol_map().end()) {
       // only an exact -child cancels; like-terms of -child would nest adds
       auto neg_child{-child};
       pos = rhs.find_like(neg_child);
-      if (pos != rhs.symbol_map().end() && !(pos->second == neg_child)) {
+      if (pos != rhs.symbol_map().end() &&
+          (!(pos->second == neg_child) || used_expr.count(pos->second))) {
         pos = rhs.symbol_map().end();
       }
     }
@@ -42,26 +77,19 @@ constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
       used_expr.insert(pos->second);
       auto combined{child + pos->second};
       if (!is_zero(combined)) {
-        result.merge_or_insert(std::move(combined));
+        add_insert_signed(result, std::move(combined), is_zero);
       }
     } else {
-      result.merge_or_insert(child);
+      add_insert_signed(result, child, is_zero);
     }
   }
   if (used_expr.size() != rhs.size()) {
     for (auto &child : rhs.symbol_map() | std::views::values) {
       if (!used_expr.count(child)) {
-        result.merge_or_insert(child);
+        add_insert_signed(result, child, is_zero);
       }
     }
   }
-}
-
-template <typename Derived>
-constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
-                                n_ary_tree<Derived> const &rhs,
-                                n_ary_tree<Derived> &result) {
-  merge_add(lhs, rhs, result, [](auto const &) { return false; });
 }
 
 } // namespace numsim::cas

--- a/include/numsim_cas/functions.h
+++ b/include/numsim_cas/functions.h
@@ -48,7 +48,12 @@ constexpr inline void merge_add(n_ary_tree<Derived> const &lhs,
   using expr_t = typename Derived::expr_t;
 
   if (lhs.coeff().is_valid() && rhs.coeff().is_valid()) {
-    result.set_coeff(lhs.coeff() + rhs.coeff());
+    // cancelled coefficients must be dropped, not stored as a literal
+    // zero ((2+x)+(y-2) printed "0+x+y", round-9 review)
+    auto coeff{lhs.coeff() + rhs.coeff()};
+    if (!is_zero(coeff)) {
+      result.set_coeff(std::move(coeff));
+    }
   } else {
     if (lhs.coeff().is_valid()) {
       result.set_coeff(lhs.coeff());

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -483,7 +483,7 @@ template <scalar_expr_holder L, scalar_expr_holder R>
   assert(lhs.is_valid());
   assert(rhs.is_valid());
   // max(x, x) → x
-  if (lhs.get().hash_value() == rhs.get().hash_value())
+  if (lhs == rhs)
     return std::forward<L>(lhs);
   // Constant folding
   auto lval = detail::try_extract_scalar_number(lhs);
@@ -510,7 +510,7 @@ template <scalar_expr_holder L, scalar_expr_holder R>
   assert(lhs.is_valid());
   assert(rhs.is_valid());
   // min(x, x) → x
-  if (lhs.get().hash_value() == rhs.get().hash_value())
+  if (lhs == rhs)
     return std::forward<L>(lhs);
   // Constant folding
   auto lval = detail::try_extract_scalar_number(lhs);

--- a/include/numsim_cas/scalar/simplifier/scalar_simplifier_mul.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_simplifier_mul.h
@@ -98,13 +98,15 @@ public:
 
   template <typename Expr>
   expr_holder_t dispatch([[maybe_unused]] Expr const &rhs) {
-    auto expr_mul{make_expression<scalar_mul>(m_lhs_node)};
-    auto &mul{expr_mul.template get<scalar_mul>()};
-    mul.push_back(m_rhs);
-    return expr_mul;
+    return push_or_combine_child();
   }
 
 private:
+  // fallback child insertion; combines an identical existing factor into a
+  // pow instead of hitting the no-duplicates assert (defined in .cpp for
+  // operator* ADL visibility)
+  expr_holder_t push_or_combine_child();
+
   using base::m_lhs;
   using base::m_rhs;
   scalar_mul const &m_lhs_node;

--- a/include/numsim_cas/scalar/visitors/scalar_differentiation.h
+++ b/include/numsim_cas/scalar/visitors/scalar_differentiation.h
@@ -66,7 +66,7 @@ public:
    * @param visitable Scalar variable node.
    */
   void operator()(scalar const &visitable) override {
-    if (visitable.hash_value() == m_arg.get().hash_value()) {
+    if (visitable == m_arg.get()) {
       m_result = get_scalar_one();
     } else {
       m_result = get_scalar_zero();

--- a/include/numsim_cas/tensor/operators/scalar/tensor_scalar_mul.h
+++ b/include/numsim_cas/tensor/operators/scalar/tensor_scalar_mul.h
@@ -38,6 +38,18 @@ public:
       hash_combine(base::m_hash_value, this->m_rhs.get().hash_value());
     }
   }
+
+  // c*T is a like term of T and of any c'*T (add-side merging, #340)
+  [[nodiscard]] bool
+  like_term_of(expression const &rhs) const noexcept override {
+    if (this->hash_value() != rhs.hash_value())
+      return false;
+    if (rhs.id() == this->id()) {
+      auto const &r = static_cast<tensor_scalar_mul const &>(rhs);
+      return this->expr_rhs() == r.expr_rhs();
+    }
+    return this->expr_rhs().get() == rhs;
+  }
 };
 
 } // namespace numsim::cas

--- a/include/numsim_cas/tensor/operators/tensor/tensor_add.h
+++ b/include/numsim_cas/tensor/operators/tensor/tensor_add.h
@@ -36,6 +36,22 @@ public:
     base::push_back(std::move(expr));
   }
 
+  /// Recompute the space join from the current children (for merge-based
+  /// construction paths that bypass push_back, e.g. merge_or_insert).
+  inline void recompute_space() {
+    this->clear_space();
+    bool first{true};
+    for (auto const &child : this->symbol_map() | std::views::values) {
+      if (first) {
+        if (auto const &sp = child.get().space())
+          this->set_space(*sp);
+        first = false;
+        continue;
+      }
+      join_child_space(child.get());
+    }
+  }
+
 private:
   void join_child_space(tensor_expression const &child) {
     auto const &child_sp = child.space();

--- a/include/numsim_cas/tensor/simplifier/tensor_simplifier_add.h
+++ b/include/numsim_cas/tensor/simplifier/tensor_simplifier_add.h
@@ -61,6 +61,13 @@ public:
     return get_default();
   }
 
+  // non-add + add --> swap so add is LHS (round-11 review: get_default
+  // nested the rhs add as a single child, so A+(B+C) != (A+B)+C).
+  // n_ary_add overrides this with the real merge, so no swap loop.
+  [[nodiscard]] expr_holder_t dispatch(tensor_add const &) {
+    return algo::m_rhs + algo::m_lhs;
+  }
+
   template <typename Expr> [[nodiscard]] expr_holder_t dispatch(Expr const &) {
     return get_default();
   }

--- a/include/numsim_cas/tensor/simplifier/tensor_simplifier_add.h
+++ b/include/numsim_cas/tensor/simplifier/tensor_simplifier_add.h
@@ -15,6 +15,14 @@ using tensor_traits = domain_traits<tensor_expression>;
 namespace simplifier {
 namespace tensor_detail {
 
+// Deep-compared like-term fold: (c1*T)+(c2*T) -> (c1+c2)*T, T+(c*T) -> (1+c)*T.
+// hash(c*T)==hash(T) by design, so hash equality alone must never merge.
+// Defined in tensor_simplifier_add.cpp where the scalar/tensor operators
+// are visible.
+[[nodiscard]] expression_holder<tensor_expression>
+try_merge_scalar_mul(expression_holder<tensor_expression> const &a,
+                     expression_holder<tensor_expression> const &b);
+
 // Tensor-specific add base: inherits generic add_dispatch for members/zero
 // dispatch, but overrides get_default() and other dispatches that require
 // tensor-specific handling (mul_type is void, add_type needs dim/rank).
@@ -28,10 +36,15 @@ public:
   using algo::algo;
 
   [[nodiscard]] expr_holder_t get_default() {
-    if (algo::m_lhs.get().hash_value() == algo::m_rhs.get().hash_value()) {
+    if (algo::m_lhs == algo::m_rhs) {
       auto constant{make_expression<scalar_constant>(2)};
       return make_expression<tensor_scalar_mul>(std::move(constant),
                                                 std::move(algo::m_rhs));
+    }
+    // Like terms: (c1*T)+(c2*T) → (c1+c2)*T, T+(c*T) → (1+c)*T
+    if (auto merged = try_merge_scalar_mul(algo::m_lhs, algo::m_rhs);
+        merged.is_valid()) {
+      return merged;
     }
     auto add_new{make_expression<tensor_add>(algo::m_lhs.get().dim(),
                                              algo::m_rhs.get().rank())};
@@ -42,7 +55,7 @@ public:
   }
 
   [[nodiscard]] expr_holder_t dispatch(tensor_negative const &expr) {
-    if (algo::m_lhs.get().hash_value() == expr.expr().get().hash_value()) {
+    if (algo::m_lhs == expr.expr()) {
       return tensor_traits::zero(algo::m_lhs);
     }
     return get_default();

--- a/include/numsim_cas/tensor/simplifier/tensor_simplifier_mul.h
+++ b/include/numsim_cas/tensor/simplifier/tensor_simplifier_mul.h
@@ -38,7 +38,7 @@ public:
 
 protected:
   expr_holder_t get_default() {
-    if (m_lhs.get().hash_value() == m_rhs.get().hash_value()) {
+    if (m_lhs == m_rhs) {
       return pow(std::move(m_lhs), 2);
     }
     auto mul_new{

--- a/include/numsim_cas/tensor/simplifier/tensor_simplifier_sub.h
+++ b/include/numsim_cas/tensor/simplifier/tensor_simplifier_sub.h
@@ -3,6 +3,7 @@
 
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/core/operators.h>
+#include <numsim_cas/functions.h>
 #include <numsim_cas/tensor/tensor_definitions.h>
 #include <numsim_cas/tensor/tensor_expression.h>
 #include <numsim_cas/tensor/tensor_std.h>
@@ -32,12 +33,30 @@ protected:
 #undef NUMSIM_ADD_OVR
 
   // rhs is negative
-  auto get_default() {
+  expr_holder_t get_default() {
+    // copy an add lhs (pushing it wholesale would nest, round-9 review);
+    // signed insert so X-(-X) combines instead of hitting the dup assert
     auto add_new{
-        make_expression<tensor_add>(m_lhs.get().dim(), m_lhs.get().rank())};
+        is_same<tensor_add>(m_lhs)
+            ? make_expression<tensor_add>(m_lhs.template get<tensor_add>())
+            : make_expression<tensor_add>(m_lhs.get().dim(),
+                                          m_lhs.get().rank())};
     auto &add{add_new.template get<tensor_add>()};
-    add.push_back(m_lhs);
-    add.push_back(-m_rhs);
+    if (!is_same<tensor_add>(m_lhs)) {
+      add.push_back(m_lhs);
+    }
+    add_insert_signed(add, -m_rhs, [](expr_holder_t const &e) {
+      return is_same<tensor_zero>(e);
+    });
+    add.invalidate_hash();
+    add.recompute_space();
+    if (add.size() == 0) {
+      return make_expression<tensor_zero>(m_lhs.get().dim(),
+                                          m_lhs.get().rank());
+    }
+    if (add.size() == 1 && !add.coeff().is_valid()) {
+      return add.symbol_map().begin()->second;
+    }
     return add_new;
   }
 

--- a/include/numsim_cas/tensor/visitors/tensor_differentiation.h
+++ b/include/numsim_cas/tensor/visitors/tensor_differentiation.h
@@ -67,7 +67,7 @@ public:
   // --- Simple nodes defined in header ---
 
   void operator()(tensor const &visitable) override {
-    if (visitable.hash_value() == m_arg.get().hash_value()) {
+    if (visitable == m_arg.get()) {
       if (m_rank_arg == 2) {
         if (auto const &sp = m_arg.get().space()) {
           auto kind = classify_space(*sp);

--- a/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_add.h
+++ b/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_add.h
@@ -45,6 +45,10 @@ public:
   // domain-specific: scalar_wrapper dispatch (numeric → base, else find/merge)
   expr_holder_t dispatch(tensor_to_scalar_scalar_wrapper const &rhs);
 
+  // domain-specific: -wrapper(s) normalizes to wrapper(-s) so it merges
+  // with the scalar_wrapper path instead of hash-based child cancellation
+  expr_holder_t dispatch(tensor_to_scalar_negative const &rhs);
+
   // Generic fallback: find in hash_map, combine or push_back
   // (symbol_type is void for t2s, so the base symbol dispatch is disabled)
   // Body defined in .cpp to keep operator+ ADL in that TU.

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_printer.h
@@ -149,6 +149,10 @@ public:
       apply(child, precedence);
       first = false;
     }
+    if (first) {
+      // all children went to the denominator: print "1/..."
+      m_out << "1";
+    }
 
     if (!denom.empty()) {
       // scalar-like bases first for consistent ordering

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
@@ -95,6 +95,22 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
   return expr_mul;
 }
 
+n_ary_mul::expr_holder_t n_ary_mul::push_or_combine_child() {
+  auto expr_mul{make_expression<scalar_mul>(m_lhs_node)};
+  auto &mul{expr_mul.template get<scalar_mul>()};
+  // an identical factor may already exist (sin(z)*x * sin(z)); a raw
+  // push_back would hit the no-duplicates assert — combine to a pow
+  auto pos{m_lhs_node.symbol_map().find(m_rhs)};
+  if (pos != m_lhs_node.symbol_map().end() && pos->second == m_rhs) {
+    auto combined{pos->second * m_rhs};
+    mul.symbol_map().erase(m_rhs);
+    mul.invalidate_hash();
+    return std::move(expr_mul) * combined;
+  }
+  mul.push_back(m_rhs);
+  return expr_mul;
+}
+
 // (x*y*z)*(x*y*z)
 n_ary_mul::expr_holder_t
 n_ary_mul::dispatch([[maybe_unused]] scalar_mul const &rhs) {

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
@@ -50,6 +50,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar const &rhs) {
   if (pos != m_lhs_node.symbol_map().end()) {
     auto expr{pos->second * m_rhs};
     mul.symbol_map().erase(m_rhs);
+    mul.invalidate_hash();
     mul.push_back(expr);
     return expr_mul;
   }
@@ -58,6 +59,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar const &rhs) {
   for (const auto &expr : pows) {
     if (expr.get<scalar_pow>().expr_lhs() == m_rhs) {
       mul.symbol_map().erase(expr);
+      mul.invalidate_hash();
       expr_mul = std::move(expr_mul) * (expr * m_rhs);
       return expr_mul;
     }
@@ -76,6 +78,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
   const auto &smap{m_lhs_node.symbol_map()};
   if (smap.contains(rhs.expr_lhs())) {
     mul.symbol_map().erase(rhs.expr_lhs());
+    mul.invalidate_hash();
     expr_mul = std::move(expr_mul) *
                pow(rhs.expr_lhs(), rhs.expr_rhs() + get_scalar_one());
     return expr_mul;
@@ -86,6 +89,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
     if (auto pow{simplify_scalar_pow_pow_mul(expr.template get<scalar_pow>(),
                                              rhs)}) {
       mul.symbol_map().erase(expr);
+      mul.invalidate_hash();
       expr_mul = std::move(expr_mul) * std::move(*pow);
       return expr_mul;
     }
@@ -145,6 +149,7 @@ exp_mul::expr_holder_t exp_mul::dispatch(scalar_mul const &rhs) {
   const auto exps{get_all<scalar_exp>(rhs)};
   for (const auto &e : exps) {
     mul.symbol_map().erase(e);
+    mul.invalidate_hash();
     expr_mul = std::move(expr_mul) *
                exp(m_lhs_node.expr() + e.template get<scalar_exp>().expr());
     return expr_mul;
@@ -165,6 +170,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_exp const &rhs) {
   const auto exps{get_all<scalar_exp>(m_lhs_node)};
   for (const auto &e : exps) {
     mul.symbol_map().erase(e);
+    mul.invalidate_hash();
     expr_mul = std::move(expr_mul) *
                exp(e.template get<scalar_exp>().expr() + rhs.expr());
     return expr_mul;
@@ -222,6 +228,7 @@ scalar_pow_mul::dispatch([[maybe_unused]] scalar_mul const &rhs) {
   const auto &smap{rhs.symbol_map()};
   if (smap.contains(m_lhs_node.expr_lhs())) {
     mul.symbol_map().erase(m_lhs_node.expr_lhs());
+    mul.invalidate_hash();
     expr_mul =
         std::move(expr_mul) *
         pow(m_lhs_node.expr_lhs(), m_lhs_node.expr_rhs() + get_scalar_one());
@@ -233,6 +240,7 @@ scalar_pow_mul::dispatch([[maybe_unused]] scalar_mul const &rhs) {
     if (auto pow{simplify_scalar_pow_pow_mul(
             m_lhs_node, expr.template get<scalar_pow>())}) {
       mul.symbol_map().erase(expr);
+      mul.invalidate_hash();
       expr_mul = std::move(expr_mul) * std::move(*pow);
       return expr_mul;
     }
@@ -266,6 +274,7 @@ symbol_mul::dispatch([[maybe_unused]] scalar_mul const &rhs) {
     // auto expr{binary_scalar_mul_simplify(pos->second, m_lhs)};
     auto expr{pos->second * m_lhs};
     mul.symbol_map().erase(m_lhs);
+    mul.invalidate_hash();
     mul.push_back(expr);
     return expr_mul;
   }

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_sub.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_sub.cpp
@@ -39,16 +39,16 @@ sub_base::expr_holder_t sub_base::dispatch(scalar_one const &) {
   return _rhs.accept(visitor);
 }
 
-// 0 - expr
+// 0 - expr (operator- so -0/-(-x) normalize, round-7 review)
 sub_base::expr_holder_t sub_base::dispatch(scalar_zero const &) {
-  if (is_same<scalar_zero>(m_rhs))
-    return get_scalar_zero();
-  return make_expression<scalar_negative>(std::move(m_rhs));
+  return -std::move(m_rhs);
 }
 
 // - expr_lhs - expr_rhs --> -(expr_lhs+expr_rhs)
+// operator-, not a raw negative node: the sum may collapse to zero
+// ((-x)-(-x)) and neg(zero) defeats every zero-singleton filter.
 sub_base::expr_holder_t sub_base::dispatch(scalar_negative const &lhs) {
-  return make_expression<scalar_negative>(lhs.expr() + std::move(m_rhs));
+  return -(lhs.expr() + std::move(m_rhs));
 }
 
 } // namespace simplifier

--- a/src/numsim_cas/scalar/visitors/scalar_printer.cpp
+++ b/src/numsim_cas/scalar/visitors/scalar_printer.cpp
@@ -85,7 +85,7 @@ void scalar_printer<Stream>::operator()(scalar_mul const &visitable) {
   bool first = true;
   if (visitable.coeff().is_valid()) {
     apply(visitable.coeff(), precedence);
-    m_out << "*";
+    first = false;
   }
   for (auto &child : sorted_map | std::views::values) {
     if (!first)
@@ -93,20 +93,31 @@ void scalar_printer<Stream>::operator()(scalar_mul const &visitable) {
     apply(child, precedence);
     first = false;
   }
+  if (first) {
+    // all children went to the denominator: print "1/..."
+    m_out << "1";
+  }
 
   if (!denom.empty()) {
     m_out << "/";
-    for (auto &entry : denom) {
-      if (entry.pos_exponent != scalar_number{1}) {
+    const bool multi = denom.size() > 1;
+    if (multi)
+      m_out << "(";
+    for (std::size_t i = 0; i < denom.size(); ++i) {
+      if (i > 0)
+        m_out << "*";
+      if (denom[i].pos_exponent != scalar_number{1}) {
         m_out << "pow(";
-        apply(entry.base);
+        apply(denom[i].base);
         m_out << ",";
-        m_out << entry.pos_exponent;
+        m_out << denom[i].pos_exponent;
         m_out << ")";
       } else {
-        apply(entry.base, Precedence::Division_RHS);
+        apply(denom[i].base, Precedence::Division_RHS);
       }
     }
+    if (multi)
+      m_out << ")";
   }
   end(precedence, parent_precedence);
 }

--- a/src/numsim_cas/tensor/simplifier/tensor_projector_simplifier.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_projector_simplifier.cpp
@@ -135,6 +135,9 @@ void tensor_projector_simplifier::operator()(tensor_add const &v) {
       for (std::size_t j = i + 1; j < entries.size(); ++j) {
         if (consumed[entries[j].child_index])
           continue;
+        // hash groups may alias (hash(c*T)==hash(T)); require deep equality
+        if (!(entries[i].argument == entries[j].argument))
+          continue;
 
         auto combined = addition_rule(entries[i].kind, entries[j].kind);
         if (combined) {

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
@@ -46,11 +46,24 @@ n_ary_add::dispatch([[maybe_unused]] Expr const &rhs) {
   auto expr_add{make_expression<tensor_add>(m_lhs_node)};
   auto &add{expr_add.template get<tensor_add>()};
   auto pos{add.find_like(m_rhs)};
+  if (pos == add.symbol_map().end() && is_same<tensor_scalar_mul>(m_rhs)) {
+    // stored bare T vs incoming c*T: probe the inner tensor (review #340)
+    pos = add.find_like(m_rhs.template get<tensor_scalar_mul>().expr_rhs());
+  }
   if (pos != add.symbol_map().end()) {
     auto combined{pos->second + m_rhs};
     add.symbol_map().erase(pos);
-    add.merge_or_insert(std::move(combined));
+    if (!is_same<tensor_zero>(combined)) {
+      add.merge_or_insert(std::move(combined));
+    }
+    add.invalidate_hash();
     add.recompute_space();
+    if (add.size() == 0) {
+      return tensor_traits::zero(m_lhs);
+    }
+    if (add.size() == 1 && !add.coeff().is_valid()) {
+      return add.symbol_map().begin()->second;
+    }
     return expr_add;
   }
   add.push_back(m_rhs);
@@ -74,6 +87,11 @@ n_ary_add::dispatch(tensor_negative const &rhs) {
     auto expr{make_expression<tensor_add>(m_lhs_node)};
     auto &add{expr.template get<tensor_add>()};
     add.symbol_map().erase(expr_rhs);
+    add.invalidate_hash();
+    add.recompute_space();
+    if (add.size() == 1 && !add.coeff().is_valid()) {
+      return add.symbol_map().begin()->second;
+    }
     return expr;
   }
   return get_default();

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
@@ -74,8 +74,18 @@ n_ary_add::dispatch([[maybe_unused]] Expr const &rhs) {
 n_ary_add::dispatch(tensor_add const &rhs) {
   auto expr{make_expression<tensor_add>(rhs.dim(), rhs.rank())};
   auto &add{expr.template get<tensor_add>()};
-  merge_add(m_lhs_node, rhs, add);
+  // zero filter + collapse: childwise combines may fully cancel
+  // ((A+B)+(C-A) left a literal 0{2} child, round-8 review)
+  merge_add(m_lhs_node, rhs, add,
+            [](expr_holder_t const &e) { return is_same<tensor_zero>(e); });
+  add.invalidate_hash();
   add.recompute_space();
+  if (add.size() == 0) {
+    return tensor_traits::zero(m_lhs);
+  }
+  if (add.size() == 1 && !add.coeff().is_valid()) {
+    return add.symbol_map().begin()->second;
+  }
   return expr;
 }
 

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
@@ -54,7 +54,11 @@ n_ary_add::dispatch([[maybe_unused]] Expr const &rhs) {
     auto combined{pos->second + m_rhs};
     add.symbol_map().erase(pos);
     if (!is_same<tensor_zero>(combined)) {
-      add.merge_or_insert(std::move(combined));
+      // signed insert: the combined term may exactly negate another child
+      // ((5A-2A)+(-3A) left a {2A,-(2A)} pair, round-9 review)
+      add_insert_signed(add, std::move(combined), [](expr_holder_t const &e) {
+        return is_same<tensor_zero>(e);
+      });
     }
     add.invalidate_hash();
     add.recompute_space();
@@ -104,7 +108,22 @@ n_ary_add::dispatch(tensor_negative const &rhs) {
     }
     return expr;
   }
-  return get_default();
+  // non-cancelling -t: insert into a copy — get_default would nest the
+  // whole lhs add as a single child (round-9 review)
+  auto expr{make_expression<tensor_add>(m_lhs_node)};
+  auto &add{expr.template get<tensor_add>()};
+  add_insert_signed(add, m_rhs, [](expr_holder_t const &e) {
+    return is_same<tensor_zero>(e);
+  });
+  add.invalidate_hash();
+  add.recompute_space();
+  if (add.size() == 0) {
+    return tensor_traits::zero(m_lhs);
+  }
+  if (add.size() == 1 && !add.coeff().is_valid()) {
+    return add.symbol_map().begin()->second;
+  }
+  return expr;
 }
 
 // ------------------------------------------------------------

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
@@ -9,6 +9,30 @@ namespace numsim::cas {
 namespace simplifier {
 namespace tensor_detail {
 
+[[nodiscard]] expression_holder<tensor_expression>
+try_merge_scalar_mul(expression_holder<tensor_expression> const &a,
+                     expression_holder<tensor_expression> const &b) {
+  using expr_holder_t = expression_holder<tensor_expression>;
+  const bool a_mul{is_same<tensor_scalar_mul>(a)};
+  const bool b_mul{is_same<tensor_scalar_mul>(b)};
+  if (a_mul && b_mul) {
+    auto const &am{a.get<tensor_scalar_mul>()};
+    auto const &bm{b.get<tensor_scalar_mul>()};
+    if (am.expr_rhs() == bm.expr_rhs()) {
+      return (am.expr_lhs() + bm.expr_lhs()) * am.expr_rhs();
+    }
+    return expr_holder_t{};
+  }
+  if (a_mul || b_mul) {
+    auto const &m{(a_mul ? a : b).get<tensor_scalar_mul>()};
+    auto const &other{a_mul ? b : a};
+    if (m.expr_rhs() == other) {
+      return (m.expr_lhs() + 1) * m.expr_rhs();
+    }
+  }
+  return expr_holder_t{};
+}
+
 // ------------------------------------------------------------
 // n_ary_add
 // ------------------------------------------------------------
@@ -21,10 +45,12 @@ template <typename Expr>
 n_ary_add::dispatch([[maybe_unused]] Expr const &rhs) {
   auto expr_add{make_expression<tensor_add>(m_lhs_node)};
   auto &add{expr_add.template get<tensor_add>()};
-  auto pos{m_lhs_node.symbol_map().find(m_rhs)};
-  if (pos != m_lhs_node.symbol_map().end()) {
-    add.symbol_map().erase(m_rhs);
-    add.push_back(pos->second + m_rhs);
+  auto pos{add.find_like(m_rhs)};
+  if (pos != add.symbol_map().end()) {
+    auto combined{pos->second + m_rhs};
+    add.symbol_map().erase(pos);
+    add.merge_or_insert(std::move(combined));
+    add.recompute_space();
     return expr_add;
   }
   add.push_back(m_rhs);
@@ -36,6 +62,7 @@ n_ary_add::dispatch(tensor_add const &rhs) {
   auto expr{make_expression<tensor_add>(rhs.dim(), rhs.rank())};
   auto &add{expr.template get<tensor_add>()};
   merge_add(m_lhs_node, rhs, add);
+  add.recompute_space();
   return expr;
 }
 
@@ -61,7 +88,7 @@ symbol_add::symbol_add(expr_holder_t lhs, expr_holder_t rhs)
 
 [[nodiscard]] symbol_add::expr_holder_t
 symbol_add::dispatch(tensor const &rhs) {
-  if (&m_lhs_node == &rhs) {
+  if (m_lhs_node == rhs) {
     return make_expression<tensor_scalar_mul>(
         make_expression<scalar_constant>(2), m_rhs);
   }
@@ -87,8 +114,7 @@ tensor_scalar_mul_add::dispatch(Expr const & /*rhs*/) {
 
 [[nodiscard]] tensor_scalar_mul_add::expr_holder_t
 tensor_scalar_mul_add::dispatch(tensor_scalar_mul const &rhs) {
-  if (m_lhs_node.expr_rhs().get().hash_value() ==
-      rhs.expr_rhs().get().hash_value()) {
+  if (m_lhs_node.expr_rhs() == rhs.expr_rhs()) {
     return (m_lhs_node.expr_lhs() + rhs.expr_lhs()) * rhs.expr_rhs();
   }
   return get_default();
@@ -97,8 +123,7 @@ tensor_scalar_mul_add::dispatch(tensor_scalar_mul const &rhs) {
 // (s*T) + (-T) → (s-1)*T
 [[nodiscard]] tensor_scalar_mul_add::expr_holder_t
 tensor_scalar_mul_add::dispatch(tensor_negative const &rhs) {
-  if (m_lhs_node.expr_rhs().get().hash_value() ==
-      rhs.expr().get().hash_value()) {
+  if (m_lhs_node.expr_rhs() == rhs.expr()) {
     return (m_lhs_node.expr_lhs() - 1) * m_lhs_node.expr_rhs();
   }
   return get_default();
@@ -119,8 +144,7 @@ add_negative::dispatch(tensor_negative const &rhs) {
 // (-T) + (s*T) → (s-1)*T
 [[nodiscard]] add_negative::expr_holder_t
 add_negative::dispatch(tensor_scalar_mul const &rhs) {
-  if (m_lhs_node.expr().get().hash_value() ==
-      rhs.expr_rhs().get().hash_value()) {
+  if (m_lhs_node.expr() == rhs.expr_rhs()) {
     return (rhs.expr_lhs() - 1) * rhs.expr_rhs();
   }
   return get_default();
@@ -171,8 +195,7 @@ add_base::dispatch(inner_product_wrapper const &) {
     auto k_lhs = classify(*lhs_info->proj);
     auto k_rhs = classify(*rhs_info->proj);
     if (k_lhs != ProjKind::Other && k_rhs != ProjKind::Other &&
-        lhs_info->argument.get().hash_value() ==
-            rhs_info->argument.get().hash_value()) {
+        lhs_info->argument == rhs_info->argument) {
       auto combined = addition_rule(k_lhs, k_rhs);
       if (combined)
         return apply_projection(*combined, lhs_info->argument);

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_add.cpp
@@ -70,7 +70,19 @@ n_ary_add::dispatch([[maybe_unused]] Expr const &rhs) {
     }
     return expr_add;
   }
-  add.push_back(m_rhs);
+  // miss path: an exact -rhs child must still cancel (round-10 review;
+  // ((A+B)-C)+C kept a {C,-C} pair via raw push_back)
+  add_insert_signed(add, m_rhs, [](expr_holder_t const &e) {
+    return is_same<tensor_zero>(e);
+  });
+  add.invalidate_hash();
+  add.recompute_space();
+  if (add.size() == 0) {
+    return tensor_traits::zero(m_lhs);
+  }
+  if (add.size() == 1 && !add.coeff().is_valid()) {
+    return add.symbol_map().begin()->second;
+  }
   return expr_add;
 }
 

--- a/src/numsim_cas/tensor/simplifier/tensor_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor/simplifier/tensor_simplifier_mul.cpp
@@ -13,7 +13,8 @@ tensor_pow_mul::tensor_pow_mul(expr_holder_t lhs, expr_holder_t rhs)
 
 tensor_pow_mul::expr_holder_t
 tensor_pow_mul::dispatch([[maybe_unused]] tensor const &rhs) {
-  if (m_lhs_node.expr_lhs().get().hash_value() == rhs.hash_value()) {
+  // hash(c*T)==hash(T) by design, so compare the base expression deeply
+  if (m_lhs_node.expr_lhs() == m_rhs) {
     const auto rhs_expr{m_lhs_node.expr_rhs() + get_scalar_one()};
     return make_expression<tensor_pow>(m_lhs_node.expr_lhs(), rhs_expr);
   }
@@ -22,7 +23,8 @@ tensor_pow_mul::dispatch([[maybe_unused]] tensor const &rhs) {
 
 tensor_pow_mul::expr_holder_t
 tensor_pow_mul::dispatch([[maybe_unused]] tensor_pow const &rhs) {
-  if (m_lhs_node.hash_value() == rhs.hash_value()) {
+  // pow hashes alias their base's hash; deep-compare the bases
+  if (m_lhs_node.expr_lhs() == rhs.expr_lhs()) {
     const auto rhs_expr{m_lhs_node.expr_rhs() + rhs.expr_rhs()};
     return make_expression<tensor_pow>(m_lhs_node.expr_lhs(), rhs_expr);
   }
@@ -58,7 +60,8 @@ symbol_mul::expr_holder_t symbol_mul::dispatch(tensor const &rhs) {
 
 /// X * pow(X,expr) --> pow(X,expr+1)
 symbol_mul::expr_holder_t symbol_mul::dispatch(tensor_pow const &rhs) {
-  if (m_lhs_node.hash_value() == rhs.expr_lhs().get().hash_value()) {
+  // hash(pow(c*X,e))==hash(X) can alias; deep-compare the pow base
+  if (m_lhs == rhs.expr_lhs()) {
     return pow(m_lhs, rhs.expr_rhs() + get_scalar_one());
   }
   return get_default();

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_add.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_add.cpp
@@ -61,8 +61,21 @@ n_ary_add::dispatch(tensor_to_scalar_scalar_wrapper const &rhs) {
     auto wrapper =
         make_expression<tensor_to_scalar_scalar_wrapper>(std::move(merged));
     auto val = Traits::try_numeric(wrapper);
-    if (!val || *val != scalar_number{0}) {
+    if (!val) {
       add.push_back(std::move(wrapper));
+    } else if (*val != scalar_number{0}) {
+      // numeric result belongs in the coeff (canonical form), not a child
+      if (add.coeff().is_valid()) {
+        auto new_coeff = add.coeff() + wrapper;
+        auto cval = Traits::try_numeric(new_coeff);
+        if (cval && *cval == scalar_number{0}) {
+          add.coeff().free();
+        } else {
+          add.set_coeff(std::move(new_coeff));
+        }
+      } else {
+        add.set_coeff(std::move(wrapper));
+      }
     }
     // round-2 review: a cancelled wrapper left an uncollapsed
     // single-child add with a stale cached hash
@@ -70,6 +83,19 @@ n_ary_add::dispatch(tensor_to_scalar_scalar_wrapper const &rhs) {
   }
   add.push_back(m_rhs);
   return expr_add;
+}
+
+// ------------------------------------------------------------
+// n_ary_add — negative scalar_wrapper normalization (round-5 sweep)
+// ------------------------------------------------------------
+n_ary_add::expr_holder_t
+n_ary_add::dispatch(tensor_to_scalar_negative const &rhs) {
+  if (is_same<tensor_to_scalar_scalar_wrapper>(rhs.expr())) {
+    auto &w = rhs.expr().template get<tensor_to_scalar_scalar_wrapper>();
+    m_rhs = make_expression<tensor_to_scalar_scalar_wrapper>(-w.expr());
+    return dispatch(m_rhs.template get<tensor_to_scalar_scalar_wrapper>());
+  }
+  return algo::dispatch(rhs);
 }
 
 // ------------------------------------------------------------

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_sub.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_sub.cpp
@@ -113,16 +113,17 @@ sub_base::expr_holder_t sub_base::dispatch(tensor_to_scalar_add const &) {
   return _rhs.accept(visitor);
 }
 
-// 0 - expr
+// 0 - expr (operator- so -0/-(-x)/-wrapper normalize, round-7 review)
 sub_base::expr_holder_t sub_base::dispatch(tensor_to_scalar_zero const &) {
-  return make_expression<tensor_to_scalar_negative>(std::move(m_rhs));
+  return -std::move(m_rhs);
 }
 
 // -expr_lhs - expr_rhs --> -(expr_lhs+expr_rhs)
+// operator-, not a raw negative node: the sum may collapse to zero and
+// neg(zero) defeats every zero-singleton filter.
 sub_base::expr_holder_t
 sub_base::dispatch(tensor_to_scalar_negative const &lhs) {
-  return make_expression<tensor_to_scalar_negative>(lhs.expr() +
-                                                    std::move(m_rhs));
+  return -(lhs.expr() + std::move(m_rhs));
 }
 
 sub_base::expr_holder_t

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_sub.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_sub.cpp
@@ -57,8 +57,22 @@ n_ary_sub::dispatch(tensor_to_scalar_scalar_wrapper const &rhs) {
     auto wrapper =
         make_expression<tensor_to_scalar_scalar_wrapper>(std::move(merged));
     auto val = Traits::try_numeric(wrapper);
-    if (!val || *val != scalar_number{0}) {
+    if (!val) {
       add.push_back(std::move(wrapper));
+    } else if (*val != scalar_number{0}) {
+      // numeric result belongs in the coeff (canonical form), not a child
+      // (round-6 review: mirror of the add-side fold)
+      if (add.coeff().is_valid()) {
+        auto new_coeff = add.coeff() + wrapper;
+        auto cval = Traits::try_numeric(new_coeff);
+        if (cval && *cval == scalar_number{0}) {
+          add.coeff().free();
+        } else {
+          add.set_coeff(std::move(new_coeff));
+        }
+      } else {
+        add.set_coeff(std::move(wrapper));
+      }
     }
     // round-2 review: mirror of the add-side collapse
     return detail::finalize_add<Traits>(std::move(expr_add));

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.cpp
@@ -1,5 +1,6 @@
 #include <numsim_cas/basic_functions.h>
 #include <numsim_cas/core/tag_invoke.h>
+#include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_positivity_propagation.h>
@@ -18,6 +19,13 @@ tag_invoke(detail::neg_fn, std::type_identity<tensor_to_scalar_expression>,
   // -(-x) = x — preserves x's existing assumptions automatically.
   if (is_same<tensor_to_scalar_negative>(e)) {
     return e.get<tensor_to_scalar_negative>().expr();
+  }
+
+  // -w(s) = w(-s): a negative wrapper and a wrapped negative are the same
+  // value; normalize to one shape so identity checks agree (round-7 review).
+  if (is_same<tensor_to_scalar_scalar_wrapper>(e)) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(
+        -e.get<tensor_to_scalar_scalar_wrapper>().expr());
   }
 
   // #260 — capture operand sign before building the node, then flip it.

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1395,6 +1395,57 @@ TEST(RoundSixReview, T2sSubWrapperMergeFoldsToCoeff) {
   EXPECT_EQ(to_string(e1 - w(c2)), "tr(A)");
 }
 
+// Round-7 review: negative(zero) minting, negative-wrapper duals, and
+// missing negation-pair cancellation in add merges.
+
+// R7-1: -e1 - e2 built a raw negative node; a fully-cancelling sum minted
+// negative(zero), defeating every zero-singleton filter.
+TEST(RoundSevenReview, NegativeLhsSubNormalizesZero) {
+  auto [x, y, z] = make_scalar_variable("x", "y", "z");
+  auto e1 = (-x) - (-x);
+  EXPECT_TRUE(is_same<scalar_zero>(e1)) << to_string(e1);
+  auto e2 = (z - y) - (x - y);
+  EXPECT_TRUE(*e2 == *(z - x)) << to_string(e2);
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto t = (-trace(A)) - (-trace(A));
+  EXPECT_TRUE(is_same<tensor_to_scalar_zero>(t)) << to_string(t);
+}
+
+// R7-2: -w(a) and w(-a) are the same value; neg_fn now normalizes so both
+// build routes agree and round-trip cancellation works.
+TEST(RoundSevenReview, T2sNegativeWrapperNormalized) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto [a] = make_scalar_variable("a");
+  auto w = [](auto e) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(e);
+  };
+  auto base = trace(A) + det(A);
+  auto e1 = base + (-w(a));
+  auto e2 = base - w(a);
+  EXPECT_TRUE(*e1 == *e2) << to_string(e1) << " vs " << to_string(e2);
+  auto e3 = (base - w(a)) + w(a);
+  EXPECT_TRUE(*e3 == *base) << to_string(e3);
+}
+
+// R7-4: negation pairs share no hash, so (3-x)+x and (3+x)+(1-x) never
+// cancelled; find_like now retries with the exact negation.
+TEST(RoundSevenReview, AddCancelsAgainstNegativeChild) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  EXPECT_EQ(to_string((3.0 - x) + x), "3");
+  EXPECT_EQ(to_string((3.0 + x) + (1.0 - x)), "4");
+  auto e = (y - x) + (x + 2.0);
+  EXPECT_TRUE(*e == *(y + 2.0)) << to_string(e);
+  // t2s merged-wrapper interiors reduce through the same path
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto [a] = make_scalar_variable("a");
+  auto w = [](auto ex) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(ex);
+  };
+  auto f = (trace(A) + w(a + 3.0)) + w(1.0 - a);
+  auto c4 = make_expression<scalar_constant>(4);
+  EXPECT_TRUE(*f == *(trace(A) + w(c4))) << to_string(f);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1540,6 +1540,22 @@ TEST(RoundTenReview, TensorAddCancelsExactNegativeChild) {
   EXPECT_TRUE(*e4 == *(A + B)) << to_string(e4);
 }
 
+// Round-11 review: tensor non-add + add nested the rhs add as one child
+// (the swap-to-n-ary dispatch was guarded on a non-void mul_type), so
+// A+(B+C) and (A+B)+C were different trees.
+TEST(RoundElevenReview, TensorAddRhsFlattens) {
+  auto [A, B, C] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2},
+                                        std::tuple{"B", std::size_t{3}, 2},
+                                        std::tuple{"C", std::size_t{3}, 2});
+  EXPECT_TRUE(*(A + (B + C)) == *((A + B) + C));
+  EXPECT_TRUE(*(2.0 * C + (A + B)) == *((A + B) + 2.0 * C));
+  EXPECT_TRUE(*(trans(C) + (A + B)) == *((A + B) + trans(C)));
+  EXPECT_TRUE(*((-C) + (A + B)) == *((A + B) - C));
+  EXPECT_TRUE(is_same<tensor_zero>((A + (B + C)) - (A + B + C)));
+  auto e = (A + (B + C)) + B;
+  EXPECT_TRUE(*e == *(A + 2.0 * B + C)) << to_string(e);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1524,6 +1524,22 @@ TEST(RoundNineReview, MergeAddDropsCancelledCoeff) {
   EXPECT_TRUE(*t == *(trace(A) + det(A))) << to_string(t);
 }
 
+// Round-10 review: the tensor n-ary add fallback was the last insertion
+// path without the exact-negation probe — ((A+B)-C)+C kept {C,-C}.
+TEST(RoundTenReview, TensorAddCancelsExactNegativeChild) {
+  auto [A, B, C] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2},
+                                        std::tuple{"B", std::size_t{3}, 2},
+                                        std::tuple{"C", std::size_t{3}, 2});
+  auto e1 = ((A + B) - C) + C;
+  EXPECT_TRUE(*e1 == *(A + B)) << to_string(e1);
+  auto e2 = (A - C) + C;
+  EXPECT_TRUE(*e2 == *A) << to_string(e2);
+  auto e3 = ((A + B) - 2.0 * C) + 2.0 * C;
+  EXPECT_TRUE(*e3 == *(A + B)) << to_string(e3);
+  auto e4 = ((A + B) - trans(C)) + trans(C);
+  EXPECT_TRUE(*e4 == *(A + B)) << to_string(e4);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1117,7 +1117,58 @@ TEST(RoundTwoReview, T2sWrapperCancelCollapses) {
   auto e2 = (trace(A) + w(a)) - w(a);
   EXPECT_TRUE(*e2 == *trace(A));
 }
+// #340 — raw hash_value() comparisons replaced by deep equality / explicit
+// like-term folds. hash(c*X)==hash(X) and hash(pow(X,c))==hash(X) stay by
+// design; they must never merge without a deep check.
+TEST(HashIdentitySweep, TensorAddNoFalseMerges) {
+  auto [X] = make_tensor_variable(std::tuple{"X", 3, 2});
+  EXPECT_EQ(to_string(X + pow(X, 2)), "X+pow(X,2)");
+  EXPECT_EQ(to_string(X + 2.0 * X), "3*X");
+  EXPECT_EQ(to_string(2.0 * X + 3.0 * X), "5*X");
+  EXPECT_NE(to_string(X + (-pow(X, 2))), "0{2}");
+  EXPECT_NE(to_string((-X) + 2.0 * pow(X, 2)), "pow(X,2)");
+}
 
+TEST(HashIdentitySweep, TensorMulNoFalsePow) {
+  auto [X] = make_tensor_variable(std::tuple{"X", 3, 2});
+  // X*(2X) and (2X)*X: the scalar factor must survive
+  EXPECT_EQ(to_string(X * (2.0 * X)).find("pow(2*X"), std::string::npos);
+  auto s1 = to_string(X * (2.0 * X));
+  auto s2 = to_string((2.0 * X) * X);
+  EXPECT_NE(s1.find("2"), std::string::npos);
+  EXPECT_NE(s2.find("2"), std::string::npos);
+  // exact same operand still folds to pow
+  EXPECT_EQ(to_string(X * X), "pow(X,2)");
+}
+
+TEST(HashIdentitySweep, ProjectorMergeRequiresSameArgument) {
+  auto [X] = make_tensor_variable(std::tuple{"X", 3, 2});
+  auto e = vol(pow(X, 2)) + dev(X);
+  EXPECT_NE(to_string(e), "sym(pow(X,2))");
+  EXPECT_NE(to_string(e), "sym(X)");
+  // same argument keeps merging
+  EXPECT_EQ(to_string(vol(X) + dev(X)), "sym(X)");
+  EXPECT_EQ(to_string(sym(X) + skew(X)), "X");
+}
+
+TEST(HashIdentitySweep, ScalarSubMaxMinDeepEquality) {
+  auto [x] = make_scalar_variable("x");
+  EXPECT_NE(to_string(sin(x + 2.0) - sin(x + 5.0)), "0");
+  EXPECT_NE(to_string(max(2.0 * x, 3.0 * x)), "2*x");
+  EXPECT_NE(to_string(min(2.0 * x, 3.0 * x)), "2*x");
+  // exact duplicates still fold
+  EXPECT_EQ(to_string(max(x, x)), "x");
+  EXPECT_EQ(to_string(sin(x + 2.0) - sin(x + 2.0)), "0");
+}
+
+TEST(HashIdentitySweep, TensorAddSpaceJoinSurvivesMerge) {
+  auto [A] = make_tensor_variable(std::tuple{"A", 3, 2});
+  auto [B] = make_tensor_variable(std::tuple{"B", 3, 2});
+  auto sa = sym(A);
+  auto sb = sym(B);
+  EXPECT_TRUE(is_symmetric(sa + sb));
+  // like-term merge path keeps the join
+  EXPECT_TRUE(is_symmetric((sa + sb) + 2.0 * sa));}
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1485,6 +1485,45 @@ TEST(RoundEightReview, TensorMergeAddZeroFiltered) {
   EXPECT_TRUE(is_same<tensor_zero>(e3)) << to_string(e3);
 }
 
+// Round-9 review: nested adds from the negative fall-through, one
+// unconverted tensor insert, and a literal zero coefficient.
+
+// R9-1: add + (-t) with a non-cancelling t fell to get_default, which
+// nested the whole lhs add as a single child; buried terms then defeated
+// merge cancellation.
+TEST(RoundNineReview, AddNegativeStaysFlat) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto e = (x + 5.0 * y) + (-y);
+  // flat children: the exact 5*y child stays reachable for cancellation
+  auto e2 = e + (-(5.0 * y));
+  EXPECT_TRUE(*e2 == *(x - y)) << to_string(e2);
+  auto [A, B, C] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2},
+                                        std::tuple{"B", std::size_t{3}, 2},
+                                        std::tuple{"C", std::size_t{3}, 2});
+  auto t = (A + B) + ((C - A) - B);
+  EXPECT_TRUE(*t == *C) << to_string(t);
+  EXPECT_TRUE(is_same<tensor_zero>(t - C)) << to_string(t - C);
+}
+
+// R9-2: the tensor n-ary fallback still plain-inserted the combined term;
+// (5A-2A)+(-3A) held an exact {2A, -(2A)} pair instead of collapsing.
+TEST(RoundNineReview, TensorCombinedInsertIsSigned) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto e = (5.0 * A + (-(2.0 * A))) + (-3.0) * A;
+  EXPECT_TRUE(is_same<tensor_zero>(e)) << to_string(e);
+}
+
+// R9-3: merge_add stored a cancelled coefficient as a literal zero —
+// (2+x)+(y-2) printed "0+x+y" and compared unequal to x+y.
+TEST(RoundNineReview, MergeAddDropsCancelledCoeff) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto e = (2.0 + x) + (y - 2.0);
+  EXPECT_TRUE(*e == *(x + y)) << to_string(e);
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto t = (2.0 + trace(A)) + (det(A) - 2.0);
+  EXPECT_TRUE(*t == *(trace(A) + det(A))) << to_string(t);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1446,6 +1446,45 @@ TEST(RoundSevenReview, AddCancelsAgainstNegativeChild) {
   EXPECT_TRUE(*f == *(trace(A) + w(c4))) << to_string(f);
 }
 
+// Round-8 review: regressions from the round-7 negation probe.
+
+// R8-1: merge_add consumed the same rhs child twice when the lhs held an
+// exact {t,-t} pair — 5x neg-matched -(5x), then -(5x) direct-matched it
+// again, turning y-5x into y-10x. Also kills the enabler: signed inserts
+// keep {t,-t} from coexisting at all.
+TEST(RoundEightReview, MergeAddNoDoubleConsume) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto f = (2.0 * x + (-(5.0 * x))) + 3.0 * x;
+  EXPECT_TRUE(is_same<scalar_zero>(f)) << to_string(f);
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  ev.set(y, 0.0);
+  EXPECT_DOUBLE_EQ(ev.apply(f + (y - 5.0 * x)), -5.0);
+  // an add manually holding the exact pair must still merge correctly
+  auto pair_add = make_expression<scalar_add>();
+  auto &pa = pair_add.get<scalar_add>();
+  pa.push_back(5.0 * x);
+  pa.push_back(-(5.0 * x));
+  auto g = pair_add + (y - 5.0 * x);
+  EXPECT_DOUBLE_EQ(ev.apply(g), -5.0) << to_string(g); // was -10
+}
+
+// R8-2: the tensor add-merge got round-7's cancellation power without the
+// zero filter — (A+B)+(C-A) held a literal 0{2} child.
+TEST(RoundEightReview, TensorMergeAddZeroFiltered) {
+  auto [A, B, C] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2},
+                                        std::tuple{"B", std::size_t{3}, 2},
+                                        std::tuple{"C", std::size_t{3}, 2});
+  auto e1 = (A + B) + (C - A);
+  EXPECT_TRUE(*e1 == *(B + C)) << to_string(e1);
+  EXPECT_EQ(to_string(e1).find("0{2}"), std::string::npos) << to_string(e1);
+  auto e2 = e1 - (B + C);
+  EXPECT_TRUE(is_same<tensor_zero>(e2)) << to_string(e2);
+  // full cancellation collapses to the zero singleton, not an empty add
+  auto e3 = (A + B) + ((-A) + (-B));
+  EXPECT_TRUE(is_same<tensor_zero>(e3)) << to_string(e3);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1182,6 +1182,158 @@ TEST(HashIdentitySweep, TensorCancellationAndReverseProbe) {
   EXPECT_EQ(to_string((X + Y) + 2.0 * X), "3*X+Y"); // reverse probe
 }
 
+// Round-5 review: whole-stack cross-check + randomized property sweep.
+// Remaining raw-hash identity holes, a constant-dropping add path, the
+// rank-lexicographic sign test in sub, and fraction-printing defects.
+
+// Sweep bug A: constant + (coeff+x) silently dropped the constant when the
+// coefficients cancelled (returned rhs with its old coeff intact).
+TEST(RoundFiveReview, ConstantPlusAddCancellingCoeff) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto e = 5.0 + (x - 5.0);
+  EXPECT_TRUE(*e == *x);
+  auto e2 = 5.0 + (x + y - 5.0);
+  EXPECT_TRUE(*e2 == *(x + y));
+  auto e3 = get_scalar_one() + (x - 1.0);
+  EXPECT_TRUE(*e3 == *x);
+}
+
+// R5-6: mul+symbol / symbol+mul used a raw map find; hash(x+2)==hash(x)
+// falsely folded 2*(x+2) + x into 3*(x+2).
+TEST(RoundFiveReview, MulAddNoAliasedCoeffFold) {
+  auto [x, z] = make_scalar_variable("x", "z");
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  EXPECT_DOUBLE_EQ(ev.apply(2.0 * (x + 2.0) + x), 7.0); // was 9
+  EXPECT_DOUBLE_EQ(ev.apply(x + 2.0 * (x + 2.0)), 7.0); // was 9
+  EXPECT_EQ(to_string(z + (-1.0) * z), "0");            // was 0*z
+}
+
+// R5-3: (-x) + (y - x) hit the no-duplicates assert in push_back.
+TEST(RoundFiveReview, NegativePlusAddContainingSameNegative) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  expression_holder<scalar_expression> e;
+  EXPECT_NO_THROW(e = (-x) + (y - x));
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  ev.set(y, 5.0);
+  EXPECT_DOUBLE_EQ(ev.apply(e), 3.0);
+}
+
+// R5-1 + R5-2/sweep bug B: c1*expr - c2*expr merged on raw hash equality
+// (falsely matching different children), and classified the sign of the
+// result with rank-lexicographic operator< instead of numeric_less.
+TEST(RoundFiveReview, MulSubDeepEqualityAndSign) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  ev.set(y, 2.0);
+  EXPECT_DOUBLE_EQ(ev.apply(2.0 * (x + 2.0) - 5.0 * (x + 9.0)), -44.0);
+  EXPECT_DOUBLE_EQ(ev.apply(2.0 * y - 2.5 * y), -1.0); // was +1
+  EXPECT_DOUBLE_EQ(ev.apply(2.5 * y - 2.0 * y), 1.0);
+}
+
+// R5-1 latent + R5-2 in symbol - c*expr: same two defects.
+TEST(RoundFiveReview, SymbolMinusScaledAddNoFalseMerge) {
+  auto [x] = make_scalar_variable("x");
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  EXPECT_DOUBLE_EQ(ev.apply(x - 5.0 * (x + 2.0)), -14.0); // was -12
+  EXPECT_EQ(to_string(x - 2.0 * x), "-x");
+  EXPECT_DOUBLE_EQ(ev.apply(x - 2.5 * x), -1.5); // was +1.5
+}
+
+// Sweep bug C companion (scalar side): add + (-aliased_child) erased the
+// wrong map entry because hash(sin(y+2))==hash(sin(y+5)).
+TEST(RoundFiveReview, AddMinusAliasedFunctionChild) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto e = (x + sin(y + 2.0)) + (-sin(y + 5.0));
+  EXPECT_NE(to_string(e), "x");
+  scalar_evaluator<double> ev;
+  ev.set(x, 0.0);
+  ev.set(y, 0.0);
+  EXPECT_DOUBLE_EQ(ev.apply(e), std::sin(2.0) - std::sin(5.0));
+}
+
+// R5-4: tensor pow/mul folds compared raw hashes; hash(c*T)==hash(T) and
+// hash(pow(T,c))==hash(T) made A*pow(2A,2) fold to pow(A,3).
+TEST(RoundFiveReview, TensorPowMulDeepBaseComparison) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  EXPECT_NE(to_string(A * pow(2.0 * A, 2)), "pow(A,3)");
+  EXPECT_NE(to_string(pow(2.0 * A, 2) * A), "pow(A,3)");
+  EXPECT_NE(to_string(pow(A, 2) * pow(2.0 * A, 3)), "pow(A,5)");
+  EXPECT_EQ(to_string(A * pow(A, 2)), "pow(A,3)");
+  EXPECT_EQ(to_string(pow(A, 2) * A), "pow(A,3)");
+  EXPECT_EQ(to_string(pow(A, 2) * pow(A, 3)), "pow(A,5)");
+}
+
+// R5-5: fraction printing — trailing "*" before "/", glued denominator
+// factors, missing "1" numerator, and rank-lexicographic classification of
+// negative double exponents.
+TEST(RoundFiveReview, ScalarFractionPrinting) {
+  auto [x, y, z] = make_scalar_variable("x", "y", "z");
+  EXPECT_EQ(to_string(2.0 * pow(x, -1.0)), "2/x"); // was "2*/x"
+  auto s = to_string(z * pow(x, -2.0) * pow(y, -1.0));
+  EXPECT_TRUE(s == "z/(pow(x,2)*y)" || s == "z/(y*pow(x,2))") << s;
+  auto s2 = to_string(pow(x, -2.0) * pow(y, -1.0));
+  EXPECT_TRUE(s2 == "1/(pow(x,2)*y)" || s2 == "1/(y*pow(x,2))") << s2;
+  EXPECT_EQ(to_string(y * pow(x, -2.5)), "y/pow(x,2.5)");
+}
+
+TEST(RoundFiveReview, T2sFractionPrinting) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto s = to_string(pow(trace(A), -1.0) * pow(det(A), -1.0));
+  EXPECT_NE(s.find("1/"), std::string::npos) << s;
+  EXPECT_EQ(s.find("*/"), std::string::npos) << s;
+}
+
+// Round-5 differential fuzzer: pow(-b, p) extracted the sign for every
+// exponent; (-b)^2 = b^2, and for symbolic p no extraction is valid.
+TEST(RoundFiveReview, PowNegativeBaseParity) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  scalar_evaluator<double> ev;
+  ev.set(x, 2.5);
+  EXPECT_DOUBLE_EQ(ev.apply(pow(-x, 2.0)), 6.25); // was -6.25
+  EXPECT_DOUBLE_EQ(ev.apply(pow(-x, 3.0)), -15.625);
+  EXPECT_EQ(to_string(pow(-x, 2.0)), "pow(x,2)");
+  EXPECT_EQ(to_string(pow(-x, 3.0)), "-pow(x,3)");
+  EXPECT_EQ(to_string(pow(-x, y)), "pow(-x,y)");
+}
+
+// Round-5 differential fuzzer: exact-duplicate children reached raw
+// push_back through the sub default and two mul fallbacks and hit the
+// no-duplicates assert.
+TEST(RoundFiveReview, DuplicateChildMergesInsteadOfThrow) {
+  auto [x, z] = make_scalar_variable("x", "z");
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  ev.set(z, 2.0);
+  expression_holder<scalar_expression> e;
+  EXPECT_NO_THROW(e = z - (-1.0) * z);
+  EXPECT_EQ(to_string(e), "2*z");
+  EXPECT_NO_THROW(e = sin(x) * (-(0.5 * sin(x) * z)));
+  EXPECT_DOUBLE_EQ(ev.apply(e), -std::sin(1.0) * std::sin(1.0));
+  auto A = sin(z) * sin(x + 1.0);
+  auto B = sin(z) * sin(x + 2.0);
+  EXPECT_NO_THROW(e = A * B); // shared sin(z) factor
+  EXPECT_DOUBLE_EQ(ev.apply(e), std::sin(2.0) * std::sin(2.0) * std::sin(2.0) *
+                                    std::sin(3.0));
+}
+
+// Sweep bug C: hash(w(a+3))==hash(w(a+1)) — cancelling against a negative
+// wrapper erased the aliased child and lost both constants.
+TEST(RoundFiveReview, T2sAliasedWrapperCancellation) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto [a] = make_scalar_variable("a");
+  auto w = [](auto e) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(e);
+  };
+  auto e = (trace(A) + w(a + 3.0)) + (-w(a + 1.0));
+  EXPECT_EQ(to_string(e), "2+tr(A)");
+  auto e2 = (trace(A) + w(a + 3.0)) - w(a + 1.0);
+  EXPECT_NE(to_string(e2), "tr(A)"); // value must not be silently lost
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1334,6 +1334,67 @@ TEST(RoundFiveReview, T2sAliasedWrapperCancellation) {
   EXPECT_NE(to_string(e2), "tr(A)"); // value must not be silently lost
 }
 
+// Round-6 review: mirrors the round-5 fixes stopped short of.
+
+// R6-1: the value==0 degenerate collapse was missing from the
+// (add ± constant/one/negative) mirror sites — (x+5)-5 stayed a
+// single-child add that printed "x" but did not compare equal to x.
+TEST(RoundSixReview, AddSubConstantCollapseMirrors) {
+  auto [x] = make_scalar_variable("x");
+  auto e1 = (x + 5.0) - 5.0;
+  EXPECT_TRUE(*e1 == *x);
+  EXPECT_FALSE(is_same<scalar_add>(e1));
+  auto e2 = (x - 5.0) + 5.0;
+  EXPECT_TRUE(*e2 == *x);
+  auto e3 = (x - 1.0) + get_scalar_one();
+  EXPECT_TRUE(*e3 == *x);
+  auto neg5 =
+      make_expression<scalar_negative>(make_expression<scalar_constant>(5));
+  auto e4 = (x + 5.0) + neg5;
+  EXPECT_TRUE(*e4 == *x);
+  EXPECT_EQ(to_string(x - ((x + 5.0) - 5.0)), "0");
+  EXPECT_EQ(to_string(((x + 5.0) - 5.0) * pow(x, -1.0)), "1");
+}
+
+// R6-2: a symbolic t2s add coefficient (wrapper(s)) was silently deleted
+// by every get_coefficient + coeff().free() fold site.
+TEST(RoundSixReview, T2sSymbolicCoeffSurvivesConstantFold) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto [s] = make_scalar_variable("s");
+  auto w = [](auto e) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(e);
+  };
+  auto c5 = make_expression<scalar_constant>(5);
+  auto c2 = make_expression<scalar_constant>(2);
+  auto base = w(s) - (trace(A) + det(A)); // coeff = wrapper(s)
+  auto has_s = [](auto const &e) {
+    return to_string(e).find('s') != std::string::npos;
+  };
+  EXPECT_TRUE(has_s(base));
+  EXPECT_TRUE(has_s(base + w(c5))); // was "5-tr(A)-det(A)"
+  EXPECT_TRUE(has_s(base - w(c2))); // was "-2-tr(A)-det(A)"
+  EXPECT_TRUE(has_s(base + (-w(c5))));
+  auto t2s_one = make_expression<tensor_to_scalar_one>();
+  EXPECT_TRUE(has_s(t2s_one + base)); // was "1-tr(A)-det(A)"
+}
+
+// R6-3: the t2s sub-side wrapper merge pushed a numeric result as a child
+// instead of folding it into the coeff — equal values compared unequal.
+TEST(RoundSixReview, T2sSubWrapperMergeFoldsToCoeff) {
+  auto [A] = make_tensor_variable(std::tuple{"A", std::size_t{3}, 2});
+  auto [a] = make_scalar_variable("a");
+  auto w = [](auto e) {
+    return make_expression<tensor_to_scalar_scalar_wrapper>(e);
+  };
+  auto c2 = make_expression<scalar_constant>(2);
+  auto e1 = (trace(A) + w(a + 3.0)) - w(a + 1.0);
+  auto e2 = trace(A) + w(c2);
+  auto e3 = (trace(A) + w(a + 3.0)) + (-w(a + 1.0));
+  EXPECT_TRUE(*e1 == *e2);
+  EXPECT_TRUE(*e1 == *e3);
+  EXPECT_EQ(to_string(e1 - w(c2)), "tr(A)");
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1168,7 +1168,20 @@ TEST(HashIdentitySweep, TensorAddSpaceJoinSurvivesMerge) {
   auto sb = sym(B);
   EXPECT_TRUE(is_symmetric(sa + sb));
   // like-term merge path keeps the join
-  EXPECT_TRUE(is_symmetric((sa + sb) + 2.0 * sa));}
+  EXPECT_TRUE(is_symmetric((sa + sb) + 2.0 * sa));
+}
+
+// Review on #340: tensor-side zero-child filter, degenerate collapse, and
+// the reverse-direction like-term probe.
+TEST(HashIdentitySweep, TensorCancellationAndReverseProbe) {
+  auto [X, Y] = make_tensor_variable(std::tuple{"X", std::size_t{3}, 2},
+                                     std::tuple{"Y", std::size_t{3}, 2});
+  auto e = (2.0 * X + Y) + (-2.0) * X;
+  EXPECT_EQ(to_string(e), "Y");
+  EXPECT_TRUE(*e == *Y);
+  EXPECT_EQ(to_string((X + Y) + 2.0 * X), "3*X+Y"); // reverse probe
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -372,9 +372,11 @@ TEST_F(ScalarFixture, POW_Simplification) {
   EXPECT_PRINT(pow(pow(x, -_2), -_2), "pow(x,4)");
   EXPECT_PRINT(pow(pow(x, -_2), _2), "pow(x,-4)");
 
-  // --- Negative base extraction: pow(-x, p) → -pow(x, p) ---
-  EXPECT_PRINT(pow(-x, _2), "-pow(x,2)");
-  EXPECT_PRINT(pow(-x, y), "-pow(x,y)");
+  // --- Negative base: sign extraction is parity-dependent (round-5 review:
+  // (-x)^2 = x^2, and for symbolic p the sign cannot be extracted at all) ---
+  EXPECT_PRINT(pow(-x, _2), "pow(x,2)");
+  EXPECT_PRINT(pow(-x, _3), "-pow(x,3)");
+  EXPECT_PRINT(pow(-x, y), "pow(-x,y)");
 
   // --- Division cancellation: pow(x, -x) → 1 ---
   EXPECT_PRINT(pow(x, -x), "1");

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -438,8 +438,9 @@ TYPED_TEST(TensorExpressionTest, AddNaryPlusNegativeCancellation) {
   EXPECT_PRINT((X + Y) + (-X), "Y");
   EXPECT_PRINT((X + Y) + (-Y), "X");
   EXPECT_PRINT((X + Y + Z) + (-Y), "X+Z");
-  // negative not in sum → default add (hash-ordered output)
-  EXPECT_PRINT((X + Y) + (-Z), "-Z+X+Y");
+  // negative not in sum → flat insert into the copy (round-9: the old
+  // fallback nested the whole lhs add, which printed as "-Z+X+Y")
+  EXPECT_PRINT((X + Y) + (-Z), "X+Y-Z");
 }
 
 // n_ary_add: merge two adds: (X+Y) + (Y+Z) → X+2*Y+Z

--- a/tests/TensorExpressionTest.h
+++ b/tests/TensorExpressionTest.h
@@ -456,9 +456,8 @@ TYPED_TEST(TensorExpressionTest, AddMergeTwoNary) {
   EXPECT_PRINT((X + Y + Z) + (X + Y + Z), "2*X+2*Y+2*Z");
 }
 
-// n_ary_add + scalar_mul: hash_map find uses hash+id; tensor_scalar_mul
-// has same hash as its tensor child but different id, so find() doesn't
-// match existing bare symbols — scalar_mul is pushed as a separate child.
+// n_ary_add + scalar_mul: c*X is a like term of a stored bare X (#340);
+// find_like merges them into (1+c)*X. Unrelated symbols stay separate.
 TYPED_TEST(TensorExpressionTest, AddNaryPlusScalarMul) {
   auto &X = this->X;
   auto &Y = this->Y;
@@ -466,8 +465,8 @@ TYPED_TEST(TensorExpressionTest, AddNaryPlusScalarMul) {
   auto &_2 = this->_2;
   auto &_3 = this->_3;
 
-  EXPECT_PRINT((X + Y) + _2 * X, "X+2*X+Y");
-  EXPECT_PRINT((X + Y) + _3 * Y, "X+Y+3*Y");
+  EXPECT_PRINT((X + Y) + _2 * X, "3*X+Y");
+  EXPECT_PRINT((X + Y) + _3 * Y, "X+4*Y");
   EXPECT_PRINT((X + Y) + _2 * Z, "X+Y+2*Z");
 }
 

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -269,8 +269,9 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_PowSimplification) {
   // pow of pow with different base expressions
   EXPECT_PRINT(numsim::cas::pow(numsim::cas::pow(nX, 2), 3), "pow(norm(X),6)");
 
-  // --- Negative base extraction: pow(-expr, p) → -pow(expr, p) ---
-  EXPECT_PRINT(numsim::cas::pow(-trX, 2), "-pow(tr(X),2)");
+  // --- Negative base: sign extraction is parity-dependent (round-5 review:
+  // (-tr(X))^2 = tr(X)^2; only odd integer exponents keep the sign) ---
+  EXPECT_PRINT(numsim::cas::pow(-trX, 2), "pow(tr(X),2)");
   EXPECT_PRINT(numsim::cas::pow(-trX, _3), "-pow(tr(X),3)");
 
   // --- Division cancellation: pow(expr, -expr) → 1 ---


### PR DESCRIPTION
## Summary

Fixes #340, fixes #341. Stacked on #386 (#339) — the deep `operator==` this sweep relies on lands there.

Every simplifier site that used raw `hash_value()` equality as semantic identity now deep-compares. Probe-confirmed wrong results fixed:

| Before | After |
|---|---|
| `X + pow(X,2)` → `2*pow(X,2)` | stays `X+pow(X,2)` |
| `X + 2*X` → `4*X` | `3*X` |
| `X * (2*X)` → `pow(X,2)` (2 dropped) | `X*2*X` (value-correct) |
| `vol(pow(X,2)) + dev(X)` → `sym(pow(X,2))` | stays unmerged (#341) |
| `sin(x+2) - sin(x+5)` → `0` | stays symbolic |
| `max(2x, 3x)` → `2x` | stays symbolic |
| `(X+Y) + 2*X` → `X+2*X+Y` (unmerged) | `3*X+Y` (new merge) |

## Notes

- `tensor_scalar_mul` overrides `like_term_of` (c·T ~ T ~ c'·T), which plugs the tensor domain into #339's `find_like` machinery — the like-term merges the shared-hash design exists for now work in both argument orders.
- The `(c1*T)+(c2*T)` fold is defined in the .cpp (operators not visible in the header TU, per the established pattern).
- `tensor_add`'s running space join is bypassed by merge-based insertion (`merge_or_insert` doesn't go through the `push_back` override); new `recompute_space()` re-derives it, fixing `sym(A)+sym(B)` losing its Symmetric tag and a latent gap in the add+add merge path.
- `TensorExpressionTest.AddNaryPlusScalarMul` pinned the documented no-merge limitation ('find() doesn't match existing bare symbols'); its expectations update to the merged forms mandated by #340.
- Diff-variable leaf matches now deep-compare (the low-severity #340 tail); the remaining #342/#343 hash overrides are separate branches.

## Testing

5 new `HashIdentitySweep` lock-in tests (tensor add/mul tables, projector argument equality, scalar sub/max/min, space-join survival). Full suite: **2426/2426 pass**.