### PR TITLE
#391 #392: derive space through quadratic sandwich and orthogonal congruence

### DIFF
--- a/include/numsim_cas/tensor/tensor_operators.h
+++ b/include/numsim_cas/tensor/tensor_operators.h
@@ -10,6 +10,7 @@
 #include <numsim_cas/scalar/scalar_globals.h>
 #include <numsim_cas/tensor/identity_tensor.h>
 #include <numsim_cas/tensor/operators/tensor/tensor_add.h>
+#include <numsim_cas/tensor/operators/tensor/tensor_mul.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_add.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_mul.h>
 #include <numsim_cas/tensor/simplifier/tensor_simplifier_sub.h>
@@ -37,6 +38,55 @@ is_trans_of(expression_holder<tensor_expression> const &a,
   if (bc.indices() != sequence{2, 1})
     return false;
   return bc.expr() == inner_target;
+}
+
+// Congruence / quadratic-sandwich space inference for a 3-factor tensor_mul
+// of the form trans(X)*M*X or X*M*trans(X):
+//   - Orthogonal outer Q: Q^T M Q is an orthogonal similarity, so it preserves
+//     M's *full* space (Sym / Dev / Vol — trace is preserved) and definiteness
+//     (PD/PSD). Closes #392.
+//   - General outer A: A^T S A is symmetric when S is symmetric, and PSD when S
+//     is PSD; the trace tag is dropped (tr(A^T D A) != 0 in general), and PD is
+//     not claimed (needs A invertible, which is unknown). Closes #391.
+// Sound-only: annotates nothing unless the middle factor carries the property.
+// Called on the generic tensor*tensor mul result (2-factor Gram forms are
+// handled earlier by their own branch).
+inline void
+annotate_congruence_space(expression_holder<tensor_expression> const &result) {
+  if (!is_same<tensor_mul>(result))
+    return;
+  auto const &factors = result.template get<tensor_mul>().data();
+  if (factors.size() != 3)
+    return;
+  auto const &front = factors[0];
+  auto const &mid = factors[1];
+  auto const &back = factors[2];
+  if (!(is_trans_of(front, back) || is_trans_of(back, front)))
+    return;
+
+  auto &out_asm = result.data()->tensor_algebra_assumptions();
+  auto const &mid_asm = mid.get().tensor_algebra_assumptions();
+  bool const mid_pd = mid_asm.contains(positive_definite{});
+  bool const mid_psd = mid_pd || mid_asm.contains(positive_semidefinite{});
+
+  // Orthogonal congruence preserves the middle's space and definiteness.
+  if (is_orthogonal(front) || is_orthogonal(back)) {
+    if (auto const &sp = mid.get().space())
+      result.data()->set_space(*sp);
+    if (mid_pd)
+      out_asm.insert(positive_definite{});
+    if (mid_psd)
+      out_asm.insert(positive_semidefinite{});
+    return;
+  }
+
+  // General congruence: symmetric kernel -> symmetric (trace tag lost);
+  // PD/PSD kernel -> PSD only.
+  if (is_symmetric(mid)) {
+    result.data()->set_space({Symmetric{}, AnyTraceTag{}});
+    if (mid_psd)
+      out_asm.insert(positive_semidefinite{});
+  }
 }
 
 // scalar binary ops
@@ -199,7 +249,10 @@ tag_invoke(mul_fn, L &&lhs, [[maybe_unused]] R &&rhs) {
   auto &_lhs{lhs.template get<tensor_visitable_t>()};
   tensor_detail::simplifier::mul_base visitor(std::forward<L>(lhs),
                                               std::forward<R>(rhs));
-  return _lhs.accept(visitor);
+  auto result = _lhs.accept(visitor);
+  // #391 / #392 — quadratic sandwich A^T*M*A and orthogonal congruence.
+  annotate_congruence_space(result);
+  return result;
 }
 
 // #256 — a positive scalar preserves PD/PSD: pos·PD → PD, pos·PSD → PSD.

--- a/tests/TensorSpacePropagationTest.h
+++ b/tests/TensorSpacePropagationTest.h
@@ -493,6 +493,95 @@ TEST_F(TensorSpacePropagationTest, GeneralSumStaysUnannotated) {
   EXPECT_FALSE(is_skew(X + Y));
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Quadratic sandwich (#391): trans(A)*S*A is symmetric (PSD if S is PSD),
+// with the trace tag dropped because a general A does not preserve trace.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_F(TensorSpacePropagationTest, SandwichSymmetricKernelIsSymmetric) {
+  // trans(A)*S*A and A*S*trans(A) are symmetric for any A when S is symmetric.
+  EXPECT_TRUE(is_symmetric(trans(X) * C * X));
+  EXPECT_TRUE(is_symmetric(X * C * trans(X)));
+  EXPECT_FALSE(is_skew(trans(X) * C * X));
+}
+
+TEST_F(TensorSpacePropagationTest, SandwichPSDKernelIsPSDNotPD) {
+  // trans(A)*P*A is PSD (PD only if A invertible, which is unknown).
+  auto P = std::get<0>(make_tensor_variable(std::tuple{"P", dim, 2}));
+  assume_positive_definite(P);
+  auto s = trans(X) * P * X;
+  EXPECT_TRUE(is_symmetric(s));
+  EXPECT_TRUE(is_positive_semidefinite(s));
+  EXPECT_FALSE(is_positive_definite(s)) << "A invertibility unknown → PSD only";
+}
+
+TEST_F(TensorSpacePropagationTest, SandwichDropsTraceTagForGeneralOuter) {
+  // Safety: trans(A)*D*A is symmetric but NOT deviatoric — a general A does
+  // not preserve trace (tr(A^T D A) != 0 in general).
+  auto s = trans(X) * D * X;
+  EXPECT_TRUE(is_symmetric(s));
+  EXPECT_FALSE(is_deviatoric(s));
+}
+
+TEST_F(TensorSpacePropagationTest, SandwichNonSymmetricKernelIsUnannotated) {
+  // Safety: a non-symmetric kernel yields no symmetric claim.
+  auto G = std::get<0>(make_tensor_variable(std::tuple{"G", dim, 2}));
+  EXPECT_FALSE(is_symmetric(trans(X) * G * X));
+}
+
+TEST_F(TensorSpacePropagationTest, SandwichRequiresTransposePairing) {
+  // Safety: A*S*A (no transpose) is not a congruence and stays unannotated.
+  EXPECT_FALSE(is_symmetric(X * C * X));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Orthogonal congruence (#392): trans(Q)*X*Q preserves the full space
+// (sym/dev/vol) and definiteness, because orthogonal similarity keeps
+// eigenvalues and trace.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+class OrthoCongruenceFixture : public TensorSpacePropagationTest {
+protected:
+  tensor_t Q;
+  OrthoCongruenceFixture() {
+    Q = std::get<0>(make_tensor_variable(std::tuple{"Q", dim, 2}));
+    assume_orthogonal(Q);
+  }
+};
+
+TEST_F(OrthoCongruenceFixture, PreservesSymmetric) {
+  EXPECT_TRUE(is_symmetric(trans(Q) * C * Q));
+}
+
+TEST_F(OrthoCongruenceFixture, PreservesDeviatoric) {
+  // trans(Q)*D*Q stays deviatoric: tr(Q^T D Q) = tr(D) = 0.
+  auto s = trans(Q) * D * Q;
+  EXPECT_TRUE(is_deviatoric(s));
+  EXPECT_TRUE(is_symmetric(s));
+}
+
+TEST_F(OrthoCongruenceFixture, PreservesVolumetric) {
+  EXPECT_TRUE(is_volumetric(trans(Q) * V * Q));
+}
+
+TEST_F(OrthoCongruenceFixture, PreservesPositiveDefinite) {
+  // Orthogonal similarity preserves eigenvalues → PD stays PD.
+  auto P = std::get<0>(make_tensor_variable(std::tuple{"P", dim, 2}));
+  assume_positive_definite(P);
+  auto s = trans(Q) * P * Q;
+  EXPECT_TRUE(is_positive_definite(s));
+  EXPECT_TRUE(is_symmetric(s));
+}
+
+TEST_F(OrthoCongruenceFixture, GeneralOuterDoesNotPreserveTrace) {
+  // Contrast with the orthogonal case: a non-orthogonal outer must drop the
+  // trace tag and must not claim PD.
+  auto P = std::get<0>(make_tensor_variable(std::tuple{"P2", dim, 2}));
+  assume_positive_definite(P);
+  EXPECT_FALSE(is_deviatoric(trans(X) * D * X));
+  EXPECT_FALSE(is_positive_definite(trans(X) * P * X));
+}
+
 } // namespace numsim::cas
 
 #endif // TENSORSPACEPROPAGATIONTEST_H


### PR DESCRIPTION
Tier-2 of the annotation-completeness umbrella (#396). **Stacked on #397** (#389/#390) — base is `389-390-gram-and-sympart`; retarget to `main` before merge.

Adds `annotate_congruence_space()`, called on the generic tensor×tensor `mul` result, which classifies a 3-factor `tensor_mul` of the form `trans(X)*M*X` or `X*M*trans(X)`:

## #391 — general congruence `Aᵀ·S·A`
Symmetric when `S` is symmetric, PSD when `S` is PSD. The **trace tag is dropped** (`tr(AᵀDA) ≠ 0` for general `A`) and PD is not claimed (needs `A` invertible, unknown). Generalizes the Gram form (#389) to an arbitrary symmetric kernel — the pull-back/push-forward operation in continuum mechanics.

## #392 — orthogonal congruence `Qᵀ·M·Q`
An orthogonal similarity preserves eigenvalues and trace, so it keeps **M's full space** (Sym/Dev/Vol) *and* definiteness:
- `Qᵀ·S·Q → sym`, `Qᵀ·D·Q → **dev**` (trace preserved), `Qᵀ·V·Q → vol`, `Qᵀ·P·Q → **PD**`.

The trace-tag contrast between #391 (dropped) and #392 (kept) is the crux, and is directly tested.

## Soundness
Reuses `is_trans_of` and the hash-safe post-construction annotation pattern. Nothing is annotated unless the middle factor carries the property. Tests cover both orientations, PD/PSD kernels, and safety fences:
- general outer drops the trace tag and does not claim PD;
- a non-symmetric kernel yields nothing;
- `A*S*A` (no transpose) is not a congruence.

clang: **1629** pass; gcc-14: **1444** pass (clean under `-Wall -Werror`).

Closes #391, closes #392. Part of #396.