### PR TITLE
Fix #342, #343: index sequences are part of node identity

### DIFF
--- a/include/numsim_cas/tensor/wrappers/permute_indices_wrapper.h
+++ b/include/numsim_cas/tensor/wrappers/permute_indices_wrapper.h
@@ -49,6 +49,30 @@ public:
     return m_indices;
   }
 
+  // #342 — the permutation is part of the node's identity: two different
+  // permutations of the same tensor must not hash or compare equal.
+  void update_hash_value() const noexcept override {
+    base::m_hash_value = 0;
+    hash_combine(base::m_hash_value, base::get_id());
+    hash_combine(base::m_hash_value, this->expr().get().hash_value());
+    hash_combine(base::m_hash_value, m_indices);
+  }
+
+  friend bool operator==(permute_indices_wrapper const &lhs,
+                         permute_indices_wrapper const &rhs) {
+    return lhs.m_indices == rhs.m_indices &&
+           static_cast<base const &>(lhs) == static_cast<base const &>(rhs);
+  }
+
+  friend bool operator<(permute_indices_wrapper const &lhs,
+                        permute_indices_wrapper const &rhs) {
+    if (static_cast<base const &>(lhs) < static_cast<base const &>(rhs))
+      return true;
+    if (static_cast<base const &>(rhs) < static_cast<base const &>(lhs))
+      return false;
+    return lhs.m_indices < rhs.m_indices;
+  }
+
 protected:
   /**
    * @brief Stores the permutation indices.

--- a/include/numsim_cas/tensor_to_scalar/tensor_inner_product_to_scalar.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_inner_product_to_scalar.h
@@ -37,6 +37,36 @@ public:
     return m_rhs_indices;
   }
 
+  // #343 — the contraction sequences are part of the node's identity
+  // (mirrors inner_product_wrapper's #266 fix): A:B and A:B^T must not
+  // hash or compare equal.
+  void update_hash_value() const noexcept override {
+    base::m_hash_value = 0;
+    hash_combine(base::m_hash_value, base::get_id());
+    hash_combine(base::m_hash_value, base::expr_lhs().get().hash_value());
+    hash_combine(base::m_hash_value, base::expr_rhs().get().hash_value());
+    hash_combine(base::m_hash_value, m_lhs_indices);
+    hash_combine(base::m_hash_value, m_rhs_indices);
+  }
+
+  friend bool operator==(tensor_inner_product_to_scalar const &lhs,
+                         tensor_inner_product_to_scalar const &rhs) {
+    return lhs.m_lhs_indices == rhs.m_lhs_indices &&
+           lhs.m_rhs_indices == rhs.m_rhs_indices &&
+           static_cast<base const &>(lhs) == static_cast<base const &>(rhs);
+  }
+
+  friend bool operator<(tensor_inner_product_to_scalar const &lhs,
+                        tensor_inner_product_to_scalar const &rhs) {
+    if (static_cast<base const &>(lhs) < static_cast<base const &>(rhs))
+      return true;
+    if (static_cast<base const &>(rhs) < static_cast<base const &>(lhs))
+      return false;
+    if (lhs.m_lhs_indices != rhs.m_lhs_indices)
+      return lhs.m_lhs_indices < rhs.m_lhs_indices;
+    return lhs.m_rhs_indices < rhs.m_rhs_indices;
+  }
+
 protected:
   sequence m_lhs_indices;
   sequence m_rhs_indices;

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1589,6 +1589,35 @@ TEST(PowDivisionConfusion, SignPullOutCanonicalizesNestedBase) {
   EXPECT_EQ(to_string(pow(-pow(x, 2.0), 2.0) - pow(x, 4.0)), "0");
 }
 
+// #342 — permute_indices_wrapper identity must include the permutation.
+TEST(IndexSequenceIdentity, PermutationsDistinguish) {
+  auto [T] = make_tensor_variable(std::tuple{"T", 3, 3});
+  auto p1 = permute_indices(T, sequence{2, 1, 3});
+  auto p2 = permute_indices(T, sequence{1, 3, 2});
+  EXPECT_FALSE(*p1 == *p2);
+  EXPECT_NE(p1.get().hash_value(), p2.get().hash_value());
+  EXPECT_NE(to_string(p1 - p2), "0{3}");
+  // identical permutation still cancels
+  auto q = permute_indices(T, sequence{2, 1, 3});
+  EXPECT_EQ(to_string(p1 - q), "0{3}");
+}
+
+// #343 — tensor_inner_product_to_scalar identity must include the
+// contraction sequences (A:B is not A:B^T).
+TEST(IndexSequenceIdentity, T2sContractionSequencesDistinguish) {
+  auto [A, B] =
+      make_tensor_variable(std::tuple{"A", 3, 2}, std::tuple{"B", 3, 2});
+  auto ab = dot_product(A, sequence{1, 2}, B, sequence{1, 2});
+  auto abt = dot_product(A, sequence{1, 2}, B, sequence{2, 1});
+  EXPECT_FALSE(*ab == *abt);
+  EXPECT_NE(ab.get().hash_value(), abt.get().hash_value());
+  EXPECT_NE(to_string(ab - abt), "0");
+  EXPECT_NE(to_string(ab + abt), to_string(2.0 * abt));
+  // identical sequences still cancel
+  auto ab2 = dot_product(A, sequence{1, 2}, B, sequence{1, 2});
+  EXPECT_EQ(to_string(ab - ab2), "0");
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H


### PR DESCRIPTION
## Summary

Fixes #342, fixes #343. Stacked on #388.

Two nodes stored index sequences but inherited base-class hash/equality that ignore them — the same bug class #266 fixed for `inner_product_wrapper`:

| Before | After |
|---|---|
| `permute_indices(T,{2,1,3}) == permute_indices(T,{1,3,2})` → true; difference → `0{3}` | distinct; stays symbolic |
| `dot_product(A,{1,2},B,{1,2}) == dot_product(A,{1,2},B,{2,1})` → true (A:B ≡ A:Bᵀ); sum → `2*dot(...)`, difference → `0` | distinct; no false merge/cancel |

## Design

- `update_hash_value` overrides fold the sequence(s) into the hash (the #266 pattern, plus the `m_hash_value = 0` reset that #372 notes the #266 version lacks — the new overrides don't inherit that latent bug).
- Non-template `operator==`/`operator<` friends compare sequences before delegating to the base comparison (win overload resolution over the base templates used by `equals_same_type`/`less_than_same_type`).
- The evaluator half of the t2s node (ignores sequences at evaluation, rank≠2 throws) is #353 — separate branch.

## Tests

2 new `IndexSequenceIdentity` lock-in tests (hash + equality + no-false-cancel + exact-match-still-cancels, both nodes). Full suite: **2428/2428 pass**. gcc-14 `-Werror` syntax check clean.