### PR TITLE
Fix #345: gate pow-over-product distribution and merges on integer exponents

### DIFF
--- a/include/numsim_cas/core/simplifier/simplifier_pow.h
+++ b/include/numsim_cas/core/simplifier/simplifier_pow.h
@@ -137,6 +137,7 @@ public:
       for (const auto &expr : pows) {
         const auto &pow_expr{expr.template get<typename Traits::pow_type>()};
         mul.symbol_map().erase(expr);
+        mul.invalidate_hash();
         auto pow_n{pow(pow_expr.expr_lhs(), pow_expr.expr_rhs() * this->m_rhs)};
         if (!result.is_valid()) {
           result = std::move(pow_n);
@@ -168,6 +169,7 @@ public:
       for (const auto &expr : pows) {
         const auto &pow_expr{expr.template get<typename Traits::pow_type>()};
         mul.symbol_map().erase(expr);
+        mul.invalidate_hash();
         auto pow_n{pow(pow_expr.expr_lhs(), pow_expr.expr_rhs() * this->m_rhs)};
         if (!result.is_valid()) {
           result = std::move(pow_n);

--- a/include/numsim_cas/core/simplifier/simplifier_pow.h
+++ b/include/numsim_cas/core/simplifier/simplifier_pow.h
@@ -117,14 +117,22 @@ public:
       : base(std::move(lhs_in), std::move(rhs)),
         lhs{base::m_lhs.template get<typename Traits::mul_type>()} {}
 
+  // (a*b)^n = a^n * b^n only holds for all reals when n is an integer (#345)
+  [[nodiscard]] bool integer_outer_exponent() const {
+    auto val = Traits::try_numeric(this->m_rhs);
+    return val && pow_integer_exponent(*val).has_value();
+  }
+
   // pow(mul, -rhs)
-  expr_holder_t dispatch([[maybe_unused]]
-                         typename Traits::negative_type const &rhs) {
+  expr_holder_t dispatch(typename Traits::negative_type const &rhs) {
+    auto inner_val = Traits::try_numeric(rhs.expr());
+    const bool int_exp{integer_outer_exponent() ||
+                       (inner_val && pow_integer_exponent(*inner_val))};
     auto mul_expr{make_expression<typename Traits::mul_type>(lhs)};
     auto &mul{mul_expr.template get<typename Traits::mul_type>()};
     // pow(x*y*pow(z,base), rhs) --> pow(x*y, rhs) * pow(z,base*rhs)
     const auto pows{get_all<typename Traits::pow_type>(lhs)};
-    if (!pows.empty()) {
+    if (!pows.empty() && int_exp) {
       expr_holder_t result;
       for (const auto &expr : pows) {
         const auto &pow_expr{expr.template get<typename Traits::pow_type>()};
@@ -155,7 +163,7 @@ public:
 
     // pow(x*y*pow(z,base), rhs) --> pow(x*y, rhs) * pow(z,base*rhs)
     const auto pows{get_all<typename Traits::pow_type>(lhs)};
-    if (!pows.empty()) {
+    if (!pows.empty() && integer_outer_exponent()) {
       expr_holder_t result;
       for (const auto &expr : pows) {
         const auto &pow_expr{expr.template get<typename Traits::pow_type>()};

--- a/include/numsim_cas/core/simplifier/simplifier_pow.h
+++ b/include/numsim_cas/core/simplifier/simplifier_pow.h
@@ -151,6 +151,11 @@ public:
           return pow(mul.coeff(), this->m_rhs) * result;
         return result;
       }
+      // single remaining child: pow(mul{y}, n) is non-canonical and never
+      // cancels against pow(y, n) (round-2 review on #345)
+      if (mul.symbol_map().size() == 1 && !mul.coeff().is_valid()) {
+        return pow(mul.symbol_map().begin()->second, this->m_rhs) * result;
+      }
       return pow(mul_expr, this->m_rhs) * result;
     }
 
@@ -182,6 +187,11 @@ public:
         if (mul.coeff().is_valid())
           return pow(mul.coeff(), this->m_rhs) * result;
         return result;
+      }
+      // single remaining child: pow(mul{y}, n) is non-canonical and never
+      // cancels against pow(y, n) (round-2 review on #345)
+      if (mul.symbol_map().size() == 1 && !mul.coeff().is_valid()) {
+        return pow(mul.symbol_map().begin()->second, this->m_rhs) * result;
       }
       return pow(mul_expr, this->m_rhs) * result;
     }

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
@@ -189,7 +189,10 @@ scalar_pow_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
     return pow(m_lhs_node.expr_lhs(), rhs_expr);
   }
 
-  if (m_lhs_node.expr_rhs() == rhs.expr_rhs()) {
+  // x^a * y^a --> (x*y)^a only for integer a (#345; mirrors
+  // simplify_scalar_pow_pow_mul's guard)
+  if (m_lhs_node.expr_rhs() == rhs.expr_rhs() &&
+      is_integer_exponent(m_lhs_node.expr_rhs())) {
     const auto lhs_expr{m_lhs_node.expr_lhs() * rhs.expr_lhs()};
     return pow(lhs_expr, m_lhs_node.expr_rhs());
   }

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_mul.cpp
@@ -75,13 +75,25 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
   auto expr_mul{make_expression<scalar_mul>(m_lhs_node)};
   auto &mul{expr_mul.template get<scalar_mul>()};
 
+  // round-2 review: the erase mutates a copied node - drop the stale
+  // cached hash and collapse a degenerate single-child/empty remainder
+  // before feeding it back into * (a coeffless mul{y} once produced
+  // ((x*y)*pow(x,-1)) - y == -3 downstream)
+  const auto collapse = [&]() -> expr_holder_t {
+    mul.invalidate_hash();
+    if (mul.symbol_map().empty()) {
+      return mul.coeff().is_valid() ? mul.coeff() : get_scalar_one();
+    }
+    if (mul.symbol_map().size() == 1 && !mul.coeff().is_valid()) {
+      return mul.symbol_map().begin()->second;
+    }
+    return expr_mul;
+  };
+
   const auto &smap{m_lhs_node.symbol_map()};
   if (smap.contains(rhs.expr_lhs())) {
     mul.symbol_map().erase(rhs.expr_lhs());
-    mul.invalidate_hash();
-    expr_mul = std::move(expr_mul) *
-               pow(rhs.expr_lhs(), rhs.expr_rhs() + get_scalar_one());
-    return expr_mul;
+    return collapse() * pow(rhs.expr_lhs(), rhs.expr_rhs() + get_scalar_one());
   }
 
   const auto pows{get_all<scalar_pow>(m_lhs_node)};
@@ -89,9 +101,7 @@ n_ary_mul::dispatch([[maybe_unused]] scalar_pow const &rhs) {
     if (auto pow{simplify_scalar_pow_pow_mul(expr.template get<scalar_pow>(),
                                              rhs)}) {
       mul.symbol_map().erase(expr);
-      mul.invalidate_hash();
-      expr_mul = std::move(expr_mul) * std::move(*pow);
-      return expr_mul;
+      return collapse() * std::move(*pow);
     }
   }
 

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -30,11 +30,12 @@ mul_pow::mul_pow(expr_holder_t lhs, expr_holder_t rhs)
 // pow(scalar_mul, -rhs)
 mul_pow::expr_holder_t
 mul_pow::dispatch([[maybe_unused]] scalar_negative const &rhs) {
+  const bool int_exp{try_int_constant(m_rhs).has_value()};
   auto mul_expr{make_expression<scalar_mul>(m_lhs_node)};
   auto &mul{mul_expr.template get<scalar_mul>()};
   // pow(x*y*pow(z,base), rhs) --> pow(x*y, rhs) * pos(z,base*rhs)
   const auto pows{get_all<scalar_pow>(m_lhs_node)};
-  if (!pows.empty()) {
+  if (!pows.empty() && int_exp) {
     expr_holder_t result;
     for (const auto &expr : pows) {
       const auto &pow_expr{expr.get<scalar_pow>()};
@@ -59,7 +60,7 @@ mul_pow::expr_holder_t mul_pow::dispatch([[maybe_unused]] Expr const &rhs) {
 
   // pow(x*y*pow(z,base), rhs) --> pow(x*y, rhs) * pos(z,base*rhs)
   const auto pows{get_all<scalar_pow>(m_lhs_node)};
-  if (!pows.empty()) {
+  if (!pows.empty() && try_int_constant(m_rhs)) {
     expr_holder_t result;
     for (const auto &expr : pows) {
       const auto &pow_expr{expr.get<scalar_pow>()};

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -40,6 +40,7 @@ mul_pow::dispatch([[maybe_unused]] scalar_negative const &rhs) {
     for (const auto &expr : pows) {
       const auto &pow_expr{expr.get<scalar_pow>()};
       mul.symbol_map().erase(expr);
+      mul.invalidate_hash();
       auto pow_n{pow(pow_expr.expr_lhs(), pow_expr.expr_rhs() * m_rhs)};
       if (!result.is_valid()) {
         result = std::move(pow_n);
@@ -65,6 +66,7 @@ mul_pow::expr_holder_t mul_pow::dispatch([[maybe_unused]] Expr const &rhs) {
     for (const auto &expr : pows) {
       const auto &pow_expr{expr.get<scalar_pow>()};
       mul.symbol_map().erase(expr);
+      mul.invalidate_hash();
       auto pow_n{pow(pow_expr.expr_lhs(), pow_expr.expr_rhs() * m_rhs)};
       if (!result.is_valid()) {
         result = std::move(pow_n);

--- a/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_simplifier_pow.cpp
@@ -48,6 +48,14 @@ mul_pow::dispatch([[maybe_unused]] scalar_negative const &rhs) {
         result = result * std::move(pow_n);
       }
     }
+    if (mul.symbol_map().empty()) {
+      return (mul.coeff().is_valid() ? pow(mul.coeff(), m_rhs)
+                                     : get_scalar_one()) *
+             result;
+    }
+    if (mul.symbol_map().size() == 1 && !mul.coeff().is_valid()) {
+      return pow(mul.symbol_map().begin()->second, m_rhs) * result;
+    }
     return pow(mul_expr, m_rhs) * result;
   }
 
@@ -73,6 +81,14 @@ mul_pow::expr_holder_t mul_pow::dispatch([[maybe_unused]] Expr const &rhs) {
       } else {
         result = result * std::move(pow_n);
       }
+    }
+    if (mul.symbol_map().empty()) {
+      return (mul.coeff().is_valid() ? pow(mul.coeff(), m_rhs)
+                                     : get_scalar_one()) *
+             result;
+    }
+    if (mul.symbol_map().size() == 1 && !mul.coeff().is_valid()) {
+      return pow(mul.symbol_map().begin()->second, m_rhs) * result;
     }
     return pow(mul_expr, m_rhs) * result;
   }

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <numsim_cas/core/operators.h>
 #include <numsim_cas/scalar/scalar_operators.h>
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.h>
@@ -62,8 +63,20 @@ static bool try_fold_numeric_pow(tensor_to_scalar_mul &mul,
     auto const &existing = it->second.template get<tensor_to_scalar_pow>();
     auto existing_base_val = t2s_traits::try_numeric(existing.expr_lhs());
     auto existing_exp_val = t2s_traits::try_numeric(existing.expr_rhs());
+    // (c1^e)*(c2^e) --> (c1*c2)^e: sound for integer e or nonneg bases (#345)
+    auto is_int = [](scalar_number const &v) {
+      if (std::get_if<std::int64_t>(&v.raw()))
+        return true;
+      auto const *d = std::get_if<double>(&v.raw());
+      return d && *d == std::round(*d);
+    };
+    auto nonneg = [](scalar_number const &v) {
+      return !numeric_less(v, scalar_number{0});
+    };
     if (existing_base_val && existing_exp_val &&
-        *existing_exp_val == *child_exp_val) {
+        *existing_exp_val == *child_exp_val &&
+        (is_int(*child_exp_val) ||
+         (nonneg(*child_base_val) && nonneg(*existing_base_val)))) {
       auto combined_base =
           t2s_traits::make_constant(*existing_base_val * *child_base_val);
       auto combined = make_expression<tensor_to_scalar_pow>(

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1658,6 +1658,24 @@ TEST(MulDuplicateFactor, MirroredOrdersFold) {
   EXPECT_NEAR(ev.apply(c), std::pow(std::sin(2.0) * 3.0, 2.0), 1e-13);
 }
 
+// #345 — pow distributes/merges over products only for integer exponents.
+TEST(PowDistributeGuard, FractionalExponentDoesNotDistribute) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  scalar_evaluator<double> ev;
+  ev.set(x, 1.0);
+  ev.set(y, -2.0);
+  auto e = pow(x * pow(y, 2.0), 0.5); // ((1)·4)^0.5 = 2, NOT y·sqrt(x) = −2
+  EXPECT_DOUBLE_EQ(ev.apply(e), 2.0);
+  // integer exponent still distributes
+  EXPECT_EQ(to_string(pow(x * pow(y, 2.0), 3.0)), "pow(y,6)*pow(x,3)");
+}
+
+TEST(PowDistributeGuard, FractionalSameExponentDoesNotMerge) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  EXPECT_NE(to_string(pow(x, 0.5) * pow(y, 0.5)), "pow(x*y,1/2)");
+  // integer exponent still merges
+  EXPECT_EQ(to_string(pow(x, 2.0) * pow(y, 2.0)), "pow(x*y,2)");}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1667,14 +1667,31 @@ TEST(PowDistributeGuard, FractionalExponentDoesNotDistribute) {
   auto e = pow(x * pow(y, 2.0), 0.5); // ((1)·4)^0.5 = 2, NOT y·sqrt(x) = −2
   EXPECT_DOUBLE_EQ(ev.apply(e), 2.0);
   // integer exponent still distributes
-  EXPECT_EQ(to_string(pow(x * pow(y, 2.0), 3.0)), "pow(y,6)*pow(x,3)");
+  EXPECT_EQ(to_string(pow(x * pow(y, 2.0), 3.0)), "pow(x,3)*pow(y,6)");
 }
 
 TEST(PowDistributeGuard, FractionalSameExponentDoesNotMerge) {
   auto [x, y] = make_scalar_variable("x", "y");
   EXPECT_NE(to_string(pow(x, 0.5) * pow(y, 0.5)), "pow(x*y,1/2)");
   // integer exponent still merges
-  EXPECT_EQ(to_string(pow(x, 2.0) * pow(y, 2.0)), "pow(x*y,2)");}
+  EXPECT_EQ(to_string(pow(x, 2.0) * pow(y, 2.0)), "pow(x*y,2)");
+}
+
+// Round-2 review on #345: pow-split canonical form and the mul producer.
+TEST(RoundTwoReview, PowSplitCollapsesSingleChildMul) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto e = pow(pow(x, 2.0) * y, 2.0); // was pow(mul{y},2)*pow(x,4)
+  EXPECT_TRUE(*e == *(pow(x, 4.0) * pow(y, 2.0)));
+  EXPECT_EQ(to_string(e - pow(x, 4.0) * pow(y, 2.0)), "0");
+}
+
+TEST(RoundTwoReview, MulPowEraseProducesCanonicalRemainder) {
+  auto [x, y] = make_scalar_variable("x", "y");
+  auto r = (x * y) * pow(x, -1.0); // must be the bare symbol y
+  EXPECT_TRUE(*r == *y);
+  EXPECT_TRUE(is_same<scalar>(r));
+  EXPECT_EQ(to_string(sin(r) - sin(y)), "0"); // no stale hash either
+}
 
 } // namespace numsim::cas
 

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -383,8 +383,8 @@ TEST_F(ScalarFixture, POW_Simplification) {
   EXPECT_PRINT(pow(x * y, -y), "pow(x*y,-y)");
 
   // --- Mul-pow extraction: pow(x*pow(y,a), b) → pow(x,b)*pow(y,a*b) ---
-  EXPECT_PRINT(pow(x * pow(y, _2), _3), "pow(y,6)*pow(x,3)");
-  EXPECT_PRINT(pow(x * pow(y, z), _2), "pow(y,2*z)*pow(x,2)");
+  EXPECT_PRINT(pow(x * pow(y, _2), _3), "pow(x,3)*pow(y,6)");
+  EXPECT_PRINT(pow(x * pow(y, z), _2), "pow(x,2)*pow(y,2*z)");
 }
 
 TEST_F(ScalarFixture, ADD_CombineSameSymbol) {

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -280,7 +280,7 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_PowSimplification) {
 
   // --- Mul-pow extraction: pow(a*pow(b,c), d) → pow(a,d)*pow(b,c*d) ---
   EXPECT_PRINT(numsim::cas::pow(trX * numsim::cas::pow(nX, 2), 3),
-               "pow(norm(X),6)*pow(tr(X),3)");
+               "pow(tr(X),3)*pow(norm(X),6)");
 
   // --- Interplay with existing mul simplifier ---
   // tr(X)*tr(X) creates pow(tr(X),2), then pow(pow(tr(X),2),3) simplifies


### PR DESCRIPTION
## Summary

Fixes #345. Stacked on #400. Sibling of #388 (#344) and of the open #336 (pow-of-pow flatten — not touched here).

| Before | After |
|---|---|
| `pow(x*y^2, 1/2)` → `y*sqrt(x)` (evaluated **−2** at x=1, y=−2) | stays unfolded, evaluates +2 |
| `pow(x, 1/2)*pow(y, 1/2)` → `pow(x*y, 1/2)` (NaN·NaN ≡ 1 for x=y=−1) | stays unmerged |
| t2s `(−2)^½·(−3)^½` → `6^½` (defined from undefined) | no fold |
| `pow(x*y^2, 3)` → `pow(y,6)*pow(x,3)` | unchanged (integer) |
| `pow(x,2)*pow(y,2)` → `pow(x*y,2)` | unchanged (integer) |

## Design

The soundness condition is **integer outer exponent** (valid for any real signs); the guards:
- generic `mul_pow_dispatch` (both dispatches): `pow_integer_exponent` on `Traits::try_numeric`, with the negative dispatch also accepting an integer inner value;
- scalar copies: `try_int_constant` (unwraps negation);
- scalar same-exponent merge: `is_integer_exponent` (mirrors the already-guarded `simplify_scalar_pow_pow_mul`);
- t2s numeric fold: integer exponent **or** both numeric bases nonnegative (keeps the positive-constant folds the div-contract suite relies on).

Nonneg-symbolic refinement (fold when the base is *assumed* nonnegative) is epic #381's scope.

## Tests

2 new evaluation-verified lock-ins (fractional blocked + integer preserved, both rules). Full suite: **2433/2433 pass**. gcc-14 `-Werror` check clean.