### PR TITLE
Fix #361: hash doubles by bit pattern, normalize numerically equal constants

### DIFF
--- a/include/numsim_cas/core/hash_functions.h
+++ b/include/numsim_cas/core/hash_functions.h
@@ -1,7 +1,9 @@
 #ifndef HASH_FUNCTIONS_H
 #define HASH_FUNCTIONS_H
 
+#include <bit>
 #include <complex>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -13,6 +15,18 @@ inline void hash_combine(std::size_t &seed, const T &value) {
   // std::hash<T> hasher;
   seed ^= static_cast<std::size_t>(value) +
           static_cast<std::size_t>(0x9e3779b9) + (seed << 6) + (seed >> 2);
+}
+
+// Doubles hash by bit pattern: the generic static_cast is UB for negative
+// values and collapses all fractions in (0,1) onto 0 (#361).
+inline void hash_combine(std::size_t &seed, double value) {
+  if (value == 0.0)
+    value = 0.0; // normalize -0.0
+  hash_combine(seed, std::bit_cast<std::uint64_t>(value));
+}
+
+inline void hash_combine(std::size_t &seed, float value) {
+  hash_combine(seed, static_cast<double>(value));
 }
 
 inline void hash_combine(std::size_t &seed, const std::string &value) {

--- a/include/numsim_cas/core/scalar_number.h
+++ b/include/numsim_cas/core/scalar_number.h
@@ -106,6 +106,25 @@ private:
   variant_t v_;
 };
 
+// Value-normalizing hash: numerically equal constants must hash equal
+// across variant alternatives (int64 2 vs double 2.0 vs rational 2/1),
+// while doubles otherwise hash by bit pattern (#361).
+inline void hash_combine(std::size_t &seed, scalar_number const &value) {
+  std::visit(
+      [&](auto const &x) {
+        using T = std::decay_t<decltype(x)>;
+        if constexpr (std::is_same_v<T, double>) {
+          if (x == static_cast<double>(static_cast<std::int64_t>(x)) &&
+              x >= -9.2e18 && x <= 9.2e18) {
+            hash_combine(seed, static_cast<std::int64_t>(x));
+            return;
+          }
+        }
+        hash_combine(seed, x);
+      },
+      value.raw());
+}
+
 } // namespace numsim::cas
 
 #endif // SCALAR_NUMBER_H

--- a/include/numsim_cas/core/scalar_number.h
+++ b/include/numsim_cas/core/scalar_number.h
@@ -114,8 +114,10 @@ inline void hash_combine(std::size_t &seed, scalar_number const &value) {
       [&](auto const &x) {
         using T = std::decay_t<decltype(x)>;
         if constexpr (std::is_same_v<T, double>) {
-          if (x == static_cast<double>(static_cast<std::int64_t>(x)) &&
-              x >= -9.2e18 && x <= 9.2e18) {
+          // guard BEFORE casting: the int64 cast is UB for NaN/inf and
+          // |x| >= 2^63 (review on #361)
+          if (x >= -9.2e18 && x <= 9.2e18 &&
+              x == static_cast<double>(static_cast<std::int64_t>(x))) {
             hash_combine(seed, static_cast<std::int64_t>(x));
             return;
           }

--- a/include/numsim_cas/scalar/scalar_constant.h
+++ b/include/numsim_cas/scalar/scalar_constant.h
@@ -61,8 +61,7 @@ protected:
   void update_hash_value() const noexcept override {
     this->m_hash_value = 0;
     hash_combine(this->m_hash_value, this->id());
-    std::visit([&](auto const &x) { hash_combine(this->m_hash_value, x); },
-               m_value.raw());
+    hash_combine(this->m_hash_value, m_value);
   }
 
 private:

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1775,7 +1775,23 @@ TEST(HashCombineDouble, NumericallyEqualConstantsHashEqual) {
   // fractional constants distinct
   auto h1 = make_expression<scalar_constant>(0.5);
   auto h2 = make_expression<scalar_constant>(0.9);
-  EXPECT_NE(h1.get().hash_value(), h2.get().hash_value());}
+  EXPECT_NE(h1.get().hash_value(), h2.get().hash_value());
+}
+
+// Review on #361: the int64 cast in the value-normalizing hash ran before
+// its range guard - UB for NaN, inf, and huge doubles.
+TEST(HashCombineDouble, HugeAndNonFiniteConstantsHashSafely) {
+  auto big = make_expression<scalar_constant>(1e300);
+  auto nan = make_expression<scalar_constant>(
+      std::numeric_limits<double>::quiet_NaN());
+  auto inf =
+      make_expression<scalar_constant>(std::numeric_limits<double>::infinity());
+  // must be UB-free under -fsanitize=float-cast-overflow (CI leg, #356)
+  (void)big.get().hash_value();
+  (void)nan.get().hash_value();
+  (void)inf.get().hash_value();
+  EXPECT_NE(big.get().hash_value(), inf.get().hash_value());
+}
 
 } // namespace numsim::cas
 

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1754,6 +1754,29 @@ TEST(ScalarNumberOverflow, Int64MinTimesRational) {
   EXPECT_TRUE(std::get_if<double>(&d.raw()) != nullptr);
 }
 
+// #361 — hash_combine(double) hashed via static_cast<size_t>: UB for
+// negatives, and every fraction in (0,1) collided with 0.
+TEST(HashCombineDouble, BitPatternNoTruncation) {
+  std::size_t a = 0, b = 0, c = 0, d = 0, e = 0;
+  hash_combine(a, 0.5);
+  hash_combine(b, 0.9);
+  EXPECT_NE(a, b);
+  hash_combine(c, -2.5); // UB-free under -fsanitize=float-cast-overflow
+  hash_combine(d, 0.0);
+  hash_combine(e, -0.0);
+  EXPECT_EQ(d, e); // ±0 normalize together
+}
+
+TEST(HashCombineDouble, NumericallyEqualConstantsHashEqual) {
+  auto ci = make_scalar_constant(2);
+  auto cd = make_expression<scalar_constant>(2.0);
+  EXPECT_EQ(ci.get().hash_value(), cd.get().hash_value());
+  EXPECT_EQ(to_string(ci * cd), "4"); // folding across alternatives intact
+  // fractional constants distinct
+  auto h1 = make_expression<scalar_constant>(0.5);
+  auto h2 = make_expression<scalar_constant>(0.9);
+  EXPECT_NE(h1.get().hash_value(), h2.get().hash_value());}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H


### PR DESCRIPTION
## Summary

Fixes #361. Stacked on #402. Prerequisite for #356 — the UBSan leg cannot be made fatal while this UB fires on every negative-constant hash.

| Before | After |
|---|---|
| `hash_combine(seed, -2.5)` → `static_cast<size_t>` **UB** (float-cast-overflow) | bit-pattern hash, UB-free |
| `hash(0.5) == hash(0.9)` (all fractions collide with 0) | distinct |
| — | ±0.0 normalize together |

## Design

The subtle part: bit-pattern hashing alone breaks constant folding across variant alternatives — `int64 2` and `double 2.0` are numerically equal (`operator==` promotes) but would hash differently, so `pow(2*sqrt(x),-1) − pow(2.0*sqrt(x),-1)` stopped canceling (caught by `ScalarDifferentiationAudit`). A value-normalizing `hash_combine(scalar_number)` overload fixes this: whole doubles in int64 range hash as their integer; `scalar_constant::update_hash_value` routes through it. Rationals with den==1 already normalize to int64 at construction.

## Tests

2 lock-ins: bit-pattern properties (no truncation, negative-safe, ±0) and cross-alternative equality (hash + fold). Full suite: **2439/2439 pass**. gcc-14 clean.