### PR TITLE
Fix #351: rank-4 identity_tensor is major-symmetric, not MinorMajor

### DIFF
--- a/include/numsim_cas/tensor/identity_tensor.h
+++ b/include/numsim_cas/tensor/identity_tensor.h
@@ -154,16 +154,16 @@ public:
 
 private:
   // Closed-form structural classification by rank. Rank-2 is Kronecker δ_ij
-  // (Symmetric). Rank-4 minor identity is δ_ik·δ_jl (MinorMajor — fully
-  // symmetric at rank-4). Higher ranks return nullopt; the variant has no
-  // general "all-pairs-minor" alternative and higher-rank identity is
-  // rarely queried. Open decision tracked in
-  // docs/sympy-assumption-redesign.md.
+  // (Symmetric). Rank-4 identity δ_ik·δ_jl has MAJOR symmetry only:
+  // swapping (ij)<->(kl) gives δ_ki·δ_lj = δ_ik·δ_jl, but swapping i<->j
+  // gives δ_jk·δ_il ≠ δ_ik·δ_jl (the minor-symmetric identity is P_sym,
+  // a different tensor). The former MinorMajor tag routed inv() through
+  // the symmetric Voigt path, evaluating inv(-I4) wrongly (#351).
   static std::optional<tensor_space> space_for_rank(std::size_t rank) noexcept {
     if (rank == 2)
       return tensor_space{Symmetric{}, AnyTraceTag{}};
     if (rank == 4)
-      return tensor_space{MinorMajor{}, AnyTraceTag{}};
+      return tensor_space{Major{}, AnyTraceTag{}};
     return std::nullopt;
   }
 };

--- a/include/numsim_cas/tensor/identity_tensor.h
+++ b/include/numsim_cas/tensor/identity_tensor.h
@@ -106,10 +106,9 @@ public:
       a.insert(positive_semidefinite{}); // PD ⇒ PSD, mirrors
                                          // assume_positive_definite()
       // PD ⇒ symmetric, via the same helper assume_positive_definite()
-      // uses. Mechanically a no-op today because space_for_rank above
-      // already wrote a qualifying space tag at both supported ranks
-      // (rank-2 Symmetric ⇒ ProjKind::Sym early-return; rank-4
-      // MinorMajor ⇒ holds_alternative early-return). The call exists
+      // uses. Mechanically a no-op today: rank-2 already carries
+      // Symmetric, and the helper's rank()!=2 gate skips rank 4 (whose
+      // tag is Major since #351). The call exists
       // so that any future drift in detail::set_symmetric_unless_more_specific
       // (e.g. it grows a sibling-field write that we'd otherwise miss)
       // tracks automatically. Pairs with the helper in tensor_assume.h.

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1793,6 +1793,17 @@ TEST(HashCombineDouble, HugeAndNonFiniteConstantsHashSafely) {
   EXPECT_NE(big.get().hash_value(), inf.get().hash_value());
 }
 
+// #351 — rank-4 identity is major-symmetric only; the MinorMajor tag routed
+// inv() through the symmetric Voigt path, evaluating inv(-I4) to -0.25 at
+// component (0,1,0,1) instead of -1 (the inverse of -I4 is -I4).
+TEST(Rank4IdentityTag, InvOfNegatedIdentity) {
+  auto I4 = make_expression<identity_tensor>(std::size_t{3}, std::size_t{4});
+  tensor_evaluator<double> ev;
+  auto r = ev.apply(inv(-I4));
+  // (0,1,0,1) flattens to ((0*3+1)*3+0)*3+1 = 10
+  EXPECT_NEAR(r->raw_data()[10], -1.0, 1e-12);
+  EXPECT_NEAR(r->raw_data()[0], -1.0, 1e-12); // (0,0,0,0)}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1802,7 +1802,8 @@ TEST(Rank4IdentityTag, InvOfNegatedIdentity) {
   auto r = ev.apply(inv(-I4));
   // (0,1,0,1) flattens to ((0*3+1)*3+0)*3+1 = 10
   EXPECT_NEAR(r->raw_data()[10], -1.0, 1e-12);
-  EXPECT_NEAR(r->raw_data()[0], -1.0, 1e-12); // (0,0,0,0)}
+  EXPECT_NEAR(r->raw_data()[0], -1.0, 1e-12); // (0,0,0,0)
+}
 
 } // namespace numsim::cas
 

--- a/tests/TensorAlgebraAssumeTest.h
+++ b/tests/TensorAlgebraAssumeTest.h
@@ -1214,11 +1214,13 @@ TEST(TensorAlgebraIdentityAssumptions, Rank2IsNotSkew) {
   EXPECT_FALSE(is_skew(I));
 }
 
-TEST(TensorAlgebraIdentityAssumptions, Rank4MinorIdentityIsMinorMajor) {
-  // I_{ijkl} = δ_ik · δ_jl. Has minor symmetry (swap (i,j) or (k,l)) AND
-  // major symmetry (swap (ij)↔(kl)).
+TEST(TensorAlgebraIdentityAssumptions, Rank4IdentityIsMajorOnly) {
+  // I_{ijkl} = δ_ik · δ_jl has MAJOR symmetry only (#351): swapping i↔j
+  // gives δ_jk·δ_il ≠ δ_ik·δ_jl. The MinorMajor tag routed inv() through
+  // the symmetric Voigt path and evaluated inv(-I4) wrongly.
   auto I = make_expression<identity_tensor>(std::size_t{3}, std::size_t{4});
-  EXPECT_TRUE(is_minor_major(I));
+  EXPECT_TRUE(is_major(I));
+  EXPECT_FALSE(is_minor_major(I));
 }
 
 TEST(TensorAlgebraIdentityAssumptions, Rank4MinorIdentityIsSymmetric) {
@@ -1334,13 +1336,13 @@ TEST(TensorAlgebraIdentityAssumptions, CopyPreservesAnnotationRank2) {
 
 TEST(TensorAlgebraIdentityAssumptions, MovePreservesAnnotationRank4) {
   // Rank-4 move ctor coverage (cpp-pro F7 gap): the rank-4 branch
-  // produces MinorMajor, distinct from rank-2 Symmetric. Both must
+  // produces Major (#351), distinct from rank-2 Symmetric. Both must
   // survive move construction. Pass-1 review on #258: also assert PD
   // survives (orthogonal is rank-2-only by design).
   identity_tensor src{std::size_t{3}, std::size_t{4}};
   identity_tensor moved{std::move(src)};
   ASSERT_TRUE(moved.space().has_value());
-  EXPECT_TRUE(std::holds_alternative<MinorMajor>(moved.space()->perm));
+  EXPECT_TRUE(std::holds_alternative<Major>(moved.space()->perm));
   EXPECT_TRUE(moved.tensor_algebra_assumptions().contains(positive_definite{}));
   EXPECT_TRUE(
       moved.tensor_algebra_assumptions().contains(positive_semidefinite{}));
@@ -1378,7 +1380,7 @@ TEST(TensorAlgebraIdentityAssumptions, CopyPreservesAnnotationRank4) {
   identity_tensor src{std::size_t{3}, std::size_t{4}};
   identity_tensor copy{src};
   ASSERT_TRUE(copy.space().has_value());
-  EXPECT_TRUE(std::holds_alternative<MinorMajor>(copy.space()->perm));
+  EXPECT_TRUE(std::holds_alternative<Major>(copy.space()->perm));
   EXPECT_TRUE(copy.tensor_algebra_assumptions().contains(positive_definite{}));
   EXPECT_TRUE(
       copy.tensor_algebra_assumptions().contains(positive_semidefinite{}));


### PR DESCRIPTION
## Summary

Fixes #351. Stacked on #403.

`I4_{ijkl} = δ_ik·δ_jl` has **major** symmetry only — swapping i↔j gives δ_jk·δ_il, a different tensor (the minor-symmetric identity is P_sym). The MinorMajor tag propagated (negation, scalar-mul) and routed `inv` through the symmetric 6×6 Voigt path:

| Before | After |
|---|---|
| `inv(-I₄)` at (0,1,0,1) → **−0.25** | −1 (the inverse of −I₄ is −I₄) |
| `is_minor_major(I₄)` → true | false; `is_major(I₄)` → true |

Likely related to the pre-existing rank-4 MinorMajor eval failures tracked in #283/#299.

## Tests

Three tests pinned the wrong annotation (`Rank4MinorIdentityIsMinorMajor` + the move/copy preservation pair from #258's review); updated to Major with the #351 rationale. New numeric lock-in evaluates `inv(-I₄)` end-to-end. `Rank4MinorIdentityIsSymmetric` (is_symmetric via the rank-4 identity) still passes unchanged. Full suite: **2440/2440 pass**. gcc-14 clean.