### PR TITLE
Fix #354: t2s constant_mul keeps a symbolic scalar_wrapper factor

### DIFF
--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
@@ -12,6 +12,9 @@ namespace simplifier {
 // --- constant_mul ---
 using t2s_traits = domain_traits<tensor_to_scalar_expression>;
 
+static void push_or_combine(tensor_to_scalar_mul &mul,
+                            mul_base::expr_holder_t const &child);
+
 constant_mul::constant_mul(expr_holder_t lhs, expr_holder_t rhs)
     : base(std::move(lhs), std::move(rhs)),
       lhs_val{t2s_traits::try_numeric(base::m_lhs)} {}
@@ -36,10 +39,14 @@ constant_mul::dispatch(tensor_to_scalar_mul const &rhs) {
   }
   auto mul_expr{make_expression<tensor_to_scalar_mul>(rhs)};
   auto &mul{mul_expr.template get<tensor_to_scalar_mul>()};
-  auto coeff{get_coefficient<t2s_traits>(mul, 1)};
-  if (lhs_val) {
-    coeff = coeff * *lhs_val;
+  if (!lhs_val) {
+    // symbolic scalar_wrapper: keep it as a factor instead of silently
+    // resetting the coefficient (#354)
+    push_or_combine(mul, base::m_lhs);
+    return mul_expr;
   }
+  auto coeff{get_coefficient<t2s_traits>(mul, 1)};
+  coeff = coeff * *lhs_val;
   mul.set_coeff(t2s_traits::make_constant(coeff));
   return mul_expr;
 }

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_mul.cpp
@@ -101,14 +101,19 @@ static void push_or_combine(tensor_to_scalar_mul &mul,
                             mul_base::expr_holder_t const &child) {
   if (try_fold_numeric_pow(mul, child))
     return;
-  auto pos = mul.symbol_map().find(child);
-  if (pos != mul.symbol_map().end()) {
-    auto combined = pos->second * child;
+  // Loop: the combined factor can collide with yet another existing child
+  // (w(x)*w(x) -> w(x^2) meeting a stored w(x^2)); a single-shot combine
+  // then threw on duplicate insertion (review on #354/#346).
+  auto entry = child;
+  while (true) {
+    auto pos = mul.symbol_map().find(entry);
+    if (pos == mul.symbol_map().end())
+      break;
+    auto combined = pos->second * entry;
     mul.symbol_map().erase(pos);
-    mul.push_back(std::move(combined));
-    return;
+    entry = std::move(combined);
   }
-  mul.push_back(child);
+  mul.push_back(std::move(entry));
 }
 
 // --- mul_base ---

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -921,4 +921,20 @@ TYPED_TEST(TensorToScalarExpressionTest,
   EXPECT_EQ(d.get().dim(), X.get().dim());
 }
 
+// #354 — a symbolic scalar_wrapper multiplied into an existing t2s mul must
+// survive as a factor (it was silently dropped and the coefficient reset).
+TYPED_TEST(TensorToScalarExpressionTest,
+           SymbolicWrapperFactorSurvivesMulMerge) {
+  auto &X = this->X;
+  auto &x = this->x;
+  using numsim::cas::det;
+  using numsim::cas::trace;
+  auto f = trace(X) * det(X); // tensor_to_scalar_mul
+  auto w = numsim::cas::make_expression<
+      numsim::cas::tensor_to_scalar_scalar_wrapper>(x);
+  auto e = w * f; // wrapper-first: hits constant_mul::dispatch(mul)
+  auto const s = numsim::cas::to_string(e);
+  EXPECT_NE(s.find("x"), std::string::npos) << s;
+}
+
 #endif // TENSORTOSCALAREXPRESSIONTEST_H

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -937,4 +937,22 @@ TYPED_TEST(TensorToScalarExpressionTest,
   EXPECT_NE(s.find("x"), std::string::npos) << s;
 }
 
+// Review on #354: chained wrapper collisions must fold, not throw.
+TYPED_TEST(TensorToScalarExpressionTest, ChainedWrapperCollisionFolds) {
+  auto &X = this->X;
+  auto &x = this->x;
+  using numsim::cas::trace;
+  auto w = [](auto e) {
+    return numsim::cas::make_expression<
+        numsim::cas::tensor_to_scalar_scalar_wrapper>(e);
+  };
+  // build a mul already holding w(x) and w(x*x); multiplying by w(x) makes
+  // w(x)*w(x) -> w(x^2) collide with the stored w(x*x)
+  auto m = (trace(X) * w(x)) * w(x * x);
+  numsim::cas::expression_holder<numsim::cas::tensor_to_scalar_expression> e;
+  EXPECT_NO_THROW(e = w(x) * m);
+  auto const s = numsim::cas::to_string(e);
+  EXPECT_NE(s.find("pow("), std::string::npos) << s;
+}
+
 #endif // TENSORTOSCALAREXPRESSIONTEST_H


### PR DESCRIPTION
## Summary

Fixes #354. Stacked on #405.

`wrapper(x) * (trace(A)*det(A))` → `1*det(A)*tr(A)` — the symbolic factor **x vanished** and the coefficient was reset. When `try_numeric` fails on the LHS wrapper, `constant_mul::dispatch(tensor_to_scalar_mul)` never inserted it. The promoted route (`x * (f*g)`) goes through `mul_base` and was correct, which is why the suite missed it.

## Fix

Non-numeric wrappers insert as factors via `push_or_combine` (forward-declared; merging with an existing wrapper child through the existing unwrap-multiply-rewrap path). Numeric path unchanged.

## Tests

Typed lock-in across all three dims (wrapper-first construction so the regression can't dodge through the promoted route). Full suite: **2445/2445 pass**.