### PR TITLE
Fix #353: t2s contraction evaluation honors the index sequences

### DIFF
--- a/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
@@ -4,6 +4,7 @@
 #include "spectral_decomposition_cache.h"
 #include "tensor_data.h"
 #include <numsim_cas/core/cas_error.h>
+#include <numsim_cas/tensor/sequence.h>
 
 #include <algorithm>
 #include <array>
@@ -58,18 +59,36 @@ class tensor_data_dcontract_wrapper final
     : public tensor_data_eval_up_unary<tensor_data_dcontract_wrapper<ValueType>,
                                        ValueType> {
 public:
+  // #353 — the contraction sequences are part of the node semantics:
+  // {1,2}/{2,1} is A_ij*B_ji (A : B^T), not A : B.
   tensor_data_dcontract_wrapper(tensor_data_base<ValueType> const &lhs,
-                                tensor_data_base<ValueType> const &rhs)
-      : m_lhs(lhs), m_rhs(rhs) {}
+                                tensor_data_base<ValueType> const &rhs,
+                                sequence const &lhs_indices,
+                                sequence const &rhs_indices)
+      : m_lhs(lhs), m_rhs(rhs), m_lhs_indices(lhs_indices),
+        m_rhs_indices(rhs_indices) {}
 
   template <std::size_t Dim, std::size_t Rank> ValueType evaluate_imp() {
     if constexpr (Rank == 2) {
       using Tensor = tensor_data<ValueType, Dim, Rank>;
       auto const &l = static_cast<const Tensor &>(m_lhs).data();
       auto const &r = static_cast<const Tensor &>(m_rhs).data();
-      return static_cast<ValueType>(tmech::dcontract(l, r));
+      const bool straight{m_lhs_indices == m_rhs_indices};
+      if (straight) {
+        // {1,2}/{1,2} = A_ij B_ij; {2,1}/{2,1} = A_ji B_ji = same sum
+        return static_cast<ValueType>(tmech::dcontract(l, r));
+      }
+      // {1,2}/{2,1} (either orientation) = A_ij B_ji
+      return static_cast<ValueType>(tmech::dcontract(l, tmech::trans(r)));
+    } else if constexpr (Rank == 1) {
+      using Tensor = tensor_data<ValueType, Dim, Rank>;
+      auto const &l = static_cast<const Tensor &>(m_lhs).data();
+      auto const &r = static_cast<const Tensor &>(m_rhs).data();
+      return static_cast<ValueType>(tmech::dot(l, r));
     } else {
-      throw evaluation_error("tensor_data_dcontract_wrapper: requires rank 2");
+      throw evaluation_error(
+          "tensor_data_dcontract_wrapper: rank > 2 contraction not "
+          "implemented (#353 follow-up in #383)");
     }
   }
 
@@ -86,6 +105,8 @@ public:
 private:
   tensor_data_base<ValueType> const &m_lhs;
   tensor_data_base<ValueType> const &m_rhs;
+  sequence m_lhs_indices;
+  sequence m_rhs_indices;
 };
 
 // ─── Eigenvalue wrapper: dispatches runtime (dim,rank), computes the

--- a/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
+++ b/include/numsim_cas/tensor/data/tensor_data_to_scalar_wrapper.h
@@ -69,6 +69,17 @@ public:
         m_rhs_indices(rhs_indices) {}
 
   template <std::size_t Dim, std::size_t Rank> ValueType evaluate_imp() {
+    // The dispatch picks Dim/Rank from the LHS; a mixed-rank/dim node
+    // (constructible through the weak dot_product precondition, #360)
+    // would type-pun the RHS cast into silent garbage (review on #353).
+    if (m_lhs.rank() != m_rhs.rank() || m_lhs.dim() != m_rhs.dim()) {
+      throw evaluation_error(
+          "tensor_data_dcontract_wrapper: operand rank/dim mismatch");
+    }
+    if (m_lhs_indices.size() != Rank || m_rhs_indices.size() != Rank) {
+      throw evaluation_error(
+          "tensor_data_dcontract_wrapper: sequence size != operand rank");
+    }
     if constexpr (Rank == 2) {
       using Tensor = tensor_data<ValueType, Dim, Rank>;
       auto const &l = static_cast<const Tensor &>(m_lhs).data();

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_evaluator.h
@@ -160,7 +160,8 @@ public:
     auto rhs_data = m_tensor_eval.apply(v.expr_rhs());
     const auto dim = lhs_data->dim();
     const auto rank = lhs_data->rank();
-    tensor_data_dcontract_wrapper<ValueType> op(*lhs_data, *rhs_data);
+    tensor_data_dcontract_wrapper<ValueType> op(
+        *lhs_data, *rhs_data, v.indices_lhs(), v.indices_rhs());
     m_result = op.evaluate(dim, rank);
   }
 

--- a/tests/TensorToScalarEvaluatorTest.h
+++ b/tests/TensorToScalarEvaluatorTest.h
@@ -482,4 +482,35 @@ TEST(T2sEval, SpectralCacheInterleavedTensors) {
 
 } // namespace numsim::cas
 
+// #353 — the evaluator must honor the stored contraction sequences.
+TEST(T2sContractionSequences, TransposedRank2AndRank1Dot) {
+  using namespace numsim::cas;
+  auto [A, B] =
+      make_tensor_variable(std::tuple{"A", std::size_t{3}, std::size_t{2}},
+                           std::tuple{"B", std::size_t{3}, std::size_t{2}});
+  tensor_to_scalar_evaluator<double> ev;
+  const std::array<double, 9> av{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const std::array<double, 9> bv{2, 3, 1, 0.5, -1, 4, 2, 2, -3};
+  ev.set(A, make_test_data<3, 2>({1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  ev.set(B, make_test_data<3, 2>({2, 3, 1, 0.5, -1, 4, 2, 2, -3}));
+  double sum_plain = 0.0, sum_trans = 0.0;
+  for (std::size_t i = 0; i < 3; ++i)
+    for (std::size_t j = 0; j < 3; ++j) {
+      sum_plain += av[i * 3 + j] * bv[i * 3 + j];
+      sum_trans += av[i * 3 + j] * bv[j * 3 + i];
+    }
+  auto plain = dot_product(A, sequence{1, 2}, B, sequence{1, 2});
+  auto transp = dot_product(A, sequence{1, 2}, B, sequence{2, 1});
+  EXPECT_NEAR(ev.apply(plain), sum_plain, 1e-12);
+  EXPECT_NEAR(ev.apply(transp), sum_trans, 1e-12); // was sum_plain (#353)
+
+  auto [u, v] =
+      make_tensor_variable(std::tuple{"u", std::size_t{3}, std::size_t{1}},
+                           std::tuple{"v", std::size_t{3}, std::size_t{1}});
+  ev.set(u, make_test_data<3, 1>({1, 2, 3}));
+  ev.set(v, make_test_data<3, 1>({4, 3, 2}));
+  auto d = dot_product(u, sequence{1}, v, sequence{1});
+  EXPECT_NEAR(ev.apply(d), 4.0 + 6.0 + 6.0, 1e-12); // threw pre-#353
+}
+
 #endif // TENSORTOSCALAREVALUATORTEST_H


### PR DESCRIPTION
## Summary

Fixes #353. Stacked on #406. Completes the node whose identity half landed in #399 (#343).

| Before | After |
|---|---|
| `dot_product(A,{1,2},B,{2,1})` evaluated as plain A : B (542.5 vs correct 479.5 in the issue repro) | contracts against the transpose |
| `dot_product(u,{1},v,{1})` threw `requires rank 2` | `tmech::dot` — also unblocks evaluating `diff(dot(u), s)` for rank-1 args |
| rank>2 silently wrong / opaque throw | clear not-implemented error referencing the #383 ceilings epic (general sequence-driven contraction is that epic's task) |

## Tests

Numeric lock-in comparing both rank-2 orientations against hand-computed sums plus the rank-1 dot. Full suite: **2446/2446 pass**. gcc-14 clean.