### PR TITLE
Fix #350: tensor_pow contract — rank-2 only, integer exponents, working negative powers

### DIFF
--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -48,7 +48,10 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
   }
   // Non-integer constant exponents have no matrix-power meaning here;
   // isotropic tensor functions (#227) cover fractional powers (#350).
-  if (is_same<scalar_constant>(expr_rhs)) {
+  if (is_same<scalar_constant>(expr_rhs) ||
+      (is_same<scalar_negative>(expr_rhs) &&
+       is_same<scalar_constant>(
+           expr_rhs.template get<scalar_negative>().expr()))) {
     if (!try_int_constant(expr_rhs)) {
       throw invalid_expression_error(
           "pow: tensor exponent must be an integer constant");

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -39,6 +39,21 @@ namespace numsim::cas {
 
 template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
 [[nodiscard]] auto pow(ExprLHS &&expr_lhs, ExprRHS &&expr_rhs) {
+  // Matrix powers are rank-2 only; the evaluator's repeated contraction
+  // and the diff kernels are meaningless for other ranks (#350).
+  if (expr_lhs.get().rank() != 2) {
+    throw invalid_expression_error(
+        "pow: tensor operand must be rank 2 (got rank " +
+        std::to_string(expr_lhs.get().rank()) + ")");
+  }
+  // Non-integer constant exponents have no matrix-power meaning here;
+  // isotropic tensor functions (#227) cover fractional powers (#350).
+  if (is_same<scalar_constant>(expr_rhs)) {
+    if (!try_int_constant(expr_rhs)) {
+      throw invalid_expression_error(
+          "pow: tensor exponent must be an integer constant");
+    }
+  }
   // pow(0, n) → 0
   if (is_same<tensor_zero>(expr_lhs))
     return make_expression<tensor_zero>(expr_lhs.get().dim(),

--- a/include/numsim_cas/tensor/tensor_std.h
+++ b/include/numsim_cas/tensor/tensor_std.h
@@ -48,11 +48,14 @@ template <tensor_expr_holder ExprLHS, scalar_expr_holder ExprRHS>
   }
   // Non-integer constant exponents have no matrix-power meaning here;
   // isotropic tensor functions (#227) cover fractional powers (#350).
-  if (is_same<scalar_constant>(expr_rhs) ||
-      (is_same<scalar_negative>(expr_rhs) &&
-       is_same<scalar_constant>(
-           expr_rhs.template get<scalar_negative>().expr()))) {
-    if (!try_int_constant(expr_rhs)) {
+  {
+    // strip any depth of negation before the literal check, matching
+    // try_int_constant's own recursion (round-2 review on #350)
+    expression_holder<scalar_expression> probe{expr_rhs};
+    while (is_same<scalar_negative>(probe)) {
+      probe = probe.template get<scalar_negative>().expr();
+    }
+    if (is_same<scalar_constant>(probe) && !try_int_constant(expr_rhs)) {
       throw invalid_expression_error(
           "pow: tensor exponent must be an integer constant");
     }

--- a/include/numsim_cas/tensor/visitors/tensor_evaluator.h
+++ b/include/numsim_cas/tensor/visitors/tensor_evaluator.h
@@ -1,6 +1,8 @@
 #ifndef TENSOR_EVALUATOR_H
 #define TENSOR_EVALUATOR_H
 
+#include <cmath>
+
 #include <algorithm>
 #include <cstring>
 #include <map>
@@ -257,6 +259,11 @@ public:
   void operator()(tensor_pow const &visitable) override {
     auto base_data = apply(visitable.expr_lhs());
     const auto exp_val = m_scalar_eval.apply(visitable.expr_rhs());
+    if (exp_val != std::round(exp_val)) {
+      // silently truncating pow(A, 0.5) to the identity was #350
+      throw evaluation_error(
+          "tensor_pow: exponent must evaluate to an integer");
+    }
     const auto n = static_cast<int>(exp_val);
     const auto d = visitable.dim();
     const auto r = visitable.rank();
@@ -283,6 +290,14 @@ public:
                                               lhs_idx, rhs_idx);
       ip.evaluate(d, r, r);
       accumulated = std::move(temp);
+    }
+    if (n < 0) {
+      // A^-n = inv(A^n); without this, pow(X,-1) returned X itself (#350)
+      auto inverted = make_tensor_data<ValueType>(d, r);
+      tensor_data_unary_wrapper<tmech_ops::inv, ValueType> iv(*inverted,
+                                                              *accumulated);
+      iv.evaluate(d, r);
+      accumulated = std::move(inverted);
     }
     m_result = std::move(accumulated);
   }

--- a/include/numsim_cas/tensor/visitors/tensor_evaluator.h
+++ b/include/numsim_cas/tensor/visitors/tensor_evaluator.h
@@ -265,7 +265,7 @@ public:
     }
     auto base_data = apply(visitable.expr_lhs());
     const auto exp_val = m_scalar_eval.apply(visitable.expr_rhs());
-    if (exp_val != std::round(exp_val) || exp_val < -1e9 || exp_val > 1e9) {
+    if (exp_val != std::round(exp_val) || exp_val < -1e6 || exp_val > 1e6) {
       // silently truncating pow(A, 0.5) to the identity was #350; the
       // range check keeps the int cast below defined for huge values
       throw evaluation_error(

--- a/include/numsim_cas/tensor/visitors/tensor_evaluator.h
+++ b/include/numsim_cas/tensor/visitors/tensor_evaluator.h
@@ -257,12 +257,19 @@ public:
   // ─── Tensor functions (tmech wrappers) ─────────────────────
 
   void operator()(tensor_pow const &visitable) override {
+    if (visitable.rank() != 2) {
+      // the repeated single-index contraction is rank-2-only; a rebuilt
+      // tree can bypass the factory gate (review on #350: substitution
+      // recreated a rank-4 pow and corrupted the heap)
+      throw evaluation_error("tensor_pow: rank-2 operand required");
+    }
     auto base_data = apply(visitable.expr_lhs());
     const auto exp_val = m_scalar_eval.apply(visitable.expr_rhs());
-    if (exp_val != std::round(exp_val)) {
-      // silently truncating pow(A, 0.5) to the identity was #350
+    if (exp_val != std::round(exp_val) || exp_val < -1e9 || exp_val > 1e9) {
+      // silently truncating pow(A, 0.5) to the identity was #350; the
+      // range check keeps the int cast below defined for huge values
       throw evaluation_error(
-          "tensor_pow: exponent must evaluate to an integer");
+          "tensor_pow: exponent must evaluate to a moderate integer");
     }
     const auto n = static_cast<int>(exp_val);
     const auto d = visitable.dim();

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation.cpp
@@ -43,6 +43,14 @@ void tensor_differentiation::operator()(tensor_pow const &visitable) {
   }
   auto n = static_cast<std::int64_t>(*int_n);
 
+  if (n < 0) {
+    // the product-rule loop below never runs for n < 0 and the invalid
+    // sum silently coerced to zero (#350); rewrite via inv() instead
+    throw not_implemented_error(
+        "tensor_differentiation: negative tensor power - rewrite as "
+        "inv(pow(A, n))");
+  }
+
   // n == 0: pow(A, 0) = I (constant), derivative is zero. The loop
   // below would correctly leave sum invalid and apply()'s fallback
   // would coerce to tensor_zero, but an explicit guard documents the

--- a/src/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.cpp
+++ b/src/numsim_cas/tensor/visitors/tensor_differentiation_wrt_scalar.cpp
@@ -55,6 +55,12 @@ void tensor_differentiation_wrt_scalar::operator()(
   }
   auto n = static_cast<std::int64_t>(*int_n);
 
+  if (n < 0) {
+    throw not_implemented_error(
+        "tensor_differentiation_wrt_scalar: negative tensor power - "
+        "rewrite as inv(pow(A, n))");
+  }
+
   // Build sum: sum_{r=0}^{n-1} (A^r) * (dA/ds) * (A^{n-1-r})
   // For rank-2 A, matrix multiplication is inner_product on the
   // contraction index. A^r and A^{n-1-r} are also rank-2.

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1881,6 +1881,27 @@ TEST(TensorPowContract, DiffOfNegativePowerThrows) {
   EXPECT_THROW((void)diff(pow(X, -2), X), not_implemented_error);
   EXPECT_NO_THROW((void)diff(inv(pow(X, 2)), X));}
 
+// Review on #350: the rank gate must also hold at evaluation (rebuilt
+// trees bypass the factory), and the factory gate must see negation-
+// wrapped constants.
+TEST(TensorPowContract, EvaluatorRankGateAndWrappedExponent) {
+  auto [X] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
+  auto [C] =
+      make_tensor_variable(std::tuple{"C", std::size_t{3}, std::size_t{4}});
+  // substitution recreates the node without the factory gate; evaluation
+  // must throw instead of corrupting the heap
+  auto p4 = substitute(pow(X, 2), X, C);
+  tensor_evaluator<double> ev;
+  auto data = std::make_shared<tensor_data<double, 3, 4>>();
+  ev.set(C, data);
+  EXPECT_THROW((void)ev.apply(p4), evaluation_error);
+  // negation-wrapped fractional constants are rejected at the factory
+  auto half = make_expression<scalar_constant>(0.5);
+  EXPECT_THROW((void)pow(X, make_expression<scalar_negative>(std::move(half))),
+               invalid_expression_error);
+}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1844,6 +1844,43 @@ TEST(RoundTwoReview, DimChangingSubstitutionDropsTag) {
   EXPECT_THROW((void)ev.apply(s), evaluation_error);
 }
 
+// #350 — tensor_pow contract: rank-2 only, integer exponents, negative
+// exponents invert, diff of negative powers no longer silently zero.
+TEST(TensorPowContract, RankAndExponentGates) {
+  auto [C] =
+      make_tensor_variable(std::tuple{"C", std::size_t{3}, std::size_t{4}});
+  auto [X] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
+  EXPECT_THROW((void)pow(C, 2), invalid_expression_error);
+  EXPECT_THROW((void)pow(C, 0), invalid_expression_error);
+  EXPECT_THROW((void)pow(X, make_expression<scalar_constant>(0.5)),
+               invalid_expression_error);
+  EXPECT_NO_THROW((void)pow(X, 3));
+  EXPECT_NO_THROW((void)pow(X, -2));
+}
+
+TEST(TensorPowContract, NegativeExponentEvaluatesInverse) {
+  auto [X] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
+  tensor_evaluator<double> ev;
+  auto data = std::make_shared<tensor_data<double, 3, 2>>();
+  data->data()(0, 0) = 2.0;
+  data->data()(1, 1) = 4.0;
+  data->data()(2, 2) = 5.0;
+  ev.set(X, data);
+  auto r1 = ev.apply(pow(X, -1));
+  EXPECT_NEAR(r1->raw_data()[0], 0.5, 1e-12); // was 2.0 (#350)
+  auto r2 = ev.apply(pow(X, -2));
+  EXPECT_NEAR(r2->raw_data()[0], 0.25, 1e-12);
+}
+
+TEST(TensorPowContract, DiffOfNegativePowerThrows) {
+  auto [X] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
+  // was a silent 0{4} (#350); inv(pow(X, 2)) is the supported spelling
+  EXPECT_THROW((void)diff(pow(X, -2), X), not_implemented_error);
+  EXPECT_NO_THROW((void)diff(inv(pow(X, 2)), X));}
+
 } // namespace numsim::cas
 
 #endif // COREBUGFIXTEST_H

--- a/tests/CoreBugFixTest.h
+++ b/tests/CoreBugFixTest.h
@@ -1879,7 +1879,8 @@ TEST(TensorPowContract, DiffOfNegativePowerThrows) {
       make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
   // was a silent 0{4} (#350); inv(pow(X, 2)) is the supported spelling
   EXPECT_THROW((void)diff(pow(X, -2), X), not_implemented_error);
-  EXPECT_NO_THROW((void)diff(inv(pow(X, 2)), X));}
+  EXPECT_NO_THROW((void)diff(inv(pow(X, 2)), X));
+}
 
 // Review on #350: the rank gate must also hold at evaluation (rebuilt
 // trees bypass the factory), and the factory gate must see negation-
@@ -1900,6 +1901,20 @@ TEST(TensorPowContract, EvaluatorRankGateAndWrappedExponent) {
   auto half = make_expression<scalar_constant>(0.5);
   EXPECT_THROW((void)pow(X, make_expression<scalar_negative>(std::move(half))),
                invalid_expression_error);
+}
+
+// Round-2 review on #350: the factory gate strips any negation depth.
+TEST(RoundTwoReview, DoubleNegatedFractionalExponentRejected) {
+  auto [X] =
+      make_tensor_variable(std::tuple{"X", std::size_t{3}, std::size_t{2}});
+  auto inner =
+      make_expression<scalar_negative>(make_expression<scalar_constant>(0.5));
+  EXPECT_THROW((void)pow(X, make_expression<scalar_negative>(std::move(inner))),
+               invalid_expression_error);
+  // negated integers still accepted
+  auto neg2 =
+      make_expression<scalar_negative>(make_expression<scalar_constant>(2));
+  EXPECT_NO_THROW((void)pow(X, std::move(neg2)));
 }
 
 } // namespace numsim::cas


### PR DESCRIPTION
## Summary

Fixes #350. Stacked on #407.

| Before | After |
|---|---|
| `eval(pow(X,-1))` returned **X itself** (no inversion) | inverts: 0.5 for diag entry 2 |
| `pow(X, 0.5)` evaluated to the **identity** (int truncation) | factory rejects; evaluator throws on non-integer values |
| `diff(pow(X,-2), X)` → silent `0{4}` | `not_implemented_error` pointing at `inv(pow(A,n))` (which differentiates correctly today) |
| `pow(C4, 0)` → **rank-2** identity for a rank-4 operand | rank gate at the factory (`invalid_expression_error`) |

## Design

Construct-early philosophy per the #383 ceilings epic: the factory gates rank (2 only — matching `dev`/`sym`/`trans` and #192's `inv` fix) and integer-constant exponents; the evaluator and diff visitors keep defense-in-depth guards for trees built by other paths. Negative integer powers now evaluate correctly (invert the accumulated power); their differentiation stays explicit-unsupported rather than silently wrong — the `inv(pow(A,n))` spelling covers that need (lock-in included).

## Tests

3 lock-ins: gates, numeric inverse evaluation (n=−1, −2), diff throw + supported spelling. Full suite: **2449/2449 pass**. gcc-14 clean.