### PR TITLE
Fix #356: CI can now fail on UBSan findings and clang-tidy warnings

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run clang-tidy
         run: |
           find src -name '*.cpp' -print0 \
-          | xargs -0 clang-tidy-18 -p build
+          | xargs -0 clang-tidy-18 -p build --warnings-as-errors='*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,9 +194,10 @@ endif()
 # Sanitizers
 if(NUMSIM_CAS_SANITIZERS)
     target_compile_options(${PROJECT_NAME} PUBLIC
-        -fsanitize=address,undefined -fno-omit-frame-pointer)
+        -fsanitize=address,undefined -fno-sanitize-recover=undefined
+        -fno-omit-frame-pointer)
     target_link_options(${PROJECT_NAME} PUBLIC
-        -fsanitize=address,undefined)
+        -fsanitize=address,undefined -fno-sanitize-recover=undefined)
 endif()
 
 # Optional convenience for Windows
@@ -274,9 +275,10 @@ if(NUMSIM_CAS_BUILD_PARSER)
 
   if(NUMSIM_CAS_SANITIZERS)
     target_compile_options(NumSim_CAS_Parser PUBLIC
-      -fsanitize=address,undefined -fno-omit-frame-pointer)
+      -fsanitize=address,undefined -fno-sanitize-recover=undefined
+      -fno-omit-frame-pointer)
     target_link_options(NumSim_CAS_Parser PUBLIC
-      -fsanitize=address,undefined)
+      -fsanitize=address,undefined -fno-sanitize-recover=undefined)
   endif()
 
   if(WIN32)

--- a/include/numsim_cas/core/scalar_number.h
+++ b/include/numsim_cas/core/scalar_number.h
@@ -96,7 +96,7 @@ public:
                                           scalar_number const &exp);
 
 private:
-  explicit scalar_number(variant_t vv) : v_(std::move(vv)) {
+  explicit scalar_number(variant_t vv) : v_(vv) {
     if (auto *r = std::get_if<rational_t>(&v_)) {
       if (r->den == 1)
         v_ = r->num;

--- a/include/numsim_cas/parser/parse_error.h
+++ b/include/numsim_cas/parser/parse_error.h
@@ -37,7 +37,7 @@ class parse_error : public cas_error {
 public:
   /// Construct with optional source context. Pass an empty `source` and
   /// `byte_offset = 0` for errors raised outside the parser.
-  parse_error(std::string message, std::size_t byte_offset,
+  parse_error(std::string const &message, std::size_t byte_offset,
               std::string_view source);
 
   /// Byte offset into the source where the error was detected, clamped

--- a/include/numsim_cas/scalar/visitors/scalar_rebuild_visitor.h
+++ b/include/numsim_cas/scalar/visitors/scalar_rebuild_visitor.h
@@ -14,7 +14,7 @@ class scalar_rebuild_visitor : public scalar_visitor_const_t {
 public:
   using expr_holder_t = expression_holder<scalar_expression>;
 
-  virtual ~scalar_rebuild_visitor() = default;
+  ~scalar_rebuild_visitor() override = default;
 
   virtual expr_holder_t apply(expr_holder_t const &expr) {
     if (expr.is_valid()) {

--- a/include/numsim_cas/tensor/wrappers/tensor_inv.h
+++ b/include/numsim_cas/tensor/wrappers/tensor_inv.h
@@ -12,8 +12,8 @@ public:
   using base = unary_op<tensor_node_base_t<tensor_inv>>;
 
   template <typename Expr>
-  explicit tensor_inv(
-      Expr &&_expr) // NOLINT(bugprone-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
+  explicit tensor_inv(Expr &&_expr)
       : base(std::forward<Expr>(_expr), _expr.get().dim(), _expr.get().rank()) {
     // ── Rank gate (#292) ──────────────────────────────────────────
     // Mirror the inv() factory's rank gate (tensor_functions.h:467)

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_rebuild_visitor.h
@@ -19,7 +19,7 @@ public:
   using scalar_holder_t = expression_holder<scalar_expression>;
   using tensor_holder_t = expression_holder<tensor_expression>;
 
-  virtual ~tensor_to_scalar_rebuild_visitor() = default;
+  ~tensor_to_scalar_rebuild_visitor() override = default;
 
   virtual t2s_holder_t apply(t2s_holder_t const &expr) {
     if (expr.is_valid()) {

--- a/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_substitution.h
+++ b/include/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_substitution.h
@@ -45,9 +45,8 @@ public:
   }
 
   tensor_holder_t apply_tensor(tensor_holder_t const &expr) override {
-    if constexpr (std::is_same_v<TargetBase, tensor_expression>) {
-      return substitute(expr, m_old, m_new);
-    } else if constexpr (std::is_same_v<TargetBase, scalar_expression>) {
+    if constexpr (std::is_same_v<TargetBase, tensor_expression> ||
+                  std::is_same_v<TargetBase, scalar_expression>) {
       return substitute(expr, m_old, m_new);
     } else {
       return expr;

--- a/src/numsim_cas/parser/parse_error.cpp
+++ b/src/numsim_cas/parser/parse_error.cpp
@@ -63,7 +63,7 @@ std::string format_message(std::string_view body, std::string_view source,
 
 } // namespace
 
-parse_error::parse_error(std::string message, std::size_t byte_offset,
+parse_error::parse_error(std::string const &message, std::size_t byte_offset,
                          std::string_view source)
     : cas_error(format_message(message, source, byte_offset)) {
   if (!source.empty()) {

--- a/src/numsim_cas/parser/parser.cpp
+++ b/src/numsim_cas/parser/parser.cpp
@@ -38,7 +38,7 @@ syntax_error translate_pegtl_error(pegtl::parse_error const &e,
   // returns a string_view from message() which can't directly
   // construct a std::string by '='.
   std::string msg(e.message());
-  return syntax_error(std::move(msg), byte, source);
+  return syntax_error(msg, byte, source);
 }
 
 // #355 — PEGTL parses by C++ recursion; deeply nested input overflows the
@@ -150,7 +150,7 @@ parsed_expression parse(std::string_view source, symbol_table &syms) {
               "bracket-list literal '[...]' cannot be a top-level expression",
               source.size(), source);
         } else {
-          return std::move(v);
+          return std::forward<decltype(v)>(v);
         }
       },
       std::move(state.values.front()));

--- a/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
+++ b/src/numsim_cas/tensor_to_scalar/visitors/tensor_to_scalar_differentiation_wrt_scalar.cpp
@@ -218,7 +218,7 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   if (!dA.is_valid() || is_same<tensor_zero>(dA)) {
     return;
   }
-  m_result = trace(std::move(dA));
+  m_result = trace(dA);
 }
 
 // dot(A) = A:A. d/ds = 2 * (A : dA/ds).
@@ -237,8 +237,8 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   sequence idx_a(rank), idx_b(rank);
   std::iota(idx_a.begin(), idx_a.end(), std::size_t{0});
   std::iota(idx_b.begin(), idx_b.end(), std::size_t{0});
-  auto contraction = dot_product(visitable.expr(), std::move(idx_a),
-                                 std::move(dA), std::move(idx_b));
+  auto contraction =
+      dot_product(visitable.expr(), std::move(idx_a), dA, std::move(idx_b));
   m_result =
       wrap_scalar(make_expression<scalar_constant>(2)) * std::move(contraction);
 }
@@ -254,8 +254,8 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   sequence idx_a(rank), idx_b(rank);
   std::iota(idx_a.begin(), idx_a.end(), std::size_t{0});
   std::iota(idx_b.begin(), idx_b.end(), std::size_t{0});
-  auto contraction = dot_product(visitable.expr(), std::move(idx_a),
-                                 std::move(dA), std::move(idx_b));
+  auto contraction =
+      dot_product(visitable.expr(), std::move(idx_a), dA, std::move(idx_b));
   auto inv_norm = pow(m_expr, -wrap_scalar(get_scalar_one()));
   m_result = std::move(contraction) * inv_norm;
 }
@@ -268,8 +268,7 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
     return;
   }
   auto invAT = inv(trans(visitable.expr()));
-  auto contracted =
-      dot_product(invAT, sequence{1, 2}, std::move(dA), sequence{1, 2});
+  auto contracted = dot_product(invAT, sequence{1, 2}, dA, sequence{1, 2});
   m_result = m_expr * std::move(contracted);
 }
 
@@ -282,8 +281,7 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
     return;
   }
   auto Ei = eigen_decomposition(visitable.expr()).basis(visitable.index());
-  m_result =
-      dot_product(std::move(Ei), sequence{1, 2}, std::move(dB), sequence{1, 2});
+  m_result = dot_product(Ei, sequence{1, 2}, dB, sequence{1, 2});
 }
 
 // [f; λ_M]: d/ds = Σ_{distinct k in M} mult_k [f; λ_{M∪{k}}] dλ_k/ds
@@ -330,14 +328,13 @@ void tensor_to_scalar_differentiation_wrt_scalar::operator()(
   if (dA.is_valid() && !is_same<tensor_zero>(dA)) {
     auto s_l = seq_lhs;
     auto s_r = seq_rhs;
-    sum = dot_product(std::move(dA), std::move(s_l), visitable.expr_rhs(),
-                      std::move(s_r));
+    sum = dot_product(dA, std::move(s_l), visitable.expr_rhs(), std::move(s_r));
   }
   if (dB.is_valid() && !is_same<tensor_zero>(dB)) {
     auto s_l = seq_lhs;
     auto s_r = seq_rhs;
-    auto term = dot_product(visitable.expr_lhs(), std::move(s_l), std::move(dB),
-                            std::move(s_r));
+    auto term =
+        dot_product(visitable.expr_lhs(), std::move(s_l), dB, std::move(s_r));
     if (sum.is_valid()) {
       sum += term;
     } else {


### PR DESCRIPTION
## Summary

Fixes #356. Stacked on #409. Deliberately sequenced last: the UBSan flag would have turned CI red before #349 (scalar_number overflow UB) and #361 (hash_combine negative-double UB) landed.

| Job | Before | After |
|---|---|---|
| sanitizer leg | UBSan recover-by-default → prints, exits 0, ctest green on real UB | `-fno-sanitize-recover=undefined` (library + parser blocks) — **verified locally: full suite green under fatal ASan+UBSan** |
| clang-tidy | exits 0 on any warning (`WarningsAsErrors: ''`) | `--warnings-as-errors='*'` |

## Baseline triage (so the tidy job starts green)

All 15 existing findings fixed rather than suppressed: 9× no-op `std::move` into const-ref params / trivially-copyable variant, 2× missing `override` on rebuild-visitor dtors, 1× `std::move` on a forwarding reference → `std::forward`, 1× cloned `if constexpr` branch merged, 1× value param → const-ref (`parse_error` ctor), 1× NOLINT moved to the line it suppresses. Verified: `run-clang-tidy-18` over `src/` reports **0 findings**.

Also includes a fixup on the #355 branch discovered by the parser-less sanitizer build: the depth-guard test sat outside `NUMSIM_CAS_PARSER_ENABLED`.

## Tests

Full suite: **2450/2450**; sanitizer configuration: **2261/2261** under fatal UBSan; gcc-14 clean.