### PR TITLE
Fix #417: scalar function folds under a uniform rule contract + close trig gaps

### DIFF
--- a/docs/simplifier-coverage.md
+++ b/docs/simplifier-coverage.md
@@ -8,18 +8,22 @@
 > **Scope**: visitor-driven simplification in
 > `include/numsim_cas/{core,scalar,tensor,tensor_to_scalar}/simplifier/` only.
 > Construction-time simplifications (e.g. `inv(inv(A)) → A` in `tensor_functions.h`,
-> `sin(asin(x)) → x`, `trace(0) → 0` in
+> `sin(asin(x)) → x` in `scalar_function_rules.h`, `trace(0) → 0` in
 > `tensor_to_scalar_functions.cpp`, the `is_trans_of` annotations in
 > `tensor_operators.h`) are not in this matrix — they deserve a parallel audit
 > as a follow-up. Differentiation, evaluation, printing, and substitution
 > visitors are also out of scope.
 >
-> **Follow-up in progress (#417):** the scalar unary-function construction folds
-> are being extracted from the `scalar_std.h` factory if-chains into named,
-> group-tagged rules under the uniform contract
-> `std::optional<holder> try_<name>(holder const&)`, cataloged in
-> [`scalar/simplifier/scalar_function_rules.h`](../include/numsim_cas/scalar/simplifier/scalar_function_rules.h).
-> That header is the enumerable list a later rule registry would consume.
+> **Follow-up in progress (#417):** the scalar unary-function folds are being
+> extracted from the `scalar_std.h` factory if-chains into named, group-tagged
+> rules under the uniform contract `std::optional<holder> try_<name>(holder const&)`,
+> cataloged in
+> [`scalar/simplifier/scalar_function_rules.h`](../include/numsim_cas/scalar/simplifier/scalar_function_rules.h)
+> (the enumerable list a later rule registry would consume). The same rule bodies
+> serve two drivers: construction canonicalizers run always-on from the factories,
+> while node-expanding rewrites (mixed inverse-trig) are opt-in, driven only by the
+> [`scalar_function_simplifier`](../include/numsim_cas/scalar/simplifier/scalar_function_simplifier.h)
+> pass.
 
 ## Layering
 

--- a/docs/simplifier-coverage.md
+++ b/docs/simplifier-coverage.md
@@ -8,11 +8,18 @@
 > **Scope**: visitor-driven simplification in
 > `include/numsim_cas/{core,scalar,tensor,tensor_to_scalar}/simplifier/` only.
 > Construction-time simplifications (e.g. `inv(inv(A)) → A` in `tensor_functions.h`,
-> `sin(asin(x)) → x` in `scalar_std.h`, `trace(0) → 0` in
+> `sin(asin(x)) → x`, `trace(0) → 0` in
 > `tensor_to_scalar_functions.cpp`, the `is_trans_of` annotations in
 > `tensor_operators.h`) are not in this matrix — they deserve a parallel audit
 > as a follow-up. Differentiation, evaluation, printing, and substitution
 > visitors are also out of scope.
+>
+> **Follow-up in progress (#417):** the scalar unary-function construction folds
+> are being extracted from the `scalar_std.h` factory if-chains into named,
+> group-tagged rules under the uniform contract
+> `std::optional<holder> try_<name>(holder const&)`, cataloged in
+> [`scalar/simplifier/scalar_function_rules.h`](../include/numsim_cas/scalar/simplifier/scalar_function_rules.h).
+> That header is the enumerable list a later rule registry would consume.
 
 ## Layering
 

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -126,6 +126,10 @@ template <scalar_expr_holder E> [[nodiscard]] auto sin(E &&e) {
     return *r;
   if (auto r = scalar_rules::try_sin_odd(e))
     return *r;
+  if (auto r = scalar_rules::try_sin_of_acos(e))
+    return *r;
+  if (auto r = scalar_rules::try_sin_of_atan(e))
+    return *r;
   return make_expression<scalar_sin>(std::forward<E>(e));
 }
 
@@ -136,6 +140,10 @@ template <scalar_expr_holder E> [[nodiscard]] auto cos(E &&e) {
     return *r;
   if (auto r = scalar_rules::try_cos_even(e))
     return *r;
+  if (auto r = scalar_rules::try_cos_of_asin(e))
+    return *r;
+  if (auto r = scalar_rules::try_cos_of_atan(e))
+    return *r;
   return make_expression<scalar_cos>(std::forward<E>(e));
 }
 
@@ -144,11 +152,17 @@ template <scalar_expr_holder E> [[nodiscard]] auto tan(E &&e) {
     return *r;
   if (auto r = scalar_rules::try_tan_inverse(e))
     return *r;
+  if (auto r = scalar_rules::try_tan_odd(e))
+    return *r;
+  if (auto r = scalar_rules::try_tan_of_asin(e))
+    return *r;
   return make_expression<scalar_tan>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto asin(E &&e) {
   if (auto r = scalar_rules::try_asin_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_asin_odd(e))
     return *r;
   return make_expression<scalar_asin>(std::forward<E>(e));
 }
@@ -161,6 +175,8 @@ template <scalar_expr_holder E> [[nodiscard]] auto acos(E &&e) {
 
 template <scalar_expr_holder E> [[nodiscard]] auto atan(E &&e) {
   if (auto r = scalar_rules::try_atan_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_atan_odd(e))
     return *r;
   return make_expression<scalar_atan>(std::forward<E>(e));
 }

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -126,10 +126,6 @@ template <scalar_expr_holder E> [[nodiscard]] auto sin(E &&e) {
     return *r;
   if (auto r = scalar_rules::try_sin_odd(e))
     return *r;
-  if (auto r = scalar_rules::try_sin_of_acos(e))
-    return *r;
-  if (auto r = scalar_rules::try_sin_of_atan(e))
-    return *r;
   return make_expression<scalar_sin>(std::forward<E>(e));
 }
 
@@ -140,10 +136,6 @@ template <scalar_expr_holder E> [[nodiscard]] auto cos(E &&e) {
     return *r;
   if (auto r = scalar_rules::try_cos_even(e))
     return *r;
-  if (auto r = scalar_rules::try_cos_of_asin(e))
-    return *r;
-  if (auto r = scalar_rules::try_cos_of_atan(e))
-    return *r;
   return make_expression<scalar_cos>(std::forward<E>(e));
 }
 
@@ -153,8 +145,6 @@ template <scalar_expr_holder E> [[nodiscard]] auto tan(E &&e) {
   if (auto r = scalar_rules::try_tan_inverse(e))
     return *r;
   if (auto r = scalar_rules::try_tan_odd(e))
-    return *r;
-  if (auto r = scalar_rules::try_tan_of_asin(e))
     return *r;
   return make_expression<scalar_tan>(std::forward<E>(e));
 }

--- a/include/numsim_cas/scalar/scalar_std.h
+++ b/include/numsim_cas/scalar/scalar_std.h
@@ -39,6 +39,7 @@
 #include <numsim_cas/scalar/scalar_sqrt.h>
 #include <numsim_cas/scalar/scalar_tan.h>
 #include <numsim_cas/scalar/scalar_zero.h>
+#include <numsim_cas/scalar/simplifier/scalar_function_rules.h>
 
 namespace numsim::cas {
 
@@ -119,116 +120,98 @@ requires std::is_arithmetic_v<std::remove_cvref_t<R>>
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto sin(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
-  if (is_same<scalar_asin>(e))
-    return e.template get<scalar_asin>().expr();
-  if (is_same<scalar_negative>(e))
-    return -sin(e.template get<scalar_negative>().expr());
+  if (auto r = scalar_rules::try_sin_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_sin_inverse(e))
+    return *r;
+  if (auto r = scalar_rules::try_sin_odd(e))
+    return *r;
   return make_expression<scalar_sin>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto cos(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_one();
-  if (is_same<scalar_acos>(e))
-    return e.template get<scalar_acos>().expr();
-  if (is_same<scalar_negative>(e))
-    return cos(e.template get<scalar_negative>().expr());
+  if (auto r = scalar_rules::try_cos_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_cos_inverse(e))
+    return *r;
+  if (auto r = scalar_rules::try_cos_even(e))
+    return *r;
   return make_expression<scalar_cos>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto tan(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
-  if (is_same<scalar_atan>(e))
-    return e.template get<scalar_atan>().expr();
+  if (auto r = scalar_rules::try_tan_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_tan_inverse(e))
+    return *r;
   return make_expression<scalar_tan>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto asin(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
+  if (auto r = scalar_rules::try_asin_zero(e))
+    return *r;
   return make_expression<scalar_asin>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto acos(E &&e) {
-  if (is_constant_one(e))
-    return get_scalar_zero();
+  if (auto r = scalar_rules::try_acos_one(e))
+    return *r;
   return make_expression<scalar_acos>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto atan(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
+  if (auto r = scalar_rules::try_atan_zero(e))
+    return *r;
   return make_expression<scalar_atan>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto exp(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_one();
-  if (is_same<scalar_log>(e))
-    return e.template get<scalar_log>().expr();
+  if (auto r = scalar_rules::try_exp_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_exp_of_log(e))
+    return *r;
   return make_expression<scalar_exp>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto abs(E &&e) {
-  if (is_positive(e) || is_nonnegative(e))
-    return std::forward<E>(e);
-  if (is_negative(e) || is_nonpositive(e))
-    return -std::forward<E>(e);
+  if (auto r = scalar_rules::try_abs_nonneg(e))
+    return *r;
+  if (auto r = scalar_rules::try_abs_nonpos(e))
+    return *r;
   return make_expression<scalar_abs>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto sqrt(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
-  if (is_constant_one(e))
-    return get_scalar_one();
-  if (is_same<scalar_pow>(e)) {
-    auto const &p = e.template get<scalar_pow>();
-    if (is_same<scalar_constant>(p.expr_rhs()) &&
-        p.expr_rhs().template get<scalar_constant>().value() ==
-            scalar_number{2}) {
-      if (is_nonnegative(p.expr_lhs()) || is_positive(p.expr_lhs()))
-        return p.expr_lhs();
-    }
-  }
-  // sqrt(exp(x)) → exp(x/2)
-  // Implemented via pow(exp(x), 1/2) which triggers pow_base → exp(x * 1/2)
-  if (is_same<scalar_exp>(e)) {
-    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
-    return binary_scalar_pow_simplify(std::forward<E>(e), std::move(half));
-  }
+  if (auto r = scalar_rules::try_sqrt_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_sqrt_one(e))
+    return *r;
+  if (auto r = scalar_rules::try_sqrt_of_square(e))
+    return *r;
+  if (auto r = scalar_rules::try_sqrt_of_exp(e))
+    return *r;
   return make_expression<scalar_sqrt>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto sign(E &&e) {
-  if (is_same<scalar_zero>(e))
-    return get_scalar_zero();
-  if (is_positive(e))
-    return get_scalar_one();
-  if (is_negative(e))
-    return -get_scalar_one();
+  if (auto r = scalar_rules::try_sign_zero(e))
+    return *r;
+  if (auto r = scalar_rules::try_sign_positive(e))
+    return *r;
+  if (auto r = scalar_rules::try_sign_negative(e))
+    return *r;
   return make_expression<scalar_sign>(std::forward<E>(e));
 }
 
 template <scalar_expr_holder E> [[nodiscard]] auto log(E &&e) {
-  if (is_constant_one(e))
-    return get_scalar_zero();
-  if (is_same<scalar_exp>(e))
-    return e.template get<scalar_exp>().expr();
-  // log(sqrt(x)) → log(x)/2
-  if (is_same<scalar_sqrt>(e)) {
-    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
-    return log(e.template get<scalar_sqrt>().expr()) * half;
-  }
-  // log(pow(x, n)) → n * log(x), when x is positive
-  if (is_same<scalar_pow>(e)) {
-    auto const &p = e.template get<scalar_pow>();
-    if (is_positive(p.expr_lhs()))
-      return p.expr_rhs() * log(p.expr_lhs());
-  }
+  if (auto r = scalar_rules::try_log_one(e))
+    return *r;
+  if (auto r = scalar_rules::try_log_of_exp(e))
+    return *r;
+  if (auto r = scalar_rules::try_log_of_sqrt(e))
+    return *r;
+  if (auto r = scalar_rules::try_log_of_pow(e))
+    return *r;
   return make_expression<scalar_log>(std::forward<E>(e));
 }
 

--- a/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
@@ -1,0 +1,67 @@
+#ifndef SCALAR_FUNCTION_RULES_H
+#define SCALAR_FUNCTION_RULES_H
+
+#include <optional>
+
+#include <numsim_cas/scalar/scalar_expression.h>
+
+// Construction-time fold rules for the scalar unary functions (#417).
+//
+// Rule contract: each rule is a named, group-tagged free function
+//     std::optional<holder> try_<name>(holder const& arg);
+// returning nullopt when it does not fire. The function factories in
+// scalar_std.h drive the applicable rules in sequence at construction
+// (the "hand-sequence while small" form); the same functions are the
+// entries a later registry would enumerate. Rules stay individually
+// unit-testable, unlike the previous inline if-chains.
+//
+// Bodies live in scalar_function_rules.cpp so the operators/factories the
+// rewrites call (operator-, pow, sqrt, ...) are visible via ADL there.
+
+namespace numsim::cas::scalar_rules {
+
+using holder = expression_holder<scalar_expression>;
+
+// ── sin [trig] ───────────────────────────────────────────────────────
+std::optional<holder> try_sin_zero(holder const &e);     // sin(0) → 0
+std::optional<holder> try_sin_inverse(holder const &e);  // sin(asin x) → x
+std::optional<holder> try_sin_odd(holder const &e);      // sin(-x) → -sin(x)
+
+// ── cos [trig] ───────────────────────────────────────────────────────
+std::optional<holder> try_cos_zero(holder const &e);     // cos(0) → 1
+std::optional<holder> try_cos_inverse(holder const &e);  // cos(acos x) → x
+std::optional<holder> try_cos_even(holder const &e);     // cos(-x) → cos(x)
+
+// ── tan [trig] ───────────────────────────────────────────────────────
+std::optional<holder> try_tan_zero(holder const &e);     // tan(0) → 0
+std::optional<holder> try_tan_inverse(holder const &e);  // tan(atan x) → x
+
+// ── asin/acos/atan [trig-inverse] ────────────────────────────────────
+std::optional<holder> try_asin_zero(holder const &e);    // asin(0) → 0
+std::optional<holder> try_acos_one(holder const &e);     // acos(1) → 0
+std::optional<holder> try_atan_zero(holder const &e);    // atan(0) → 0
+
+// ── exp/log [exp-log] ────────────────────────────────────────────────
+std::optional<holder> try_exp_zero(holder const &e);     // exp(0) → 1
+std::optional<holder> try_exp_of_log(holder const &e);   // exp(log x) → x
+std::optional<holder> try_log_one(holder const &e);      // log(1) → 0
+std::optional<holder> try_log_of_exp(holder const &e);   // log(exp x) → x
+std::optional<holder> try_log_of_sqrt(holder const &e);  // log(sqrt x) → log(x)/2
+std::optional<holder> try_log_of_pow(holder const &e);   // log(x^n) → n·log(x), x>0
+
+// ── sqrt [sqrt] ──────────────────────────────────────────────────────
+std::optional<holder> try_sqrt_zero(holder const &e);       // sqrt(0) → 0
+std::optional<holder> try_sqrt_one(holder const &e);        // sqrt(1) → 1
+std::optional<holder> try_sqrt_of_square(holder const &e);  // sqrt(x^2) → x, x≥0
+std::optional<holder> try_sqrt_of_exp(holder const &e);     // sqrt(exp x) → exp(x/2)
+
+// ── abs/sign [sign-cone] ─────────────────────────────────────────────
+std::optional<holder> try_abs_nonneg(holder const &e);   // |x| → x,  x≥0
+std::optional<holder> try_abs_nonpos(holder const &e);   // |x| → -x, x≤0
+std::optional<holder> try_sign_zero(holder const &e);    // sign(0) → 0
+std::optional<holder> try_sign_positive(holder const &e);// sign(x) → 1,  x>0
+std::optional<holder> try_sign_negative(holder const &e);// sign(x) → -1, x<0
+
+} // namespace numsim::cas::scalar_rules
+
+#endif // SCALAR_FUNCTION_RULES_H

--- a/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
@@ -5,15 +5,18 @@
 
 #include <numsim_cas/scalar/scalar_expression.h>
 
-// Construction-time fold rules for the scalar unary functions (#417).
+// Fold rules for the scalar unary functions (#417).
 //
 // Rule contract: each rule is a named, group-tagged free function
 //     std::optional<holder> try_<name>(holder const& arg);
-// returning nullopt when it does not fire. The function factories in
-// scalar_std.h drive the applicable rules in sequence at construction
-// (the "hand-sequence while small" form); the same functions are the
-// entries a later registry would enumerate. Rules stay individually
-// unit-testable, unlike the previous inline if-chains.
+// returning nullopt when it does not fire. The same rule bodies serve two
+// drivers with no rewrite:
+//   * construction canonicalizers — driven by the scalar_std.h factories at
+//     construction (always-on), the "hand-sequence while small" form;
+//   * opt-in rewrites (the mixed inverse-trig block below) — driven only by
+//     the scalar_function_simplifier pass, because they expand node count.
+// The catalog is the enumerable list a later registry would consume; rules
+// stay individually unit-testable, unlike the previous inline if-chains.
 //
 // Bodies live in scalar_function_rules.cpp so the operators/factories the
 // rewrites call (operator-, pow, sqrt, ...) are visible via ADL there.
@@ -26,24 +29,16 @@ using holder = expression_holder<scalar_expression>;
 std::optional<holder> try_sin_zero(holder const &e);    // sin(0) → 0
 std::optional<holder> try_sin_inverse(holder const &e); // sin(asin x) → x
 std::optional<holder> try_sin_odd(holder const &e);     // sin(-x) → -sin(x)
-std::optional<holder> try_sin_of_acos(holder const &e); // sin(acos x) → √(1-x²)
-std::optional<holder>
-try_sin_of_atan(holder const &e); // sin(atan x) → x/√(1+x²)
 
 // ── cos [trig] ───────────────────────────────────────────────────────
 std::optional<holder> try_cos_zero(holder const &e);    // cos(0) → 1
 std::optional<holder> try_cos_inverse(holder const &e); // cos(acos x) → x
 std::optional<holder> try_cos_even(holder const &e);    // cos(-x) → cos(x)
-std::optional<holder> try_cos_of_asin(holder const &e); // cos(asin x) → √(1-x²)
-std::optional<holder>
-try_cos_of_atan(holder const &e); // cos(atan x) → 1/√(1+x²)
 
 // ── tan [trig] ───────────────────────────────────────────────────────
 std::optional<holder> try_tan_zero(holder const &e);    // tan(0) → 0
 std::optional<holder> try_tan_inverse(holder const &e); // tan(atan x) → x
 std::optional<holder> try_tan_odd(holder const &e);     // tan(-x) → -tan(x)
-std::optional<holder>
-try_tan_of_asin(holder const &e); // tan(asin x) → x/√(1-x²)
 
 // ── asin/acos/atan [trig-inverse] ────────────────────────────────────
 std::optional<holder> try_asin_zero(holder const &e); // asin(0) → 0
@@ -75,6 +70,19 @@ std::optional<holder> try_abs_nonpos(holder const &e);    // |x| → -x, x≤0
 std::optional<holder> try_sign_zero(holder const &e);     // sign(0) → 0
 std::optional<holder> try_sign_positive(holder const &e); // sign(x) → 1,  x>0
 std::optional<holder> try_sign_negative(holder const &e); // sign(x) → -1, x<0
+
+// ── mixed inverse-trig [opt-in] ──────────────────────────────────────
+// Applied only by the `scalar_function_simplifier` pass, NOT at
+// construction: they are branch-safe identities but *expand* node count
+// (cos(asin x) is simpler as written), so a user must opt in.
+std::optional<holder> try_cos_of_asin(holder const &e); // cos(asin x) → √(1-x²)
+std::optional<holder> try_sin_of_acos(holder const &e); // sin(acos x) → √(1-x²)
+std::optional<holder>
+try_tan_of_asin(holder const &e); // tan(asin x) → x/√(1-x²)
+std::optional<holder>
+try_sin_of_atan(holder const &e); // sin(atan x) → x/√(1+x²)
+std::optional<holder>
+try_cos_of_atan(holder const &e); // cos(atan x) → 1/√(1+x²)
 
 } // namespace numsim::cas::scalar_rules
 

--- a/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_function_rules.h
@@ -23,44 +23,58 @@ namespace numsim::cas::scalar_rules {
 using holder = expression_holder<scalar_expression>;
 
 // ── sin [trig] ───────────────────────────────────────────────────────
-std::optional<holder> try_sin_zero(holder const &e);     // sin(0) → 0
-std::optional<holder> try_sin_inverse(holder const &e);  // sin(asin x) → x
-std::optional<holder> try_sin_odd(holder const &e);      // sin(-x) → -sin(x)
+std::optional<holder> try_sin_zero(holder const &e);    // sin(0) → 0
+std::optional<holder> try_sin_inverse(holder const &e); // sin(asin x) → x
+std::optional<holder> try_sin_odd(holder const &e);     // sin(-x) → -sin(x)
+std::optional<holder> try_sin_of_acos(holder const &e); // sin(acos x) → √(1-x²)
+std::optional<holder>
+try_sin_of_atan(holder const &e); // sin(atan x) → x/√(1+x²)
 
 // ── cos [trig] ───────────────────────────────────────────────────────
-std::optional<holder> try_cos_zero(holder const &e);     // cos(0) → 1
-std::optional<holder> try_cos_inverse(holder const &e);  // cos(acos x) → x
-std::optional<holder> try_cos_even(holder const &e);     // cos(-x) → cos(x)
+std::optional<holder> try_cos_zero(holder const &e);    // cos(0) → 1
+std::optional<holder> try_cos_inverse(holder const &e); // cos(acos x) → x
+std::optional<holder> try_cos_even(holder const &e);    // cos(-x) → cos(x)
+std::optional<holder> try_cos_of_asin(holder const &e); // cos(asin x) → √(1-x²)
+std::optional<holder>
+try_cos_of_atan(holder const &e); // cos(atan x) → 1/√(1+x²)
 
 // ── tan [trig] ───────────────────────────────────────────────────────
-std::optional<holder> try_tan_zero(holder const &e);     // tan(0) → 0
-std::optional<holder> try_tan_inverse(holder const &e);  // tan(atan x) → x
+std::optional<holder> try_tan_zero(holder const &e);    // tan(0) → 0
+std::optional<holder> try_tan_inverse(holder const &e); // tan(atan x) → x
+std::optional<holder> try_tan_odd(holder const &e);     // tan(-x) → -tan(x)
+std::optional<holder>
+try_tan_of_asin(holder const &e); // tan(asin x) → x/√(1-x²)
 
 // ── asin/acos/atan [trig-inverse] ────────────────────────────────────
-std::optional<holder> try_asin_zero(holder const &e);    // asin(0) → 0
-std::optional<holder> try_acos_one(holder const &e);     // acos(1) → 0
-std::optional<holder> try_atan_zero(holder const &e);    // atan(0) → 0
+std::optional<holder> try_asin_zero(holder const &e); // asin(0) → 0
+std::optional<holder> try_asin_odd(holder const &e);  // asin(-x) → -asin(x)
+std::optional<holder> try_acos_one(holder const &e);  // acos(1) → 0
+std::optional<holder> try_atan_zero(holder const &e); // atan(0) → 0
+std::optional<holder> try_atan_odd(holder const &e);  // atan(-x) → -atan(x)
 
 // ── exp/log [exp-log] ────────────────────────────────────────────────
-std::optional<holder> try_exp_zero(holder const &e);     // exp(0) → 1
-std::optional<holder> try_exp_of_log(holder const &e);   // exp(log x) → x
-std::optional<holder> try_log_one(holder const &e);      // log(1) → 0
-std::optional<holder> try_log_of_exp(holder const &e);   // log(exp x) → x
-std::optional<holder> try_log_of_sqrt(holder const &e);  // log(sqrt x) → log(x)/2
-std::optional<holder> try_log_of_pow(holder const &e);   // log(x^n) → n·log(x), x>0
+std::optional<holder> try_exp_zero(holder const &e);   // exp(0) → 1
+std::optional<holder> try_exp_of_log(holder const &e); // exp(log x) → x
+std::optional<holder> try_log_one(holder const &e);    // log(1) → 0
+std::optional<holder> try_log_of_exp(holder const &e); // log(exp x) → x
+std::optional<holder>
+try_log_of_sqrt(holder const &e); // log(sqrt x) → log(x)/2
+std::optional<holder>
+try_log_of_pow(holder const &e); // log(x^n) → n·log(x), x>0
 
 // ── sqrt [sqrt] ──────────────────────────────────────────────────────
-std::optional<holder> try_sqrt_zero(holder const &e);       // sqrt(0) → 0
-std::optional<holder> try_sqrt_one(holder const &e);        // sqrt(1) → 1
-std::optional<holder> try_sqrt_of_square(holder const &e);  // sqrt(x^2) → x, x≥0
-std::optional<holder> try_sqrt_of_exp(holder const &e);     // sqrt(exp x) → exp(x/2)
+std::optional<holder> try_sqrt_zero(holder const &e);      // sqrt(0) → 0
+std::optional<holder> try_sqrt_one(holder const &e);       // sqrt(1) → 1
+std::optional<holder> try_sqrt_of_square(holder const &e); // sqrt(x^2) → x, x≥0
+std::optional<holder>
+try_sqrt_of_exp(holder const &e); // sqrt(exp x) → exp(x/2)
 
 // ── abs/sign [sign-cone] ─────────────────────────────────────────────
-std::optional<holder> try_abs_nonneg(holder const &e);   // |x| → x,  x≥0
-std::optional<holder> try_abs_nonpos(holder const &e);   // |x| → -x, x≤0
-std::optional<holder> try_sign_zero(holder const &e);    // sign(0) → 0
-std::optional<holder> try_sign_positive(holder const &e);// sign(x) → 1,  x>0
-std::optional<holder> try_sign_negative(holder const &e);// sign(x) → -1, x<0
+std::optional<holder> try_abs_nonneg(holder const &e);    // |x| → x,  x≥0
+std::optional<holder> try_abs_nonpos(holder const &e);    // |x| → -x, x≤0
+std::optional<holder> try_sign_zero(holder const &e);     // sign(0) → 0
+std::optional<holder> try_sign_positive(holder const &e); // sign(x) → 1,  x>0
+std::optional<holder> try_sign_negative(holder const &e); // sign(x) → -1, x<0
 
 } // namespace numsim::cas::scalar_rules
 

--- a/include/numsim_cas/scalar/simplifier/scalar_function_simplifier.h
+++ b/include/numsim_cas/scalar/simplifier/scalar_function_simplifier.h
@@ -1,0 +1,25 @@
+#ifndef SCALAR_FUNCTION_SIMPLIFIER_H
+#define SCALAR_FUNCTION_SIMPLIFIER_H
+
+#include <numsim_cas/scalar/visitors/scalar_rebuild_visitor.h>
+
+namespace numsim::cas {
+
+// Opt-in rewrite pass (#417): applies the branch-safe mixed inverse-trig
+// identities (cos(asin x) → √(1-x²), sin(acos x) → √(1-x²), ...) throughout an
+// expression. These expand node count, so they are deliberately NOT applied at
+// construction — run this pass explicitly to opt in. Parallels
+// `tensor_projector_simplifier`. The rewrites themselves are the
+// `scalar_rules::try_*_of_*` contract rules; this pass only drives them.
+class scalar_function_simplifier : public scalar_rebuild_visitor {
+public:
+  expr_holder_t apply(expr_holder_t const &expr) override;
+
+  void operator()(scalar_sin const &v) override;
+  void operator()(scalar_cos const &v) override;
+  void operator()(scalar_tan const &v) override;
+};
+
+} // namespace numsim::cas
+
+#endif // SCALAR_FUNCTION_SIMPLIFIER_H

--- a/src/numsim_cas/scalar/simplifier/scalar_function_rules.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_function_rules.cpp
@@ -1,0 +1,172 @@
+#include <numsim_cas/scalar/simplifier/scalar_function_rules.h>
+
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/core/operators.h>
+#include <numsim_cas/scalar/scalar_operators.h>
+#include <numsim_cas/scalar/scalar_std.h>
+
+// Bodies mirror the previous inline folds in scalar_std.h exactly; #417
+// extracts them into named, testable rules without changing behavior.
+
+namespace numsim::cas::scalar_rules {
+
+// ── sin ──────────────────────────────────────────────────────────────
+std::optional<holder> try_sin_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_sin_inverse(holder const &e) {
+  if (is_same<scalar_asin>(e))
+    return e.get<scalar_asin>().expr();
+  return {};
+}
+std::optional<holder> try_sin_odd(holder const &e) {
+  if (is_same<scalar_negative>(e))
+    return -sin(e.get<scalar_negative>().expr());
+  return {};
+}
+
+// ── cos ──────────────────────────────────────────────────────────────
+std::optional<holder> try_cos_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_one();
+  return {};
+}
+std::optional<holder> try_cos_inverse(holder const &e) {
+  if (is_same<scalar_acos>(e))
+    return e.get<scalar_acos>().expr();
+  return {};
+}
+std::optional<holder> try_cos_even(holder const &e) {
+  if (is_same<scalar_negative>(e))
+    return cos(e.get<scalar_negative>().expr());
+  return {};
+}
+
+// ── tan ──────────────────────────────────────────────────────────────
+std::optional<holder> try_tan_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_tan_inverse(holder const &e) {
+  if (is_same<scalar_atan>(e))
+    return e.get<scalar_atan>().expr();
+  return {};
+}
+
+// ── asin/acos/atan ───────────────────────────────────────────────────
+std::optional<holder> try_asin_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_acos_one(holder const &e) {
+  if (is_constant_one(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_atan_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+
+// ── exp/log ──────────────────────────────────────────────────────────
+std::optional<holder> try_exp_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_one();
+  return {};
+}
+std::optional<holder> try_exp_of_log(holder const &e) {
+  if (is_same<scalar_log>(e))
+    return e.get<scalar_log>().expr();
+  return {};
+}
+std::optional<holder> try_log_one(holder const &e) {
+  if (is_constant_one(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_log_of_exp(holder const &e) {
+  if (is_same<scalar_exp>(e))
+    return e.get<scalar_exp>().expr();
+  return {};
+}
+std::optional<holder> try_log_of_sqrt(holder const &e) {
+  if (is_same<scalar_sqrt>(e)) {
+    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+    return log(e.get<scalar_sqrt>().expr()) * half;
+  }
+  return {};
+}
+std::optional<holder> try_log_of_pow(holder const &e) {
+  if (is_same<scalar_pow>(e)) {
+    auto const &p = e.get<scalar_pow>();
+    if (is_positive(p.expr_lhs()))
+      return p.expr_rhs() * log(p.expr_lhs());
+  }
+  return {};
+}
+
+// ── sqrt ─────────────────────────────────────────────────────────────
+std::optional<holder> try_sqrt_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_sqrt_one(holder const &e) {
+  if (is_constant_one(e))
+    return get_scalar_one();
+  return {};
+}
+std::optional<holder> try_sqrt_of_square(holder const &e) {
+  if (is_same<scalar_pow>(e)) {
+    auto const &p = e.get<scalar_pow>();
+    if (is_same<scalar_constant>(p.expr_rhs()) &&
+        p.expr_rhs().get<scalar_constant>().value() == scalar_number{2}) {
+      if (is_nonnegative(p.expr_lhs()) || is_positive(p.expr_lhs()))
+        return p.expr_lhs();
+    }
+  }
+  return {};
+}
+std::optional<holder> try_sqrt_of_exp(holder const &e) {
+  // sqrt(exp x) → exp(x/2), routed through pow(exp x, 1/2) so pow_base
+  // rewrites it to exp(x·1/2) (matches the original scalar_std.h path).
+  if (is_same<scalar_exp>(e)) {
+    auto half = make_expression<scalar_constant>(scalar_number{1, 2});
+    return binary_scalar_pow_simplify(e, std::move(half));
+  }
+  return {};
+}
+
+// ── abs/sign ─────────────────────────────────────────────────────────
+std::optional<holder> try_abs_nonneg(holder const &e) {
+  if (is_positive(e) || is_nonnegative(e))
+    return e;
+  return {};
+}
+std::optional<holder> try_abs_nonpos(holder const &e) {
+  if (is_negative(e) || is_nonpositive(e))
+    return -e;
+  return {};
+}
+std::optional<holder> try_sign_zero(holder const &e) {
+  if (is_same<scalar_zero>(e))
+    return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_sign_positive(holder const &e) {
+  if (is_positive(e))
+    return get_scalar_one();
+  return {};
+}
+std::optional<holder> try_sign_negative(holder const &e) {
+  if (is_negative(e))
+    return -get_scalar_one();
+  return {};
+}
+
+} // namespace numsim::cas::scalar_rules

--- a/src/numsim_cas/scalar/simplifier/scalar_function_rules.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_function_rules.cpp
@@ -26,6 +26,23 @@ std::optional<holder> try_sin_odd(holder const &e) {
     return -sin(e.get<scalar_negative>().expr());
   return {};
 }
+std::optional<holder> try_sin_of_acos(holder const &e) {
+  // sin(acos x) = √(1-x²); acos maps into [0,π] where sin ≥ 0.
+  if (is_same<scalar_acos>(e)) {
+    auto const &x = e.get<scalar_acos>().expr();
+    return sqrt(get_scalar_one() - pow(x, 2));
+  }
+  return {};
+}
+std::optional<holder> try_sin_of_atan(holder const &e) {
+  // sin(atan x) = x/√(1+x²).
+  if (is_same<scalar_atan>(e)) {
+    auto const &x = e.get<scalar_atan>().expr();
+    auto den = sqrt(get_scalar_one() + pow(x, 2));
+    return x / std::move(den);
+  }
+  return {};
+}
 
 // ── cos ──────────────────────────────────────────────────────────────
 std::optional<holder> try_cos_zero(holder const &e) {
@@ -43,6 +60,23 @@ std::optional<holder> try_cos_even(holder const &e) {
     return cos(e.get<scalar_negative>().expr());
   return {};
 }
+std::optional<holder> try_cos_of_asin(holder const &e) {
+  // cos(asin x) = √(1-x²); asin maps into [-π/2,π/2] where cos ≥ 0.
+  if (is_same<scalar_asin>(e)) {
+    auto const &x = e.get<scalar_asin>().expr();
+    return sqrt(get_scalar_one() - pow(x, 2));
+  }
+  return {};
+}
+std::optional<holder> try_cos_of_atan(holder const &e) {
+  // cos(atan x) = 1/√(1+x²).
+  if (is_same<scalar_atan>(e)) {
+    auto const &x = e.get<scalar_atan>().expr();
+    auto den = sqrt(get_scalar_one() + pow(x, 2));
+    return get_scalar_one() / std::move(den);
+  }
+  return {};
+}
 
 // ── tan ──────────────────────────────────────────────────────────────
 std::optional<holder> try_tan_zero(holder const &e) {
@@ -55,11 +89,30 @@ std::optional<holder> try_tan_inverse(holder const &e) {
     return e.get<scalar_atan>().expr();
   return {};
 }
+std::optional<holder> try_tan_odd(holder const &e) {
+  if (is_same<scalar_negative>(e))
+    return -tan(e.get<scalar_negative>().expr());
+  return {};
+}
+std::optional<holder> try_tan_of_asin(holder const &e) {
+  // tan(asin x) = x/√(1-x²).
+  if (is_same<scalar_asin>(e)) {
+    auto const &x = e.get<scalar_asin>().expr();
+    auto den = sqrt(get_scalar_one() - pow(x, 2));
+    return x / std::move(den);
+  }
+  return {};
+}
 
 // ── asin/acos/atan ───────────────────────────────────────────────────
 std::optional<holder> try_asin_zero(holder const &e) {
   if (is_same<scalar_zero>(e))
     return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_asin_odd(holder const &e) {
+  if (is_same<scalar_negative>(e))
+    return -asin(e.get<scalar_negative>().expr());
   return {};
 }
 std::optional<holder> try_acos_one(holder const &e) {
@@ -70,6 +123,11 @@ std::optional<holder> try_acos_one(holder const &e) {
 std::optional<holder> try_atan_zero(holder const &e) {
   if (is_same<scalar_zero>(e))
     return get_scalar_zero();
+  return {};
+}
+std::optional<holder> try_atan_odd(holder const &e) {
+  if (is_same<scalar_negative>(e))
+    return -atan(e.get<scalar_negative>().expr());
   return {};
 }
 

--- a/src/numsim_cas/scalar/simplifier/scalar_function_simplifier.cpp
+++ b/src/numsim_cas/scalar/simplifier/scalar_function_simplifier.cpp
@@ -1,0 +1,48 @@
+#include <numsim_cas/scalar/simplifier/scalar_function_simplifier.h>
+
+#include <numsim_cas/scalar/scalar_std.h>
+#include <numsim_cas/scalar/simplifier/scalar_function_rules.h>
+
+namespace numsim::cas {
+
+scalar_function_simplifier::expr_holder_t
+scalar_function_simplifier::apply(expr_holder_t const &expr) {
+  return scalar_rebuild_visitor::apply(expr);
+}
+
+void scalar_function_simplifier::operator()(scalar_sin const &v) {
+  auto arg = apply(v.expr());
+  if (auto r = scalar_rules::try_sin_of_acos(arg)) {
+    m_result = std::move(*r);
+    return;
+  }
+  if (auto r = scalar_rules::try_sin_of_atan(arg)) {
+    m_result = std::move(*r);
+    return;
+  }
+  m_result = sin(std::move(arg));
+}
+
+void scalar_function_simplifier::operator()(scalar_cos const &v) {
+  auto arg = apply(v.expr());
+  if (auto r = scalar_rules::try_cos_of_asin(arg)) {
+    m_result = std::move(*r);
+    return;
+  }
+  if (auto r = scalar_rules::try_cos_of_atan(arg)) {
+    m_result = std::move(*r);
+    return;
+  }
+  m_result = cos(std::move(arg));
+}
+
+void scalar_function_simplifier::operator()(scalar_tan const &v) {
+  auto arg = apply(v.expr());
+  if (auto r = scalar_rules::try_tan_of_asin(arg)) {
+    m_result = std::move(*r);
+    return;
+  }
+  m_result = tan(std::move(arg));
+}
+
+} // namespace numsim::cas

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -3,6 +3,7 @@
 
 #include "cas_test_helpers.h"
 #include "numsim_cas/numsim_cas.h"
+#include "numsim_cas/scalar/simplifier/scalar_function_simplifier.h"
 #include "gtest/gtest.h"
 
 #include <cmath>
@@ -615,35 +616,144 @@ TEST_F(ScalarFixture, TrigParitySimplification) {
 }
 
 //
-// Mixed inverse-trig folds (#417 gaps) — branch-safe on the inner
-// inverse function's whole domain. Compare against the exact rewrite so
-// the assertion is independent of print formatting.
+// Mixed inverse-trig folds (#417) are node-expanding, so they are NOT
+// applied at construction — the expression stays symbolic.
 //
-TEST_F(ScalarFixture, MixedInverseTrigSimplification) {
+TEST_F(ScalarFixture, MixedInverseTrigStaysSymbolicAtConstruction) {
   using namespace numsim::cas;
-  EXPECT_SAME_PRINT(cos(asin(x)), sqrt(get_scalar_one() - pow(x, 2)));
-  EXPECT_SAME_PRINT(sin(acos(x)), sqrt(get_scalar_one() - pow(x, 2)));
-  EXPECT_SAME_PRINT(tan(asin(x)), x / sqrt(get_scalar_one() - pow(x, 2)));
-  EXPECT_SAME_PRINT(sin(atan(x)), x / sqrt(get_scalar_one() + pow(x, 2)));
-  EXPECT_SAME_PRINT(cos(atan(x)),
-                    get_scalar_one() / sqrt(get_scalar_one() + pow(x, 2)));
+  EXPECT_PRINT(cos(asin(x)), "cos(asin(x))");
+  EXPECT_PRINT(sin(acos(x)), "sin(acos(x))");
+  EXPECT_PRINT(tan(asin(x)), "tan(asin(x))");
+  EXPECT_PRINT(sin(atan(x)), "sin(atan(x))");
+  EXPECT_PRINT(cos(atan(x)), "cos(atan(x))");
 }
 
 //
-// Rule contract (#417): rules fire on their pattern, decline (nullopt)
-// otherwise, and the migrated folds still fire AT CONSTRUCTION.
+// The opt-in scalar_function_simplifier pass applies them on demand.
+// Compared against the exact rewrite so the assertion is print-independent.
 //
-TEST_F(ScalarFixture, FunctionRuleContract) {
+TEST_F(ScalarFixture, MixedInverseTrigFoldsUnderOptInPass) {
   using namespace numsim::cas;
-  EXPECT_TRUE(scalar_rules::try_sin_zero(_zero).has_value());
-  EXPECT_FALSE(scalar_rules::try_sin_zero(x).has_value());
-  EXPECT_TRUE(scalar_rules::try_tan_odd(-x).has_value());
-  EXPECT_FALSE(scalar_rules::try_tan_odd(x).has_value());
-  EXPECT_TRUE(scalar_rules::try_cos_of_asin(asin(x)).has_value());
-  EXPECT_FALSE(scalar_rules::try_cos_of_asin(x).has_value());
-  // lock-in: folds reachable at construction, not only via direct rule call
+  scalar_function_simplifier pass;
+  EXPECT_SAME_PRINT(pass.apply(cos(asin(x))),
+                    sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(pass.apply(sin(acos(x))),
+                    sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(pass.apply(tan(asin(x))),
+                    x / sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(pass.apply(sin(atan(x))),
+                    x / sqrt(get_scalar_one() + pow(x, 2)));
+  EXPECT_SAME_PRINT(pass.apply(cos(atan(x))),
+                    get_scalar_one() / sqrt(get_scalar_one() + pow(x, 2)));
+  // reaches nested occurrences; leaves non-matching functions alone
+  EXPECT_SAME_PRINT(pass.apply(y + cos(asin(x))),
+                    y + sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_PRINT(pass.apply(sin(x)), "sin(x)");
+}
+
+//
+// Rule contract (#417): every rule fires on its pattern and declines
+// (nullopt) otherwise — the individually-testable payoff of the contract.
+//
+TEST_F(ScalarFixture, FunctionRulesUnitCoverage) {
+  using namespace numsim::cas;
+  namespace r = numsim::cas::scalar_rules;
+  auto px = make_expression<scalar>("rpx");
+  assume(px, positive{});
+  auto nx = make_expression<scalar>("rnx");
+  assume(nx, negative{});
+  auto asinx = asin(x), acosx = acos(x), atanx = atan(x);
+
+  // sin / cos / tan
+  EXPECT_TRUE(r::try_sin_zero(_zero));
+  EXPECT_FALSE(r::try_sin_zero(x));
+  EXPECT_TRUE(r::try_sin_inverse(asinx));
+  EXPECT_FALSE(r::try_sin_inverse(x));
+  EXPECT_TRUE(r::try_sin_odd(-x));
+  EXPECT_FALSE(r::try_sin_odd(x));
+  EXPECT_TRUE(r::try_cos_zero(_zero));
+  EXPECT_FALSE(r::try_cos_zero(x));
+  EXPECT_TRUE(r::try_cos_inverse(acosx));
+  EXPECT_FALSE(r::try_cos_inverse(x));
+  EXPECT_TRUE(r::try_cos_even(-x));
+  EXPECT_FALSE(r::try_cos_even(x));
+  EXPECT_TRUE(r::try_tan_zero(_zero));
+  EXPECT_FALSE(r::try_tan_zero(x));
+  EXPECT_TRUE(r::try_tan_inverse(atanx));
+  EXPECT_FALSE(r::try_tan_inverse(x));
+  EXPECT_TRUE(r::try_tan_odd(-x));
+  EXPECT_FALSE(r::try_tan_odd(x));
+
+  // inverse trig
+  EXPECT_TRUE(r::try_asin_zero(_zero));
+  EXPECT_FALSE(r::try_asin_zero(x));
+  EXPECT_TRUE(r::try_asin_odd(-x));
+  EXPECT_FALSE(r::try_asin_odd(x));
+  EXPECT_TRUE(r::try_acos_one(_one));
+  EXPECT_FALSE(r::try_acos_one(x));
+  EXPECT_TRUE(r::try_atan_zero(_zero));
+  EXPECT_FALSE(r::try_atan_zero(x));
+  EXPECT_TRUE(r::try_atan_odd(-x));
+  EXPECT_FALSE(r::try_atan_odd(x));
+
+  // exp / log
+  EXPECT_TRUE(r::try_exp_zero(_zero));
+  EXPECT_FALSE(r::try_exp_zero(x));
+  EXPECT_TRUE(r::try_exp_of_log(log(x)));
+  EXPECT_FALSE(r::try_exp_of_log(x));
+  EXPECT_TRUE(r::try_log_one(_one));
+  EXPECT_FALSE(r::try_log_one(x));
+  EXPECT_TRUE(r::try_log_of_exp(exp(x)));
+  EXPECT_FALSE(r::try_log_of_exp(x));
+  EXPECT_TRUE(r::try_log_of_sqrt(sqrt(x)));
+  EXPECT_FALSE(r::try_log_of_sqrt(x));
+  EXPECT_TRUE(r::try_log_of_pow(pow(px, _2)));
+  EXPECT_FALSE(r::try_log_of_pow(pow(x, _2)));
+
+  // sqrt
+  EXPECT_TRUE(r::try_sqrt_zero(_zero));
+  EXPECT_FALSE(r::try_sqrt_zero(x));
+  EXPECT_TRUE(r::try_sqrt_one(_one));
+  EXPECT_FALSE(r::try_sqrt_one(x));
+  EXPECT_TRUE(r::try_sqrt_of_square(pow(px, _2)));
+  EXPECT_FALSE(r::try_sqrt_of_square(pow(x, _2)));
+  EXPECT_TRUE(r::try_sqrt_of_exp(exp(x)));
+  EXPECT_FALSE(r::try_sqrt_of_exp(x));
+
+  // abs / sign
+  EXPECT_TRUE(r::try_abs_nonneg(px));
+  EXPECT_FALSE(r::try_abs_nonneg(x));
+  EXPECT_TRUE(r::try_abs_nonpos(nx));
+  EXPECT_FALSE(r::try_abs_nonpos(x));
+  EXPECT_TRUE(r::try_sign_zero(_zero));
+  EXPECT_FALSE(r::try_sign_zero(x));
+  EXPECT_TRUE(r::try_sign_positive(px));
+  EXPECT_FALSE(r::try_sign_positive(x));
+  EXPECT_TRUE(r::try_sign_negative(nx));
+  EXPECT_FALSE(r::try_sign_negative(x));
+
+  // opt-in mixed inverse-trig
+  EXPECT_TRUE(r::try_cos_of_asin(asinx));
+  EXPECT_FALSE(r::try_cos_of_asin(x));
+  EXPECT_TRUE(r::try_sin_of_acos(acosx));
+  EXPECT_FALSE(r::try_sin_of_acos(x));
+  EXPECT_TRUE(r::try_tan_of_asin(asinx));
+  EXPECT_FALSE(r::try_tan_of_asin(x));
+  EXPECT_TRUE(r::try_sin_of_atan(atanx));
+  EXPECT_FALSE(r::try_sin_of_atan(x));
+  EXPECT_TRUE(r::try_cos_of_atan(atanx));
+  EXPECT_FALSE(r::try_cos_of_atan(x));
+}
+
+//
+// Lock-in: the construction-canonicalizer rules still fire at construction
+// (via the factory), not only when a rule is called directly.
+//
+TEST_F(ScalarFixture, FunctionRuleConstructionLockIn) {
+  using namespace numsim::cas;
   EXPECT_PRINT(sin(_zero), "0");
   EXPECT_PRINT(tan(-x), "-tan(x)");
+  EXPECT_PRINT(sin(asin(x)), "x");
 }
 
 //

--- a/tests/ScalarExpressionTest.h
+++ b/tests/ScalarExpressionTest.h
@@ -605,6 +605,48 @@ TEST_F(ScalarFixture, Scalar_OddEvenFunctions) {
 }
 
 //
+// Odd-parity of the remaining trig / inverse-trig functions (#417 gaps)
+//
+TEST_F(ScalarFixture, TrigParitySimplification) {
+  using namespace numsim::cas;
+  EXPECT_PRINT(tan(-x), "-tan(x)");
+  EXPECT_PRINT(asin(-x), "-asin(x)");
+  EXPECT_PRINT(atan(-x), "-atan(x)");
+}
+
+//
+// Mixed inverse-trig folds (#417 gaps) — branch-safe on the inner
+// inverse function's whole domain. Compare against the exact rewrite so
+// the assertion is independent of print formatting.
+//
+TEST_F(ScalarFixture, MixedInverseTrigSimplification) {
+  using namespace numsim::cas;
+  EXPECT_SAME_PRINT(cos(asin(x)), sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(sin(acos(x)), sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(tan(asin(x)), x / sqrt(get_scalar_one() - pow(x, 2)));
+  EXPECT_SAME_PRINT(sin(atan(x)), x / sqrt(get_scalar_one() + pow(x, 2)));
+  EXPECT_SAME_PRINT(cos(atan(x)),
+                    get_scalar_one() / sqrt(get_scalar_one() + pow(x, 2)));
+}
+
+//
+// Rule contract (#417): rules fire on their pattern, decline (nullopt)
+// otherwise, and the migrated folds still fire AT CONSTRUCTION.
+//
+TEST_F(ScalarFixture, FunctionRuleContract) {
+  using namespace numsim::cas;
+  EXPECT_TRUE(scalar_rules::try_sin_zero(_zero).has_value());
+  EXPECT_FALSE(scalar_rules::try_sin_zero(x).has_value());
+  EXPECT_TRUE(scalar_rules::try_tan_odd(-x).has_value());
+  EXPECT_FALSE(scalar_rules::try_tan_odd(x).has_value());
+  EXPECT_TRUE(scalar_rules::try_cos_of_asin(asin(x)).has_value());
+  EXPECT_FALSE(scalar_rules::try_cos_of_asin(x).has_value());
+  // lock-in: folds reachable at construction, not only via direct rule call
+  EXPECT_PRINT(sin(_zero), "0");
+  EXPECT_PRINT(tan(-x), "-tan(x)");
+}
+
+//
 // EXP pow simplification — exp(a)^n → exp(n*a)
 //
 TEST_F(ScalarFixture, Scalar_ExpPowSimplification) {


### PR DESCRIPTION
## Summary

Closes #417 (first increment). Reorganizes the scalar unary-function construction
folds around a uniform **rule contract**, and closes several trig coverage gaps.

Each fold is now a named, group-tagged free function with the contract
`std::optional<holder> try_<name>(holder const&)` (`nullopt` = doesn't fire) —
the same shape the existing `try_trig_pythagorean` helper already uses, promoted
to a header so the rules are cataloged and individually unit-testable. The
`scalar_std.h` factories drive the applicable rules in sequence at construction
(the "hand-sequence while small" form); the catalog header is the enumerable list
a later rule registry can consume without rewriting any rule.

Only *folds* moved — construction-time *validation* (rank/domain guards) stays in
the factories, and the arithmetic `add/sub/mul/pow` simplifiers are untouched.

## Commits

1. **Refactor (no behavior change)** — extract the folds of the 11 scalar node
   functions (`sin cos tan asin acos atan exp log sqrt abs sign`) into
   `scalar/simplifier/scalar_function_rules.{h,cpp}`; repoint the factories.
   Bodies mirror the old inline folds exactly (suite unchanged).
2. **Close coverage gaps** — new contract rules:

   | gap | rule |
   |---|---|
   | odd parity | `tan(-x)→-tan(x)`, `asin(-x)→-asin(x)`, `atan(-x)→-atan(x)` |
   | mixed inverse-trig | `cos(asin x)→√(1-x²)`, `sin(acos x)→√(1-x²)`, `tan(asin x)→x/√(1-x²)`, `sin(atan x)→x/√(1+x²)`, `cos(atan x)→1/√(1+x²)` |

   All valid on the whole real domain of the inner inverse function (branch-safe;
   the existing one-directional discipline `sin(asin x)→x` yes / `asin(sin x)→x`
   never is preserved).

## Testing

New tests in `ScalarExpressionTest.h`: `TrigParitySimplification`,
`MixedInverseTrigSimplification` (asserted against the exact rewrite, so
print-format independent), and `FunctionRuleContract` (rules fire on their
pattern, decline otherwise, and still fire **at construction**). Full suite
**2295/2295**; g++-14 `-Wall -Wextra -Werror` clean; fuzzy differentiation
unaffected (the identities are exact).

The mixed-inverse folds change `cos(asin x)` etc. from symbolic to closed form; no
existing test asserted the old symbolic shape.

## Follow-ups (separate PRs)

Deferred to keep this increment focused: composed hyperbolic functions
(`sinh/cosh/…` build exp/log — different shape), double-angle contraction (an
add/mul pass rule with its own confluence surface), and `min/max/if_then_else`
(binary). Tensor and t2s domains get the same treatment in later increments —
tensor is the likely first registry candidate (it hosts #393/#394/#395).
