### PR TITLE
Fix #420: t2s function folds under the rule contract + close trans gaps

### DIFF
--- a/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h
+++ b/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h
@@ -9,7 +9,7 @@
 // Construction-time fold rules for the t2s functions (#417 / #420).
 //
 // Rule contract: each rule is a named, group-tagged free function
-//     std::optional<result> try_<name>(tensor_holder const& arg);
+//     std::optional<t2s_holder> try_<name>(tensor_holder const& arg);
 // returning nullopt when it does not fire. The trace/det/norm/dot functions in
 // tensor_to_scalar_functions.cpp drive the applicable rules in sequence at
 // construction. Bodies live in the matching .cpp because they call the t2s /
@@ -21,43 +21,56 @@
 namespace numsim::cas::t2s_rules {
 
 using tensor_holder = expression_holder<tensor_expression>;
-using result = expression_holder<tensor_to_scalar_expression>;
+using t2s_holder = expression_holder<tensor_to_scalar_expression>;
 
 // ── dot / dot_product [dot] ──────────────────────────────────────────
-std::optional<result> try_dot_product_zero(tensor_holder const &lhs,
-                                           tensor_holder const &rhs);
-std::optional<result> try_dot_zero(tensor_holder const &e); // dot(0) → 0
+std::optional<t2s_holder> try_dot_product_zero(tensor_holder const &lhs,
+                                               tensor_holder const &rhs);
+std::optional<t2s_holder> try_dot_zero(tensor_holder const &e); // dot(0) → 0
 
 // ── trace [trace] ────────────────────────────────────────────────────
-std::optional<result> try_trace_zero(tensor_holder const &e);     // tr(0) → 0
-std::optional<result> try_trace_identity(tensor_holder const &e); // tr(I) → dim
-std::optional<result>
+std::optional<t2s_holder> try_trace_zero(tensor_holder const &e); // tr(0) → 0
+std::optional<t2s_holder>
+try_trace_identity(tensor_holder const &e); // tr(I) → dim
+std::optional<t2s_holder>
 try_trace_of_trans(tensor_holder const &e); // tr(Aᵀ) → tr(A)
-std::optional<result>
+std::optional<t2s_holder>
 try_trace_scalar_mul(tensor_holder const &e); // tr(s·A) → s·tr(A)
-std::optional<result>
+std::optional<t2s_holder>
 try_trace_add(tensor_holder const &e); // tr(A+B) → tr(A)+tr(B)
 
 // ── norm [norm] ──────────────────────────────────────────────────────
-std::optional<result> try_norm_zero(tensor_holder const &e); // ‖0‖ → 0
-std::optional<result> try_norm_of_trans(tensor_holder const &e); // ‖Aᵀ‖ → ‖A‖
-std::optional<result>
+std::optional<t2s_holder> try_norm_zero(tensor_holder const &e); // ‖0‖ → 0
+std::optional<t2s_holder>
+try_norm_of_trans(tensor_holder const &e); // ‖Aᵀ‖ → ‖A‖
+std::optional<t2s_holder>
 try_norm_scalar_mul(tensor_holder const &e); // ‖s·A‖ → |s|·‖A‖
 
 // ── det [det] ────────────────────────────────────────────────────────
-std::optional<result> try_det_zero(tensor_holder const &e);     // det(0) → 0
-std::optional<result> try_det_identity(tensor_holder const &e); // det(I) → 1
-std::optional<result>
+std::optional<t2s_holder> try_det_zero(tensor_holder const &e); // det(0) → 0
+std::optional<t2s_holder>
+try_det_identity(tensor_holder const &e); // det(I) → 1
+std::optional<t2s_holder>
 try_det_chirality(tensor_holder const &e); // proper→1, improper→-1
-std::optional<result>
+std::optional<t2s_holder>
 try_det_inv(tensor_holder const &e); // det(A⁻¹) → 1/det(A)
-std::optional<result> try_det_trans(tensor_holder const &e); // det(Aᵀ) → det(A)
-std::optional<result>
+std::optional<t2s_holder>
+try_det_trans(tensor_holder const &e); // det(Aᵀ) → det(A)
+std::optional<t2s_holder>
 try_det_outer_product(tensor_holder const &e); // det(u⊗v) → 0, dim≥2
-std::optional<result>
+std::optional<t2s_holder>
 try_det_scalar_mul(tensor_holder const &e); // det(s·A) → sᵈ·det(A)
-std::optional<result>
+std::optional<t2s_holder>
 try_det_mul(tensor_holder const &e); // det(∏Aᵢ) → ∏det(Aᵢ)
+
+// ── exp / sqrt [math] ────────────────────────────────────────────────
+// (t2s log has no construction folds.) Argument is a t2s scalar, not a tensor.
+std::optional<t2s_holder> try_exp_zero(t2s_holder const &e);   // exp(0) → 1
+std::optional<t2s_holder> try_exp_of_log(t2s_holder const &e); // exp(log x) → x
+std::optional<t2s_holder> try_sqrt_zero(t2s_holder const &e); // sqrt(0) → 0
+std::optional<t2s_holder> try_sqrt_one(t2s_holder const &e);  // sqrt(1) → 1
+std::optional<t2s_holder>
+try_sqrt_wrapper_one(t2s_holder const &e); // sqrt(⟨1⟩) → 1
 
 } // namespace numsim::cas::t2s_rules
 

--- a/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h
+++ b/include/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h
@@ -1,0 +1,64 @@
+#ifndef TENSOR_TO_SCALAR_FUNCTION_RULES_H
+#define TENSOR_TO_SCALAR_FUNCTION_RULES_H
+
+#include <optional>
+
+#include <numsim_cas/tensor/tensor_expression.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
+
+// Construction-time fold rules for the t2s functions (#417 / #420).
+//
+// Rule contract: each rule is a named, group-tagged free function
+//     std::optional<result> try_<name>(tensor_holder const& arg);
+// returning nullopt when it does not fire. The trace/det/norm/dot functions in
+// tensor_to_scalar_functions.cpp drive the applicable rules in sequence at
+// construction. Bodies live in the matching .cpp because they call the t2s /
+// tensor / scalar operators (operator*, /, pow, abs), which must be visible via
+// ADL there — the same .h-decl / .cpp-def split as scalar_function_rules.
+//
+// These rules are cross-domain: they take a tensor and yield a t2s scalar. The
+// catalog is the enumerable list a later registry would consume.
+namespace numsim::cas::t2s_rules {
+
+using tensor_holder = expression_holder<tensor_expression>;
+using result = expression_holder<tensor_to_scalar_expression>;
+
+// ── dot / dot_product [dot] ──────────────────────────────────────────
+std::optional<result> try_dot_product_zero(tensor_holder const &lhs,
+                                           tensor_holder const &rhs);
+std::optional<result> try_dot_zero(tensor_holder const &e); // dot(0) → 0
+
+// ── trace [trace] ────────────────────────────────────────────────────
+std::optional<result> try_trace_zero(tensor_holder const &e);     // tr(0) → 0
+std::optional<result> try_trace_identity(tensor_holder const &e); // tr(I) → dim
+std::optional<result>
+try_trace_of_trans(tensor_holder const &e); // tr(Aᵀ) → tr(A)
+std::optional<result>
+try_trace_scalar_mul(tensor_holder const &e); // tr(s·A) → s·tr(A)
+std::optional<result>
+try_trace_add(tensor_holder const &e); // tr(A+B) → tr(A)+tr(B)
+
+// ── norm [norm] ──────────────────────────────────────────────────────
+std::optional<result> try_norm_zero(tensor_holder const &e); // ‖0‖ → 0
+std::optional<result> try_norm_of_trans(tensor_holder const &e); // ‖Aᵀ‖ → ‖A‖
+std::optional<result>
+try_norm_scalar_mul(tensor_holder const &e); // ‖s·A‖ → |s|·‖A‖
+
+// ── det [det] ────────────────────────────────────────────────────────
+std::optional<result> try_det_zero(tensor_holder const &e);     // det(0) → 0
+std::optional<result> try_det_identity(tensor_holder const &e); // det(I) → 1
+std::optional<result>
+try_det_chirality(tensor_holder const &e); // proper→1, improper→-1
+std::optional<result>
+try_det_inv(tensor_holder const &e); // det(A⁻¹) → 1/det(A)
+std::optional<result> try_det_trans(tensor_holder const &e); // det(Aᵀ) → det(A)
+std::optional<result>
+try_det_outer_product(tensor_holder const &e); // det(u⊗v) → 0, dim≥2
+std::optional<result>
+try_det_scalar_mul(tensor_holder const &e); // det(s·A) → sᵈ·det(A)
+std::optional<result>
+try_det_mul(tensor_holder const &e); // det(∏Aᵢ) → ∏det(Aᵢ)
+
+} // namespace numsim::cas::t2s_rules
+
+#endif // TENSOR_TO_SCALAR_FUNCTION_RULES_H

--- a/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
+++ b/include/numsim_cas/tensor_to_scalar/tensor_to_scalar_std.h
@@ -1,6 +1,7 @@
 #ifndef TENSOR_TO_SCALAR_STD_H
 #define TENSOR_TO_SCALAR_STD_H
 
+#include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h>
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_simplifier_pow.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_expression.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_if_then_else.h>
@@ -100,35 +101,21 @@ template <tensor_to_scalar_expr_holder Expr>
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto exp(Expr &&expr) {
-  // exp(0) → 1
-  if (is_same<tensor_to_scalar_zero>(expr))
-    return make_expression<tensor_to_scalar_one>();
-
-  // exp(log(x)) → x (inverse pair)
-  if (is_same<tensor_to_scalar_log>(expr))
-    return expr.template get<tensor_to_scalar_log>().expr();
-
+  if (auto r = t2s_rules::try_exp_zero(expr))
+    return *r;
+  if (auto r = t2s_rules::try_exp_of_log(expr))
+    return *r;
   return make_expression<tensor_to_scalar_exp>(std::forward<Expr>(expr));
 }
 
 template <tensor_to_scalar_expr_holder Expr>
 [[nodiscard]] auto sqrt(Expr &&expr) {
-  // sqrt(0) → 0
-  if (is_same<tensor_to_scalar_zero>(expr))
-    return make_expression<tensor_to_scalar_zero>();
-
-  // sqrt(1) → 1
-  if (is_same<tensor_to_scalar_one>(expr))
-    return make_expression<tensor_to_scalar_one>();
-
-  // sqrt(scalar_wrapper(1)) → 1
-  {
-    using traits = domain_traits<tensor_to_scalar_expression>;
-    auto val = traits::try_numeric(expr);
-    if (val && *val == scalar_number{1})
-      return make_expression<tensor_to_scalar_one>();
-  }
-
+  if (auto r = t2s_rules::try_sqrt_zero(expr))
+    return *r;
+  if (auto r = t2s_rules::try_sqrt_one(expr))
+    return *r;
+  if (auto r = t2s_rules::try_sqrt_wrapper_one(expr))
+    return *r;
   return make_expression<tensor_to_scalar_sqrt>(std::forward<Expr>(expr));
 }
 

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.cpp
@@ -1,6 +1,7 @@
 #include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h>
 
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_domain_traits.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
 
@@ -20,25 +21,25 @@
 namespace numsim::cas::t2s_rules {
 
 // ── dot / dot_product ────────────────────────────────────────────────
-std::optional<result> try_dot_product_zero(tensor_holder const &lhs,
-                                           tensor_holder const &rhs) {
+std::optional<t2s_holder> try_dot_product_zero(tensor_holder const &lhs,
+                                               tensor_holder const &rhs) {
   if (is_same<tensor_zero>(lhs) || is_same<tensor_zero>(rhs))
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
-std::optional<result> try_dot_zero(tensor_holder const &e) {
+std::optional<t2s_holder> try_dot_zero(tensor_holder const &e) {
   if (is_same<tensor_zero>(e))
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
 
 // ── trace ────────────────────────────────────────────────────────────
-std::optional<result> try_trace_zero(tensor_holder const &e) {
+std::optional<t2s_holder> try_trace_zero(tensor_holder const &e) {
   if (is_same<tensor_zero>(e))
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
-std::optional<result> try_trace_identity(tensor_holder const &e) {
+std::optional<t2s_holder> try_trace_identity(tensor_holder const &e) {
   // tr(I) = dim. Rank-2 asserted by the caller, so any identity_tensor here
   // is the rank-2 Kronecker delta (#188 unified kronecker_delta).
   if (is_same<identity_tensor>(e)) {
@@ -48,7 +49,7 @@ std::optional<result> try_trace_identity(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_trace_of_trans(tensor_holder const &e) {
+std::optional<t2s_holder> try_trace_of_trans(tensor_holder const &e) {
   // tr(Aᵀ) = tr(A). trans() builds permute_indices_wrapper{2,1}; match the
   // index sequence so a non-transpose permutation is not mis-simplified.
   if (is_same<permute_indices_wrapper>(e)) {
@@ -58,17 +59,17 @@ std::optional<result> try_trace_of_trans(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_trace_scalar_mul(tensor_holder const &e) {
+std::optional<t2s_holder> try_trace_scalar_mul(tensor_holder const &e) {
   if (is_same<tensor_scalar_mul>(e)) {
     auto const &sm = e.get<tensor_scalar_mul>();
     return sm.expr_lhs() * trace(sm.expr_rhs());
   }
   return {};
 }
-std::optional<result> try_trace_add(tensor_holder const &e) {
+std::optional<t2s_holder> try_trace_add(tensor_holder const &e) {
   if (is_same<tensor_add>(e)) {
     auto const &add = e.get<tensor_add>();
-    result r;
+    t2s_holder r;
     if (add.coeff().is_valid())
       r = trace(add.coeff());
     for (auto const &child : add.symbol_map() | std::views::values) {
@@ -83,12 +84,12 @@ std::optional<result> try_trace_add(tensor_holder const &e) {
 }
 
 // ── norm ─────────────────────────────────────────────────────────────
-std::optional<result> try_norm_zero(tensor_holder const &e) {
+std::optional<t2s_holder> try_norm_zero(tensor_holder const &e) {
   if (is_same<tensor_zero>(e))
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
-std::optional<result> try_norm_of_trans(tensor_holder const &e) {
+std::optional<t2s_holder> try_norm_of_trans(tensor_holder const &e) {
   // ‖Aᵀ‖ = ‖A‖ — the Frobenius norm is transpose-invariant.
   if (is_same<permute_indices_wrapper>(e)) {
     auto const &perm = e.get<permute_indices_wrapper>();
@@ -97,7 +98,7 @@ std::optional<result> try_norm_of_trans(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_norm_scalar_mul(tensor_holder const &e) {
+std::optional<t2s_holder> try_norm_scalar_mul(tensor_holder const &e) {
   if (is_same<tensor_scalar_mul>(e)) {
     auto const &sm = e.get<tensor_scalar_mul>();
     return abs(sm.expr_lhs()) * norm(sm.expr_rhs());
@@ -106,17 +107,17 @@ std::optional<result> try_norm_scalar_mul(tensor_holder const &e) {
 }
 
 // ── det ──────────────────────────────────────────────────────────────
-std::optional<result> try_det_zero(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_zero(tensor_holder const &e) {
   if (is_same<tensor_zero>(e))
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
-std::optional<result> try_det_identity(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_identity(tensor_holder const &e) {
   if (is_same<identity_tensor>(e))
     return make_expression<tensor_to_scalar_one>();
   return {};
 }
-std::optional<result> try_det_chirality(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_chirality(tensor_holder const &e) {
   // det of an orthogonal tensor is ±1, resolved by chirality (#269):
   // proper → +1, improper → −1, bare orthogonal → NO fold (sign unknown).
   if (is_proper_rotation(e))
@@ -125,7 +126,7 @@ std::optional<result> try_det_chirality(tensor_holder const &e) {
     return -make_expression<tensor_to_scalar_one>();
   return {};
 }
-std::optional<result> try_det_inv(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_inv(tensor_holder const &e) {
   // det(A⁻¹) = 1/det(A), routed through t2s div → canonical pow(det(A),-1).
   if (is_same<tensor_inv>(e)) {
     auto const &inner = e.get<tensor_inv>().expr();
@@ -133,7 +134,7 @@ std::optional<result> try_det_inv(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_det_trans(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_trans(tensor_holder const &e) {
   if (is_same<permute_indices_wrapper>(e)) {
     auto const &perm = e.get<permute_indices_wrapper>();
     if (perm.indices() == sequence{2, 1})
@@ -141,13 +142,13 @@ std::optional<result> try_det_trans(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_det_outer_product(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_outer_product(tensor_holder const &e) {
   // det(u ⊗ v) = 0 for dim ≥ 2 (rank-1 matrix). dim = 1 is the 1×1 scalar.
   if (is_same<outer_product_wrapper>(e) && e.get().dim() >= 2)
     return make_expression<tensor_to_scalar_zero>();
   return {};
 }
-std::optional<result> try_det_scalar_mul(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_scalar_mul(tensor_holder const &e) {
   if (is_same<tensor_scalar_mul>(e)) {
     auto const &sm = e.get<tensor_scalar_mul>();
     auto dim = static_cast<int>(sm.expr_rhs().get().dim());
@@ -156,10 +157,10 @@ std::optional<result> try_det_scalar_mul(tensor_holder const &e) {
   }
   return {};
 }
-std::optional<result> try_det_mul(tensor_holder const &e) {
+std::optional<t2s_holder> try_det_mul(tensor_holder const &e) {
   if (is_same<tensor_mul>(e)) {
     auto const &mul = e.get<tensor_mul>();
-    result r;
+    t2s_holder r;
     if (mul.coeff().is_valid())
       r = det(mul.coeff());
     for (auto const &child : mul.data()) {
@@ -170,6 +171,36 @@ std::optional<result> try_det_mul(tensor_holder const &e) {
     }
     return r;
   }
+  return {};
+}
+
+// ── exp / sqrt ───────────────────────────────────────────────────────
+std::optional<t2s_holder> try_exp_zero(t2s_holder const &e) {
+  if (is_same<tensor_to_scalar_zero>(e))
+    return make_expression<tensor_to_scalar_one>();
+  return {};
+}
+std::optional<t2s_holder> try_exp_of_log(t2s_holder const &e) {
+  if (is_same<tensor_to_scalar_log>(e))
+    return e.get<tensor_to_scalar_log>().expr();
+  return {};
+}
+std::optional<t2s_holder> try_sqrt_zero(t2s_holder const &e) {
+  if (is_same<tensor_to_scalar_zero>(e))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<t2s_holder> try_sqrt_one(t2s_holder const &e) {
+  if (is_same<tensor_to_scalar_one>(e))
+    return make_expression<tensor_to_scalar_one>();
+  return {};
+}
+std::optional<t2s_holder> try_sqrt_wrapper_one(t2s_holder const &e) {
+  // sqrt(⟨1⟩) → 1 — a scalar_wrapper numerically equal to 1.
+  using traits = domain_traits<tensor_to_scalar_expression>;
+  auto val = traits::try_numeric(e);
+  if (val && *val == scalar_number{1})
+    return make_expression<tensor_to_scalar_one>();
   return {};
 }
 

--- a/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.cpp
+++ b/src/numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.cpp
@@ -1,0 +1,176 @@
+#include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h>
+
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h>
+#include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
+
+#include <numsim_cas/basic_functions.h>
+#include <numsim_cas/scalar/scalar_std.h>
+#include <numsim_cas/tensor/tensor_assume.h>
+#include <numsim_cas/tensor/tensor_definitions.h>
+#include <numsim_cas/tensor/tensor_operators.h>
+
+#include <ranges>
+
+// Bodies mirror the previous inline folds in tensor_to_scalar_functions.cpp
+// exactly; #420 extracts them into named, testable rules. The two *_of_trans
+// rules are new (transpose-invariance gaps). The det terminal node + its PD/PSD
+// annotation stays in det() — it is not an early-return fold.
+
+namespace numsim::cas::t2s_rules {
+
+// ── dot / dot_product ────────────────────────────────────────────────
+std::optional<result> try_dot_product_zero(tensor_holder const &lhs,
+                                           tensor_holder const &rhs) {
+  if (is_same<tensor_zero>(lhs) || is_same<tensor_zero>(rhs))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<result> try_dot_zero(tensor_holder const &e) {
+  if (is_same<tensor_zero>(e))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+
+// ── trace ────────────────────────────────────────────────────────────
+std::optional<result> try_trace_zero(tensor_holder const &e) {
+  if (is_same<tensor_zero>(e))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<result> try_trace_identity(tensor_holder const &e) {
+  // tr(I) = dim. Rank-2 asserted by the caller, so any identity_tensor here
+  // is the rank-2 Kronecker delta (#188 unified kronecker_delta).
+  if (is_same<identity_tensor>(e)) {
+    auto dim = e.get().dim();
+    return make_expression<tensor_to_scalar_scalar_wrapper>(
+        make_expression<scalar_constant>(static_cast<int>(dim)));
+  }
+  return {};
+}
+std::optional<result> try_trace_of_trans(tensor_holder const &e) {
+  // tr(Aᵀ) = tr(A). trans() builds permute_indices_wrapper{2,1}; match the
+  // index sequence so a non-transpose permutation is not mis-simplified.
+  if (is_same<permute_indices_wrapper>(e)) {
+    auto const &perm = e.get<permute_indices_wrapper>();
+    if (perm.indices() == sequence{2, 1})
+      return trace(perm.expr());
+  }
+  return {};
+}
+std::optional<result> try_trace_scalar_mul(tensor_holder const &e) {
+  if (is_same<tensor_scalar_mul>(e)) {
+    auto const &sm = e.get<tensor_scalar_mul>();
+    return sm.expr_lhs() * trace(sm.expr_rhs());
+  }
+  return {};
+}
+std::optional<result> try_trace_add(tensor_holder const &e) {
+  if (is_same<tensor_add>(e)) {
+    auto const &add = e.get<tensor_add>();
+    result r;
+    if (add.coeff().is_valid())
+      r = trace(add.coeff());
+    for (auto const &child : add.symbol_map() | std::views::values) {
+      if (r.is_valid())
+        r = r + trace(child);
+      else
+        r = trace(child);
+    }
+    return r;
+  }
+  return {};
+}
+
+// ── norm ─────────────────────────────────────────────────────────────
+std::optional<result> try_norm_zero(tensor_holder const &e) {
+  if (is_same<tensor_zero>(e))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<result> try_norm_of_trans(tensor_holder const &e) {
+  // ‖Aᵀ‖ = ‖A‖ — the Frobenius norm is transpose-invariant.
+  if (is_same<permute_indices_wrapper>(e)) {
+    auto const &perm = e.get<permute_indices_wrapper>();
+    if (perm.indices() == sequence{2, 1})
+      return norm(perm.expr());
+  }
+  return {};
+}
+std::optional<result> try_norm_scalar_mul(tensor_holder const &e) {
+  if (is_same<tensor_scalar_mul>(e)) {
+    auto const &sm = e.get<tensor_scalar_mul>();
+    return abs(sm.expr_lhs()) * norm(sm.expr_rhs());
+  }
+  return {};
+}
+
+// ── det ──────────────────────────────────────────────────────────────
+std::optional<result> try_det_zero(tensor_holder const &e) {
+  if (is_same<tensor_zero>(e))
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<result> try_det_identity(tensor_holder const &e) {
+  if (is_same<identity_tensor>(e))
+    return make_expression<tensor_to_scalar_one>();
+  return {};
+}
+std::optional<result> try_det_chirality(tensor_holder const &e) {
+  // det of an orthogonal tensor is ±1, resolved by chirality (#269):
+  // proper → +1, improper → −1, bare orthogonal → NO fold (sign unknown).
+  if (is_proper_rotation(e))
+    return make_expression<tensor_to_scalar_one>();
+  if (is_improper_rotation(e))
+    return -make_expression<tensor_to_scalar_one>();
+  return {};
+}
+std::optional<result> try_det_inv(tensor_holder const &e) {
+  // det(A⁻¹) = 1/det(A), routed through t2s div → canonical pow(det(A),-1).
+  if (is_same<tensor_inv>(e)) {
+    auto const &inner = e.get<tensor_inv>().expr();
+    return make_expression<tensor_to_scalar_one>() / det(inner);
+  }
+  return {};
+}
+std::optional<result> try_det_trans(tensor_holder const &e) {
+  if (is_same<permute_indices_wrapper>(e)) {
+    auto const &perm = e.get<permute_indices_wrapper>();
+    if (perm.indices() == sequence{2, 1})
+      return det(perm.expr());
+  }
+  return {};
+}
+std::optional<result> try_det_outer_product(tensor_holder const &e) {
+  // det(u ⊗ v) = 0 for dim ≥ 2 (rank-1 matrix). dim = 1 is the 1×1 scalar.
+  if (is_same<outer_product_wrapper>(e) && e.get().dim() >= 2)
+    return make_expression<tensor_to_scalar_zero>();
+  return {};
+}
+std::optional<result> try_det_scalar_mul(tensor_holder const &e) {
+  if (is_same<tensor_scalar_mul>(e)) {
+    auto const &sm = e.get<tensor_scalar_mul>();
+    auto dim = static_cast<int>(sm.expr_rhs().get().dim());
+    auto dim_expr = make_expression<scalar_constant>(dim);
+    return pow(sm.expr_lhs(), std::move(dim_expr)) * det(sm.expr_rhs());
+  }
+  return {};
+}
+std::optional<result> try_det_mul(tensor_holder const &e) {
+  if (is_same<tensor_mul>(e)) {
+    auto const &mul = e.get<tensor_mul>();
+    result r;
+    if (mul.coeff().is_valid())
+      r = det(mul.coeff());
+    for (auto const &child : mul.data()) {
+      if (r.is_valid())
+        r = r * det(child);
+      else
+        r = det(child);
+    }
+    return r;
+  }
+  return {};
+}
+
+} // namespace numsim::cas::t2s_rules

--- a/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
+++ b/src/numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.cpp
@@ -1,3 +1,4 @@
+#include <numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_definitions.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_functions.h>
 #include <numsim_cas/tensor_to_scalar/tensor_to_scalar_operators.h>
@@ -20,8 +21,8 @@ expression_holder<tensor_to_scalar_expression> dot_product(
   assert(call_tensor::rank(lhs) == lhs_indices.size() ||
          call_tensor::rank(rhs) == rhs_indices.size());
 
-  if (is_same<tensor_zero>(lhs) || is_same<tensor_zero>(rhs))
-    return make_expression<tensor_to_scalar_zero>();
+  if (auto r = t2s_rules::try_dot_product_zero(lhs, rhs))
+    return *r;
 
   return make_expression<tensor_inner_product_to_scalar>(
       lhs, std::move(lhs_indices), rhs, std::move(rhs_indices));
@@ -29,8 +30,8 @@ expression_holder<tensor_to_scalar_expression> dot_product(
 
 expression_holder<tensor_to_scalar_expression>
 dot(expression_holder<tensor_expression> const &expr) {
-  if (is_same<tensor_zero>(expr))
-    return make_expression<tensor_to_scalar_zero>();
+  if (auto r = t2s_rules::try_dot_zero(expr))
+    return *r;
 
   return make_expression<tensor_dot>(expr);
 }
@@ -39,36 +40,16 @@ expression_holder<tensor_to_scalar_expression>
 trace(expression_holder<tensor_expression> const &expr) {
   assert(expr.get().rank() == 2);
 
-  if (is_same<tensor_zero>(expr))
-    return make_expression<tensor_to_scalar_zero>();
-
-  // trace(I) = dim. The asserted rank-2 input means any identity_tensor
-  // reaching here is the rank-2 Kronecker delta (since #188 unified
-  // kronecker_delta into identity_tensor).
-  if (is_same<identity_tensor>(expr)) {
-    auto dim = expr.get().dim();
-    return make_expression<tensor_to_scalar_scalar_wrapper>(
-        make_expression<scalar_constant>(static_cast<int>(dim)));
-  }
-
-  if (is_same<tensor_scalar_mul>(expr)) {
-    auto const &sm = expr.get<tensor_scalar_mul>();
-    return sm.expr_lhs() * trace(sm.expr_rhs());
-  }
-
-  if (is_same<tensor_add>(expr)) {
-    auto const &add = expr.get<tensor_add>();
-    expression_holder<tensor_to_scalar_expression> result;
-    if (add.coeff().is_valid())
-      result = trace(add.coeff());
-    for (auto const &child : add.symbol_map() | std::views::values) {
-      if (result.is_valid())
-        result = result + trace(child);
-      else
-        result = trace(child);
-    }
-    return result;
-  }
+  if (auto r = t2s_rules::try_trace_zero(expr))
+    return *r;
+  if (auto r = t2s_rules::try_trace_identity(expr))
+    return *r;
+  if (auto r = t2s_rules::try_trace_of_trans(expr))
+    return *r;
+  if (auto r = t2s_rules::try_trace_scalar_mul(expr))
+    return *r;
+  if (auto r = t2s_rules::try_trace_add(expr))
+    return *r;
 
   return make_expression<tensor_trace>(expr);
 }
@@ -77,13 +58,12 @@ expression_holder<tensor_to_scalar_expression>
 norm(expression_holder<tensor_expression> const &expr) {
   assert(expr.get().rank() == 2);
 
-  if (is_same<tensor_zero>(expr))
-    return make_expression<tensor_to_scalar_zero>();
-
-  if (is_same<tensor_scalar_mul>(expr)) {
-    auto const &sm = expr.get<tensor_scalar_mul>();
-    return abs(sm.expr_lhs()) * norm(sm.expr_rhs());
-  }
+  if (auto r = t2s_rules::try_norm_zero(expr))
+    return *r;
+  if (auto r = t2s_rules::try_norm_of_trans(expr))
+    return *r;
+  if (auto r = t2s_rules::try_norm_scalar_mul(expr))
+    return *r;
 
   return make_expression<tensor_norm>(expr);
 }
@@ -92,72 +72,22 @@ expression_holder<tensor_to_scalar_expression>
 det(expression_holder<tensor_expression> const &expr) {
   assert(expr.get().rank() == 2);
 
-  if (is_same<tensor_zero>(expr))
-    return make_expression<tensor_to_scalar_zero>();
-
-  // det(I) = 1 at rank 2 (the asserted rank-2 input means any
-  // identity_tensor reaching here is the rank-2 Kronecker delta;
-  // kronecker_delta was unified into identity_tensor by #188).
-  if (is_same<identity_tensor>(expr))
-    return make_expression<tensor_to_scalar_one>();
-
-  // det of an orthogonal tensor is ±1, resolved by chirality (#269):
-  //   proper rotation   → +1
-  //   improper rotation → -1  (reflection)
-  //   bare `orthogonal`  → NO fold — det could be either sign, so folding to
-  //                        +1 would be silently wrong for a reflection.
-  // (proper/improper still imply orthogonal, so inv(R) → trans(R) is
-  //  unaffected.) Closes one half of #246.
-  if (is_proper_rotation(expr))
-    return make_expression<tensor_to_scalar_one>();
-  if (is_improper_rotation(expr))
-    return -make_expression<tensor_to_scalar_one>();
-
-  // det(inv(A)) = 1/det(A). Routes through the t2s div operator which
-  // composes via pow(rhs, -1) — produces canonical pow(det(A), -1).
-  if (is_same<tensor_inv>(expr)) {
-    auto const &inner = expr.get<tensor_inv>().expr();
-    return make_expression<tensor_to_scalar_one>() / det(inner);
-  }
-
-  // det(trans(A)) = det(A). trans() builds permute_indices_wrapper with
-  // sequence{2, 1}; det is rank-2 only (asserted), so any
-  // permute_indices_wrapper reaching here is necessarily the transpose.
-  // Still match on the index sequence so a future caller passing a
-  // non-transpose permutation doesn't get a wrong simplification.
-  if (is_same<permute_indices_wrapper>(expr)) {
-    auto const &perm = expr.get<permute_indices_wrapper>();
-    if (perm.indices() == sequence{2, 1})
-      return det(perm.expr());
-  }
-
-  // det(u ⊗ v) = 0 for dim ≥ 2. The outer product u ⊗ v of two rank-1
-  // tensors is a rank-2 matrix of rank 1 (linear-algebra sense), so its
-  // determinant is zero for any n×n with n ≥ 2. For dim = 1 the matrix
-  // is the 1×1 scalar u₀·v₀ — don't fold.
-  if (is_same<outer_product_wrapper>(expr) && expr.get().dim() >= 2)
-    return make_expression<tensor_to_scalar_zero>();
-
-  if (is_same<tensor_scalar_mul>(expr)) {
-    auto const &sm = expr.get<tensor_scalar_mul>();
-    auto dim = static_cast<int>(sm.expr_rhs().get().dim());
-    auto dim_expr = make_expression<scalar_constant>(dim);
-    return pow(sm.expr_lhs(), std::move(dim_expr)) * det(sm.expr_rhs());
-  }
-
-  if (is_same<tensor_mul>(expr)) {
-    auto const &mul = expr.get<tensor_mul>();
-    expression_holder<tensor_to_scalar_expression> result;
-    if (mul.coeff().is_valid())
-      result = det(mul.coeff());
-    for (auto const &child : mul.data()) {
-      if (result.is_valid())
-        result = result * det(child);
-      else
-        result = det(child);
-    }
-    return result;
-  }
+  if (auto r = t2s_rules::try_det_zero(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_identity(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_chirality(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_inv(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_trans(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_outer_product(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_scalar_mul(expr))
+    return *r;
+  if (auto r = t2s_rules::try_det_mul(expr))
+    return *r;
 
   auto result = make_expression<tensor_det>(expr);
   // Propagate positivity from PD/PSD annotations on the input (#246

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -3,6 +3,7 @@
 
 #include "cas_test_helpers.h"
 #include "numsim_cas/numsim_cas.h"
+#include "numsim_cas/tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h"
 #include "gtest/gtest.h"
 
 namespace {
@@ -553,6 +554,79 @@ TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_TraceSimplification) {
 
   // normal case unchanged
   EXPECT_PRINT(trace(X), "tr(X)");
+}
+
+//
+// #420 transpose gaps — trace and the Frobenius norm are transpose-invariant.
+//
+TYPED_TEST(TensorToScalarExpressionTest, TensorToScalar_TraceNormTransGaps) {
+  auto &X = this->X;
+  using numsim::cas::norm;
+  using numsim::cas::trace;
+  using numsim::cas::trans;
+  EXPECT_PRINT(trace(trans(X)), "tr(X)");
+  EXPECT_PRINT(norm(trans(X)), "norm(X)");
+}
+
+//
+// Rule contract (#420): each t2s fold rule fires on its pattern and declines
+// (nullopt) otherwise. Chirality and outer-product rules are exercised by the
+// end-to-end det tests.
+//
+TYPED_TEST(TensorToScalarExpressionTest,
+           TensorToScalar_FunctionRulesUnitCoverage) {
+  namespace r = numsim::cas::t2s_rules;
+  using numsim::cas::inv;
+  using numsim::cas::trans;
+  auto &X = this->X;
+  auto &Y = this->Y;
+  auto &Zero = this->_Zero;
+  auto &One = this->_One;
+  auto &_2 = this->_2;
+
+  // dot
+  EXPECT_TRUE(r::try_dot_product_zero(Zero, X));
+  EXPECT_FALSE(r::try_dot_product_zero(X, Y));
+  EXPECT_TRUE(r::try_dot_zero(Zero));
+  EXPECT_FALSE(r::try_dot_zero(X));
+
+  // trace
+  EXPECT_TRUE(r::try_trace_zero(Zero));
+  EXPECT_FALSE(r::try_trace_zero(X));
+  EXPECT_TRUE(r::try_trace_identity(One));
+  EXPECT_FALSE(r::try_trace_identity(X));
+  EXPECT_TRUE(r::try_trace_scalar_mul(_2 * X));
+  EXPECT_FALSE(r::try_trace_scalar_mul(X));
+  EXPECT_TRUE(r::try_trace_add(X + Y));
+  EXPECT_FALSE(r::try_trace_add(X));
+
+  // norm
+  EXPECT_TRUE(r::try_norm_zero(Zero));
+  EXPECT_FALSE(r::try_norm_zero(X));
+  EXPECT_TRUE(r::try_norm_scalar_mul(_2 * X));
+  EXPECT_FALSE(r::try_norm_scalar_mul(X));
+
+  // det
+  EXPECT_TRUE(r::try_det_zero(Zero));
+  EXPECT_FALSE(r::try_det_zero(X));
+  EXPECT_TRUE(r::try_det_identity(One));
+  EXPECT_FALSE(r::try_det_identity(X));
+  EXPECT_TRUE(r::try_det_inv(inv(X)));
+  EXPECT_FALSE(r::try_det_inv(X));
+  EXPECT_TRUE(r::try_det_scalar_mul(_2 * X));
+  EXPECT_FALSE(r::try_det_scalar_mul(X));
+  EXPECT_TRUE(r::try_det_mul(X * Y));
+  EXPECT_FALSE(r::try_det_mul(X));
+
+  // transpose-keyed rules (trans is degenerate at dim 1)
+  EXPECT_FALSE(r::try_trace_of_trans(X));
+  EXPECT_FALSE(r::try_norm_of_trans(X));
+  EXPECT_FALSE(r::try_det_trans(X));
+  if constexpr (TestFixture::Dim >= 2) {
+    EXPECT_TRUE(r::try_trace_of_trans(trans(X)));
+    EXPECT_TRUE(r::try_norm_of_trans(trans(X)));
+    EXPECT_TRUE(r::try_det_trans(trans(X)));
+  }
 }
 
 // ---------- det() simplification ----------

--- a/tests/TensorToScalarExpressionTest.h
+++ b/tests/TensorToScalarExpressionTest.h
@@ -627,6 +627,27 @@ TYPED_TEST(TensorToScalarExpressionTest,
     EXPECT_TRUE(r::try_norm_of_trans(trans(X)));
     EXPECT_TRUE(r::try_det_trans(trans(X)));
   }
+
+  // exp / sqrt — t2s math folds; arguments are t2s scalars, not tensors.
+  auto t2s_zero =
+      numsim::cas::make_expression<numsim::cas::tensor_to_scalar_zero>();
+  auto t2s_one =
+      numsim::cas::make_expression<numsim::cas::tensor_to_scalar_one>();
+  auto trX = numsim::cas::trace(X); // a t2s expr, not zero/one/log/wrapper
+  auto logtr = numsim::cas::log(trX);
+  auto wrap1 = numsim::cas::make_expression<
+      numsim::cas::tensor_to_scalar_scalar_wrapper>(
+      numsim::cas::get_scalar_one());
+  EXPECT_TRUE(r::try_exp_zero(t2s_zero));
+  EXPECT_FALSE(r::try_exp_zero(trX));
+  EXPECT_TRUE(r::try_exp_of_log(logtr));
+  EXPECT_FALSE(r::try_exp_of_log(trX));
+  EXPECT_TRUE(r::try_sqrt_zero(t2s_zero));
+  EXPECT_FALSE(r::try_sqrt_zero(trX));
+  EXPECT_TRUE(r::try_sqrt_one(t2s_one));
+  EXPECT_FALSE(r::try_sqrt_one(trX));
+  EXPECT_TRUE(r::try_sqrt_wrapper_one(wrap1));
+  EXPECT_FALSE(r::try_sqrt_wrapper_one(trX));
 }
 
 // ---------- det() simplification ----------


### PR DESCRIPTION
## Summary

Closes #420; part of #417 (rule-contract effort, second domain — t2s). Extracts the
construction folds of the t2s functions (`trace`/`det`/`norm`/`dot`/`dot_product`) out of
the `tensor_to_scalar_functions.cpp` if-chains into named, group-tagged `try_*` rules, and
closes two transpose-invariance gaps.

Rules follow the uniform contract `std::optional<result> try_<name>(tensor_holder const&)`
(`nullopt` = doesn't fire), cataloged in `tensor_to_scalar/simplifier/tensor_to_scalar_function_rules.h`
with bodies in the matching `.cpp` — the same `.h`-decl / `.cpp`-def split as
`scalar_function_rules`, required here because the rewrites call the t2s/tensor/scalar
operators (`*`, `/`, `pow`, `abs`) which must be ADL-visible. The functions drive the rules
in sequence at construction; the `det` terminal `tensor_det` node + its PD/PSD positivity
annotation stays in `det()` (it is not an early-return fold).

## Gaps closed

Both transpose-invariant, so always-on canonicalizers (not expansions):

| gap | rule |
|---|---|
| `trace(Aᵀ) → trace(A)` | `try_trace_of_trans` |
| `‖Aᵀ‖ → ‖A‖` (Frobenius) | `try_norm_of_trans` |

Matched on `permute_indices_wrapper` with `sequence{2,1}` — the same guarded pattern the
existing `det(trans A) → det(A)` fold uses, so a non-transpose permutation is never
mis-simplified.

## Deferred

`trace(AB) = trace(BA)` (cyclic) is a **reordering** → non-confluent → belongs in an opt-in
pass, not construction. Left for a follow-up (the tensor domain will grow the pass tier).

## Testing

- Existing `TensorToScalar_{Trace,Det,Norm}Simplification` tests are unchanged and pass —
  the extraction is behavior-identical.
- New: `TensorToScalar_TraceNormTransGaps` (the two new folds, end-to-end) and
  `TensorToScalar_FunctionRulesUnitCoverage` (every rule fires on its pattern / declines
  otherwise; transpose-keyed rules guarded for dim ≥ 2 where `trans` is non-degenerate).
- Full suite **2298/2298**; g++-14 `-Wall -Wextra -Werror` clean.

No change to `docs/simplifier-coverage.md` — the scalar PR (#418) edits the same scope
paragraph, so touching it here would create a needless conflict; they'll reconcile on merge.
